### PR TITLE
Automated cherry pick of #11: fix(compute): add network default params limit

### DIFF
--- a/containers/Compute/sections/ServerNetwork/NetworkConfig.vue
+++ b/containers/Compute/sections/ServerNetwork/NetworkConfig.vue
@@ -138,6 +138,7 @@ export default {
     networkParamsC () {
       if (!this.networkList[0].vpc.id) return {}
       return {
+        limit: 20,
         vpc: this.networkList[0].vpc.id,
         ...this.networkParams,
       }


### PR DESCRIPTION
Cherry pick of #11 on release/3.6.

#11: fix(compute): add network default params limit