### PR TITLE
Automated cherry pick of #29: fix(compute): 修复功能选择vmware，没有显示主机快照菜单

### DIFF
--- a/containers/Compute/router/index.js
+++ b/containers/Compute/router/index.js
@@ -315,7 +315,7 @@ export default {
               if (isScopedPolicyMenuHidden('sub_hidden_menus.instance_snapshot')) {
                 return true
               }
-              return !hasSetupKey(['onestack'])
+              return !hasSetupKey(['onestack', 'vmware'])
             },
           },
           component: Layout,


### PR DESCRIPTION
Cherry pick of #29 on release/3.7.

#29: fix(compute): 修复功能选择vmware，没有显示主机快照菜单