### PR TITLE
fix(OsSelect): #7261 创建vmware虚拟机时，vmware平台镜像vm-test应该归属于RHEL，不应该归属于linux

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -506,6 +506,8 @@ export default {
         if (osVal.toLowerCase().includes('linux')) {
           if (osVal.toLowerCase().includes('amazon linux')) {
             osVal = 'Amazon Linux'
+          } else if (osVal.includes('RedHat Enterprise Linux')) {
+            osVal = 'RHEL'
           } else {
             osVal = 'Linux'
           }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->
fix(OsSelect): #7261 创建vmware虚拟机时，vmware平台镜像vm-test应该归属于RHEL，不应该归属于linux

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->
- release/3.6