### PR TITLE
Automated cherry pick of #56: fix(OsSelect): #7261 创建vmware虚拟机时，vmware平台镜像vm-test应该归属于RHEL，不应该归属于linux

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -506,6 +506,8 @@ export default {
         if (osVal.toLowerCase().includes('linux')) {
           if (osVal.toLowerCase().includes('amazon linux')) {
             osVal = 'Amazon Linux'
+          } else if (osVal.includes('RedHat Enterprise Linux')) {
+            osVal = 'RHEL'
           } else {
             osVal = 'Linux'
           }


### PR DESCRIPTION
Cherry pick of #56 on release/3.7.

#56: fix(OsSelect): #7261 创建vmware虚拟机时，vmware平台镜像vm-test应该归属于RHEL，不应该归属于linux