### PR TITLE
fix(OsSelect): #7274 从ISO启动的windows系统vmware虚拟机重装系统选择windows系统时无法选中，前端报错

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -640,7 +640,11 @@ export default {
         this.defaultSelect(os)
         if (image) {
           image = { key: image.id, label: image.name }
-          this.form.fc.setFieldsValue({ image })
+          if (this.imageOptions.length === 0) {
+            this.form.fc.setFieldsValue({ image: initData })
+          } else {
+            this.form.fc.setFieldsValue({ image })
+          }
           this.imageChange(image)
         }
       } else {

--- a/containers/Compute/sections/OsSelect/index.vue
+++ b/containers/Compute/sections/OsSelect/index.vue
@@ -187,7 +187,7 @@ export default {
       const lastSelectedImageInfo = storage.get('oc_selected_image') || {}
       const image = ret[0].imageMsg
 
-      if (image.properties) {
+      if (image?.properties) {
         let os_distribution = image.properties.os_distribution
         const os_type = image.properties.os_type
         if (os_distribution) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->
- fix(OsSelect): #7274 从ISO启动的windows系统vmware虚拟机重装系统选择windows系统时无法选中，前端报错

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->
- release/3.7
