### PR TITLE
Automated cherry pick of #59: fix(OsSelect): #7274 从ISO启动的windows系统vmware虚拟机重装系统选择windows系统时无法选中，前端报错

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -638,7 +638,11 @@ export default {
         this.defaultSelect(os)
         if (image) {
           image = { key: image.id, label: image.name }
-          this.form.fc.setFieldsValue({ image })
+          if (this.imageOptions.length === 0) {
+            this.form.fc.setFieldsValue({ image: initData })
+          } else {
+            this.form.fc.setFieldsValue({ image })
+          }
           this.imageChange(image)
         }
       } else {

--- a/containers/Compute/sections/OsSelect/index.vue
+++ b/containers/Compute/sections/OsSelect/index.vue
@@ -187,7 +187,7 @@ export default {
       const lastSelectedImageInfo = storage.get('oc_selected_image') || {}
       const image = ret[0].imageMsg
 
-      if (image.properties) {
+      if (image?.properties) {
         let os_distribution = image.properties.os_distribution
         const os_type = image.properties.os_type
         if (os_distribution) {


### PR DESCRIPTION
Cherry pick of #59 on release/3.7.

#59: fix(OsSelect): #7274 从ISO启动的windows系统vmware虚拟机重装系统选择windows系统时无法选中，前端报错