### PR TITLE
bugfix(compute): fix osselect imageselect

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelectTemplate.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelectTemplate.vue
@@ -3,18 +3,18 @@
     <a-select-option v-for="item in imageOptions" :key="item.id" :value="item.id">
       <div>
         <a-row>
-          <a-col :span="18">
-            {{ item.name }}
-          </a-col>
-          <a-col :span="6" align="right">
-            <div class="oc-selected-display-none text-color-secondary" style="text-align: right;">
-              {{ imgLabels(item) }}
-            </div>
+          <a-col :span="24">
+            <div>{{ item.name }}</div>
           </a-col>
         </a-row>
         <a-row>
-          <a-col :span="24">
+          <a-col :span="16">
             <div class="oc-selected-display-none text-color-secondary" v-if="showExternalId && item.external_id">{{ $t('compute.text_1346') }}: {{ item.external_id }}</div>
+          </a-col>
+          <a-col :span="8" align="right">
+            <div class="oc-selected-display-none text-color-secondary" style="text-align: right;">
+              {{ imgLabels(item) }}
+            </div>
           </a-col>
         </a-row>
       </div>


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

修改 aws windows虚拟机重装系统时在1366*768分辨率的屏幕上镜像显示重叠 问题
解决: 修改ImageSelectTemplate组件,将imgLabels放入第二行中

**是否需要 backport 到之前的 release 分支**:
- release/3.7
