### PR TITLE
fix(compute): 网络切换到自动调度后弹性公网IP使用默认，不支持新建

### DIFF
--- a/containers/Compute/sections/ServerNetwork/index.vue
+++ b/containers/Compute/sections/ServerNetwork/index.vue
@@ -177,6 +177,7 @@ export default {
   },
   methods: {
     change (e) {
+      this.form.fd.networkType = e.target.value
       switch (e.target.value) {
         case NETWORK_OPTIONS_MAP.default.key:
           this.networkComponent = ''

--- a/containers/Compute/views/vminstance/create/form/IDC.vue
+++ b/containers/Compute/views/vminstance/create/form/IDC.vue
@@ -211,6 +211,7 @@ import { resolveValueChangeField } from '@/utils/common/ant'
 import { IMAGES_TYPE_MAP, STORAGE_TYPES, HOST_CPU_ARCHS } from '@/constants/compute'
 import EipConfig from '@Compute/sections/EipConfig'
 import OsArch from '@/sections/OsArch'
+import { NETWORK_OPTIONS_MAP } from '@Compute/constants'
 
 export default {
   name: 'VM_IDCCreate',
@@ -391,7 +392,10 @@ export default {
       }
     },
     showEip () {
-      const { vpcs } = this.form.fd
+      const { vpcs, networkType } = this.form.fd
+      if (networkType === NETWORK_OPTIONS_MAP.default.key) {
+        return false
+      }
       if (R.is(Object, vpcs)) {
         const vpcList = Object.values(vpcs)
         if (vpcList.length && !~vpcList.indexOf('default')) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->
- 修复：网络切换到自动调度后弹性公网IP使用默认，不支持新建

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->
- release/3.6
