### PR TITLE
Automated cherry pick of #87: fix(compute): 网络切换到自动调度后弹性公网IP使用默认，不支持新建

### DIFF
--- a/containers/Compute/sections/ServerNetwork/index.vue
+++ b/containers/Compute/sections/ServerNetwork/index.vue
@@ -177,6 +177,7 @@ export default {
   },
   methods: {
     change (e) {
+      this.form.fd.networkType = e.target.value
       switch (e.target.value) {
         case NETWORK_OPTIONS_MAP.default.key:
           this.networkComponent = ''

--- a/containers/Compute/views/vminstance/create/form/IDC.vue
+++ b/containers/Compute/views/vminstance/create/form/IDC.vue
@@ -211,6 +211,7 @@ import { resolveValueChangeField } from '@/utils/common/ant'
 import { IMAGES_TYPE_MAP, STORAGE_TYPES, HOST_CPU_ARCHS } from '@/constants/compute'
 import EipConfig from '@Compute/sections/EipConfig'
 import OsArch from '@/sections/OsArch'
+import { NETWORK_OPTIONS_MAP } from '@Compute/constants'
 
 export default {
   name: 'VM_IDCCreate',
@@ -391,7 +392,10 @@ export default {
       }
     },
     showEip () {
-      const { vpcs } = this.form.fd
+      const { vpcs, networkType } = this.form.fd
+      if (networkType === NETWORK_OPTIONS_MAP.default.key) {
+        return false
+      }
       if (R.is(Object, vpcs)) {
         const vpcList = Object.values(vpcs)
         if (vpcList.length && !~vpcList.indexOf('default')) {


### PR DESCRIPTION
Cherry pick of #87 on release/3.6.

#87: fix(compute): 网络切换到自动调度后弹性公网IP使用默认，不支持新建