### PR TITLE
fix(workflow): 通过主机工单创建虚拟机失败，工单详情中缺少查看失败原因的链接

### DIFF
--- a/src/views/workflow/components/ProcessHistory.vue
+++ b/src/views/workflow/components/ProcessHistory.vue
@@ -43,7 +43,7 @@ export default {
         minWidth: 40,
         showOverflow: 'title',
       },
-      /* {
+      {
         field: 'task_approved',
         title: this.$t('common_364'),
         minWidth: 40,
@@ -57,7 +57,7 @@ export default {
             }
           },
         },
-      }, */
+      },
       {
         field: 'comment',
         title: this.$t('common_157'),
@@ -72,7 +72,7 @@ export default {
     ]
   },
   methods: {
-    getApproveHandle (msg, row) {
+    getApproveHandle (row, msg) {
       const statusObj = approveStatusMap[`${row.activity_id}`]
       const approved = row.task.local_variables.approved
       const pdk = this.processInstanceInfo.process_definition_key


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->
- 修复：通过主机工单创建虚拟机失败，工单详情中缺少查看失败原因的链接

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->
- release/3.7
