### PR TITLE
fix: misc fixed for cloudbox

### DIFF
--- a/containers/Dashboard/extends/Ring/components/Server.vue
+++ b/containers/Dashboard/extends/Ring/components/Server.vue
@@ -76,8 +76,8 @@ export default {
     const initialCloudEnvValue = ((this.params && this.params.type !== 'k8s') && this.params.cloud_env) || ''
     const initialBrandValue = ((this.params && this.params.type !== 'k8s') && this.params.brand) || ''
     const initialRegionValue = ((this.params && this.params.type !== 'k8s') && this.params.region) || ''
-    const initialAllUsageKeyValue = ((this.params && this.params.type !== 'k8s') && this.params.all_usage_key) || 'hosts.memory'
-    const initialUsageKeyValue = ((this.params && this.params.type !== 'k8s') && this.params.usage_key) || 'all.servers.memory'
+    const initialAllUsageKeyValue = ((this.params && this.params.type !== 'k8s') && this.params.all_usage_key) || ''
+    const initialUsageKeyValue = ((this.params && this.params.type !== 'k8s') && this.params.usage_key) || ''
     const initialRegionAccountType = ((this.params && this.params.type !== 'k8s') && this.params.regionAccountType) || 'region'
     const initialColorValue = ((this.params && this.params.type !== 'k8s') && this.params.color) || 'default'
     const initialUsageLabelValue = ((this.params && this.params.type !== 'k8s') && this.params.usage_label && this.params.usage_label.length > 0) ? this.params.usage_label : this.$t('dashboard.text_33')

--- a/containers/Dashboard/locales/en.json
+++ b/containers/Dashboard/locales/en.json
@@ -100,7 +100,7 @@
   "dashboard.text_97": "Usage metrics",
   "dashboard.usage_metric_name": "Usage metric name",
   "dashboard.remaining_usage_metric_name": "Remaining metric name",
-  "dashboard.text_98": "Cloud region & Platform",
+  "dashboard.text_98": "Cloud Platform",
   "dashboard.text_99": "All",
   "dashboard.text_100": "Region & Account",
   "dashboard.text_101": "Region",

--- a/containers/Dashboard/locales/zh-CN.json
+++ b/containers/Dashboard/locales/zh-CN.json
@@ -100,7 +100,7 @@
   "dashboard.text_97": "使用量指标",
   "dashboard.usage_metric_name": "指标名称",
   "dashboard.remaining_usage_metric_name": "剩余指标名称",
-  "dashboard.text_98": "云环境和平台",
+  "dashboard.text_98": "云平台",
   "dashboard.text_99": "全部",
   "dashboard.text_100": "区域或云账号",
   "dashboard.text_101": "区域",

--- a/containers/Network/views/network/Create.vue
+++ b/containers/Network/views/network/Create.vue
@@ -427,7 +427,7 @@ export default {
         scope: this.scope,
         limit: 0,
         is_on_premise: true,
-        usable_vpc: true,
+        // usable_vpc: true,
         show_emulated: true,
       }
       if (this.cloudEnv === 'private') {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2140,6 +2140,7 @@
   "auth.register.submit": "Sign Up",
   "auth.register.account_name.placeholder": "Administrator Account",
   "auth.register.account_name.validate": "Please enter the administrator account",
+  "auth.register.account_name.preserved": "This account has been reserved for system administration, please choose another name",
   "auth.register.account_password.placeholder": "Please enter your password",
   "auth.register.confirm_account_password.placeholder": "Please confirm the administrator password again",
   "auth.register.account_password.validate": "Please enter the administrator password",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -2147,6 +2147,7 @@
   "auth.register.submit": "注册",
   "auth.register.account_name.placeholder": "管理员账号",
   "auth.register.account_name.validate": "请输入管理员账号",
+  "auth.register.account_name.preserved": "该管理员账号被系统预留，请使用其他账号名",
   "auth.register.account_password.placeholder": "请输入密码",
   "auth.register.confirm_account_password.placeholder": "请再次确认管理员密码",
   "auth.register.account_password.validate": "请输入管理员密码",

--- a/src/sections/Auth/AdminRegister.vue
+++ b/src/sections/Auth/AdminRegister.vue
@@ -63,7 +63,15 @@ export default {
       rules: {
         account_name: [
           { required: true, message: this.$t('auth.register.account_name.validate') },
-          { validator: this.$validate('domainAccount') },
+          {
+            validator: (rule, value, _callback) => {
+              if (value && value === 'sysadmin') {
+                _callback(this.$t('auth.register.account_name.preserved'))
+              } else {
+                this.$validate('domainAccount')(rule, value, _callback)
+              }
+            },
+          },
         ],
         account_password: [
           { required: true, message: this.$t('auth.register.account_password.validate') },

--- a/src/sections/Navbar/index.vue
+++ b/src/sections/Navbar/index.vue
@@ -374,12 +374,19 @@ export default {
     showWorkFlow () {
       return this.showWorkOrder && this.workflow.enabledKeys?.length > 0
     },
+    globalSettingSetupKeys () {
+      const { globalSetting } = this.$store.state
+      if (globalSetting && globalSetting.value) {
+        return globalSetting.value.setupKeys || []
+      }
+      return []
+    },
   },
   watch: {
     userInfo: {
       handler (val, oldVal = {}) {
         if (val.id !== oldVal.id) {
-          if (getSetupInStorage() && val.roles && val.roles.includes('admin')) {
+          if (getSetupInStorage() && this.globalSettingSetupKeys.length === 0 && val.roles && val.roles.includes('admin')) {
             this.$router.push('/guide')
             return
           }


### PR DESCRIPTION
1. adminRegister: user name cann't be sysadmin
2. region list is empty in network create forms
3. set empty init value in dashboard utilization forms

**这个 PR 实现什么功能/修复什么问题**:
1. 注册时候禁止使用sysadmin
2. 新建第一个本地IDC网络时的region下拉列表为空
3. 使用率控件的form初始值应该重置为空

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->

/cc @Easy-MJ 