### PR TITLE
bugfix(compute): close vminstance filter(vmem_size & disk)

### DIFF
--- a/containers/Compute/views/vminstance/components/List.vue
+++ b/containers/Compute/views/vminstance/components/List.vue
@@ -115,15 +115,15 @@ export default {
       region: getRegionFilter(),
       vpc: getVpcFilter(),
       os_arch: getOsArchFilter(),
-      vmem_size: {
-        label: this.$t('table.title.vmem_size'),
-      },
+      // vmem_size: {
+      //   label: this.$t('table.title.vmem_size'),
+      // },
       vcpu_count: {
         label: 'CPU',
       },
-      disk: {
-        label: this.$t('table.title.disk'),
-      },
+      // disk: {
+      //   label: this.$t('table.title.disk'),
+      // },
     }
     this.hiddenFilterOptions.forEach(key => {
       delete filterOptions[key]


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

后端暂时不支持对磁盘和内存的过滤搜索,暂时关掉

**是否需要 backport 到之前的 release 分支**:

- release/3.7
