### PR TITLE
Automated cherry pick of #108: bugfix(compute): close vminstance filter(vmem_size & disk)

### DIFF
--- a/containers/Compute/views/vminstance/components/List.vue
+++ b/containers/Compute/views/vminstance/components/List.vue
@@ -115,15 +115,15 @@ export default {
       region: getRegionFilter(),
       vpc: getVpcFilter(),
       os_arch: getOsArchFilter(),
-      vmem_size: {
-        label: this.$t('table.title.vmem_size'),
-      },
+      // vmem_size: {
+      //   label: this.$t('table.title.vmem_size'),
+      // },
       vcpu_count: {
         label: 'CPU',
       },
-      disk: {
-        label: this.$t('table.title.disk'),
-      },
+      // disk: {
+      //   label: this.$t('table.title.disk'),
+      // },
     }
     this.hiddenFilterOptions.forEach(key => {
       delete filterOptions[key]


### PR DESCRIPTION
Cherry pick of #108 on release/3.7.

#108: bugfix(compute): close vminstance filter(vmem_size & disk)