### PR TITLE
Automated cherry pick of #160: feat(TagSelect): support min-width

### DIFF
--- a/src/sections/TagSelect/index.vue
+++ b/src/sections/TagSelect/index.vue
@@ -398,7 +398,7 @@ export default {
 
 <style lang="less" scoped>
 .tag-wrap {
-  width: 200px;
+  min-width: 200px;
   max-height: 400px;
   overflow: hidden;
   overflow-y: auto;


### PR DESCRIPTION
Cherry pick of #160 on release/3.7.

#160: feat(TagSelect): support min-width