### PR TITLE
fix(Compute): #10789 baremetal install sys with zone and region error

### DIFF
--- a/containers/Compute/views/baremetal/create/index.vue
+++ b/containers/Compute/views/baremetal/create/index.vue
@@ -1207,8 +1207,8 @@ export default {
         nets,
         prefer_host: this.isInstallOperationSystem ? this.$route.query.id : values.schedPolicyHost,
         description: values.description,
-        prefer_region: values.cloudregion ? values.cloudregion.key : this.$route.query.zone_id,
-        prefer_zone: values.zone ? values.zone.key : this.$route.query.region_id,
+        prefer_region: values.cloudregion ? values.cloudregion.key : this.$route.query.region_id,
+        prefer_zone: values.zone ? values.zone.key : this.$route.query.zone_id,
       }
       if (values.loginPassword) params.password = values.loginPassword
       if (values.loginKeypair) params.keypair = values.loginKeypair.key


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->
- 物理机安装操作系统时可用区应该取所选host所在区域和可用区的id

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->
- release/3.6
