### PR TITLE
fix(ServerPassword): 使用主机快照创建主机，不应该显示设置密码的输入框

### DIFF
--- a/containers/Compute/sections/ServerPassword/index.vue
+++ b/containers/Compute/sections/ServerPassword/index.vue
@@ -101,9 +101,11 @@ export default {
     isSnapshotImageType (val) {
       if (val) {
         this.disabled = true
+        const v = LOGIN_TYPES_MAP.image.key
         this.form.fc.setFieldsValue({
-          [this.decorators.loginType[0]]: LOGIN_TYPES_MAP.image.key,
+          [this.decorators.loginType[0]]: v,
         })
+        this.vmLoginType = v
       } else {
         this.disabled = false
       }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->
- 修复：使用主机快照创建主机，不应该显示设置密码的输入框

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->
- release/3.5
