### PR TITLE
vue router meta add propertity canRenderDefaultLayout

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -97,7 +97,10 @@ router.beforeEach(async (to, from, next) => {
   } catch (error) {
     throw error
   } finally {
-    store.commit('auth/SET_CAN_RENDER_DEFAULT_LAYOUT', true)
+    const { canRenderDefaultLayout = true } = to.meta
+    if (canRenderDefaultLayout) {
+      store.commit('auth/SET_CAN_RENDER_DEFAULT_LAYOUT', true)
+    }
     next()
   }
 })


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
* vue router meta add propertity canRenderDefaultLayout
* 
**是否需要 backport 到之前的 release 分支**:
- release/3.7

/area dashboard
/cc @Easy-MJ @GuoLiBin6 
