### PR TITLE
fix(ServerPassword): 选择主机快照默认选中保留镜像设置且不支持更改类型

### DIFF
--- a/containers/Compute/sections/ServerPassword/index.vue
+++ b/containers/Compute/sections/ServerPassword/index.vue
@@ -128,7 +128,7 @@ export default {
         const loginTypeInitailValue = this.decorator.loginType[1].initialValue
         const keys = Object.keys(this.loginTypeMap)
         let vmLoginType = loginTypeInitailValue
-        if (!keys.includes(loginTypeInitailValue)) { // 如果表单中的初始值不在 loginTypeMap 中
+        if (!keys.includes(loginTypeInitailValue) || this.isSnapshotImageType) { // 如果表单中的初始值不在 loginTypeMap 中, 主机快照只支持保留镜像设置
           if (keys.includes(LOGIN_TYPES_MAP.image.key)) { // 如果maps中有"保留镜像设置"，则设置
             vmLoginType = LOGIN_TYPES_MAP.image.key
           } else { // 否则设置第一项


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->
- 修复：选择主机快照默认选中保留镜像设置且不支持更改类型

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->
- release/3.5
