### PR TITLE
feat(ServerNetwork): add vpc options

### DIFF
--- a/containers/Compute/sections/ServerNetwork/NetworkConfig.vue
+++ b/containers/Compute/sections/ServerNetwork/NetworkConfig.vue
@@ -21,7 +21,8 @@
           :remote-fn="q => ({ search: q })"
           @change="v => vpcChange(v, i)"
           :disabled="vpcObj && !!vpcObj.id"
-          :select-props="{ allowClear: true, placeholder: $t('compute.text_194') }" />
+          :select-props="{ allowClear: true, placeholder: $t('compute.text_194') }"
+          :options="vpcResList" />
         <a-tag v-else color="blue" class="w-100 mr-1">{{ getVpcTag(networkList[0].vpc) }}</a-tag>
       </a-form-item>
       <a-form-item
@@ -124,6 +125,9 @@ export default {
     ipsDisable: {
       type: Boolean,
       default: false,
+    },
+    vpcResList: {
+      type: Array,
     },
   },
   data () {

--- a/containers/Compute/sections/ServerNetwork/index.vue
+++ b/containers/Compute/sections/ServerNetwork/index.vue
@@ -23,7 +23,8 @@
         :ipsDisable="ipsDisable"
         :network-resource-mapper="networkResourceMapper"
         :vpc-resource-mapper="vpcResourceMapper"
-        :limit="form.fi.capability.max_nic_count" />
+        :limit="form.fi.capability.max_nic_count"
+        :vpcResList="vpcResList" />
     </a-form-item>
     <a-form-item v-if="networkComponent === 'schedtag'">
       <network-schedtag
@@ -106,6 +107,9 @@ export default {
       type: Object,
     },
     allowNetworkTypes: {
+      type: Array,
+    },
+    vpcResList: {
       type: Array,
     },
   },

--- a/src/components/BaseSelect/index.vue
+++ b/src/components/BaseSelect/index.vue
@@ -399,7 +399,7 @@ export default {
       this.disabledOpts()
     },
     async loadOpts (query) {
-      if (this.options) return // 指定数据源是外传options,这里不请求
+      if (this.options?.length > 0) return // 指定数据源是外传options,这里不请求
       if (!R.isNil(query) && this.filterable) return // 如果开启本地搜索，远程搜索将取消
       const { manager, params } = this.genParams(query)
       this.loadMoreOffset = 0


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->
- 功能支持：网络IP子网的vpc数据使用资源池的子网数据源

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->
- release/3.5
