### PR TITLE
Automated cherry pick of #269: fix(OsSelect): select instance snapshot params and console error

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -278,7 +278,7 @@ export default {
           this.fetchHostImages(params)
           break
         case IMAGES_TYPE_MAP.snapshot.key: // 主机快照
-          params = { ...this.imageParams, status: 'ready' }
+          params = { ...this.imageParams, status: 'ready', provider: this.cloudproviderParamsExtra?.provider }
           this.fetchSnapshotImages(params)
           break
         default: // image list

--- a/containers/Compute/sections/OsSelect/ImageSelectTemplate.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelectTemplate.vue
@@ -84,9 +84,16 @@ export default {
     },
     imgLabels (img) {
       const size = sizestr(img.size, 'B', 1024)
+<<<<<<< HEAD
       const arch = img.properties && img.properties.arch ? img.properties.arch : 'x86_64'
       const bios = img.properties && img.properties.uefi_support ? 'UEFI' : 'BIOS'
       const part = img.properties && img.properties.partition_type ? img.properties.partition_type.toUpperCase() : 'MBR'
+=======
+      const props = img.properties || (img.info ? img.info.properties : undefined)
+      const arch = props && props.os_arch && props.os_arch === 'aarch64' ? this.$t('compute.cpu_arch.aarch64') : props?.os_arch || 'x86_64'
+      const bios = props && props.uefi_support ? 'UEFI' : 'BIOS'
+      const part = props && props.partition_type ? props.partition_type.toUpperCase() : 'MBR'
+>>>>>>> fix(OsSelect): select instance snapshot params and console error
       return `${size}|${arch}|${part}|${bios}`
     },
   },


### PR DESCRIPTION
Cherry pick of #269 on release/3.6.

#269: fix(OsSelect): select instance snapshot params and console error