### PR TITLE
fix(Locales): image save fail i18n

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -199,7 +199,8 @@
       "unknown": "Unknown",
       "pending_delete": "Pending Delete",
       "converting": "Converting format",
-      "deactivated": "Deleting"
+      "deactivated": "Deleting",
+      "save_fail": "Save failed"
     },
     "imageCache": {
       "ready": "Normal",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -199,7 +199,8 @@
       "unknown": "未知",
       "pending_delete": "待删除",
       "converting": "格式转换中",
-      "deactivated": "正在删除"
+      "deactivated": "正在删除",
+      "save_fail": "保存失败"
     },
     "imageCache": {
       "ready": "正常",


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->
- 修复：中文模式下镜像列表save_fail未翻译

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->
- release/3.5
