### PR TITLE
Automated cherry pick of #273: fix(Locales): image save fail i18n

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -199,7 +199,8 @@
       "unknown": "Unknown",
       "pending_delete": "Pending Delete",
       "converting": "Converting format",
-      "deactivated": "Deleting"
+      "deactivated": "Deleting",
+      "save_fail": "Save failed"
     },
     "imageCache": {
       "ready": "Normal",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -199,7 +199,8 @@
       "unknown": "未知",
       "pending_delete": "待删除",
       "converting": "格式转换中",
-      "deactivated": "正在删除"
+      "deactivated": "正在删除",
+      "save_fail": "保存失败"
     },
     "imageCache": {
       "ready": "正常",


### PR DESCRIPTION
Cherry pick of #273 on release/3.7.

#273: fix(Locales): image save fail i18n