### PR TITLE
fix(TagTableColumn): #7435 列表鼠标hover标签icon时，只展示user的标签，不展示ext的

### DIFF
--- a/src/sections/TagTableColumn/index.vue
+++ b/src/sections/TagTableColumn/index.vue
@@ -87,7 +87,9 @@ export default {
       return data
     },
     tags () {
-      let ret = this.data.arr.map(item => {
+      let ret = this.data.arr.filter((item) => {
+        return item.key.startsWith('user:')
+      }).map(item => {
         const rgb = getTagColor(item.key, item.value, 'rgb')
         const strRgb = rgb.join(',')
         return {
@@ -97,7 +99,7 @@ export default {
           ...item,
         }
       })
-      // 根据title去重，ext和user相同的value只显示一个
+      // 根据title去重，相同的value只显示一个
       ret = R.uniqBy(item => item.title, ret)
       return ret
     },


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->
- 修复：列表鼠标hover标签icon时，只展示user的标签，不展示ext的

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.5
-->
- release/3.6
