### PR TITLE
monitor query add metric translations for storage

### DIFF
--- a/containers/Monitor/constants/index.js
+++ b/containers/Monitor/constants/index.js
@@ -354,6 +354,7 @@ export const filterKeyMap = {
   zone: i18n.t('common.zone'),
   vm_name: i18n.t('dictionary.server'),
   vm_ip: i18n.t('dictionary.serverip'),
+  storage_name: i18n.t('storage.text_37'),
   oss_name: i18n.t('scope.text_77'),
   oss_ip: i18n.t('common_721'),
   elb_name: i18n.t('scope.text_105'),


### PR DESCRIPTION
**What this PR does / why we need it**:
*monitor query add metric translations for storage 

**Does this PR need to be backport to the previous release branch?**:

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6
- release/3.5

/area monitor
/cc @Easy-MJ 
