### PR TITLE
Automated cherry pick of #320: monitor query add metric translations for storage

### DIFF
--- a/containers/Monitor/constants/index.js
+++ b/containers/Monitor/constants/index.js
@@ -420,6 +420,7 @@ export const filterKeyMap = {
   zone: i18n.t('common.zone'),
   vm_name: i18n.t('dictionary.server'),
   vm_ip: i18n.t('dictionary.serverip'),
+  storage_name: i18n.t('storage.text_37'),
   oss_name: i18n.t('scope.text_77'),
   oss_ip: i18n.t('common_721'),
   elb_name: i18n.t('scope.text_105'),


### PR DESCRIPTION
Cherry pick of #320 on release/3.5.

#320: monitor query add metric translations for storage