### PR TITLE
lbcert cache add common name & subject_alternative_names

### DIFF
--- a/containers/Network/views/lbcerts/sidepage/Cache.vue
+++ b/containers/Network/views/lbcerts/sidepage/Cache.vue
@@ -49,12 +49,18 @@ export default {
           field: 'common_name',
           title: this.$t('network.text_318'),
           width: 70,
+          formatter: ({ cellValue, row, column }) => {
+            return this.$attrs.data.common_name || '-'
+          },
         },
         getTimeTableColumn(),
         {
           field: 'subject_alternative_names',
           title: this.$t('network.text_320'),
           width: 100,
+          formatter: ({ cellValue, row, column }) => {
+            return this.$attrs.data.subject_alternative_names || '-'
+          },
         },
         getBrandTableColumn(),
         getRegionTableColumn(),


### PR DESCRIPTION
**What this PR does / why we need it**:
*lbcert cache add common name & subject_alternative_names

**Does this PR need to be backport to the previous release branch?**:
- release/3.7

/area network
/cc @Easy-MJ 
