### PR TITLE
Automated cherry pick of #398: fix(Compute/vminstance): #7471 移动云链接vnc按钮不应该禁用，且提示信息不对

### DIFF
--- a/containers/Compute/views/vminstance/utils.js
+++ b/containers/Compute/views/vminstance/utils.js
@@ -135,6 +135,7 @@ const actionEableMap = {
       ctyun: false,
       google: false,
       apsara: ['running'],
+      ecloud: ['running'],
     },
   },
   'EIP SSH': {
@@ -155,6 +156,7 @@ const actionEableMap = {
       ctyun: ['running'],
       google: ['running'],
       apsara: ['running'],
+      ecloud: ['running'],
     },
   },
   'IP SSH': {
@@ -175,6 +177,7 @@ const actionEableMap = {
       ctyun: false,
       google: false,
       apsara: false,
+      ecloud: false,
     },
   },
   createSnapshot: {


### PR DESCRIPTION
Cherry pick of #398 on release/3.7.

#398: fix(Compute/vminstance): #7471 移动云链接vnc按钮不应该禁用，且提示信息不对