### PR TITLE
feature(cloudenv): delete-pricecomparator-list-sync

### DIFF
--- a/containers/Cloudenv/views/server-price-comparator/components/List.vue
+++ b/containers/Cloudenv/views/server-price-comparator/components/List.vue
@@ -2,6 +2,7 @@
   <page-list
     :list="list"
     :columns="columns"
+    :showSync="false"
     :group-actions="groupActions"
     :single-actions="singleActions" />
 </template>

--- a/src/components/PageList/Actions/index.vue
+++ b/src/components/PageList/Actions/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="beforeShowMenuLoaded">
-    <template v-for="item of options">
+    <template v-for="(item,index) of options">
       <!-- 一组操作，下拉形式展示 -->
       <template v-if="item.actions">
         <dropmenus
@@ -25,7 +25,7 @@
           :button-type="buttonType"
           :button-size="buttonSize"
           :button-block="buttonBlock"
-          :class="{ 'ml-2': group }"
+          :class="{ 'ml-2': group && ((index === 0 && showSync) || index !== 0) }"
           :button-style="buttonStyle"
           @clear-selected="clearSelected" />
       </template>
@@ -70,6 +70,10 @@ export default {
     },
     beforeShowMenu: {
       type: Function,
+    },
+    // 按钮组前是否还有刷新按钮
+    showSync: {
+      type: Boolean,
     },
   },
   data () {

--- a/src/components/PageList/components/Header.vue
+++ b/src/components/PageList/components/Header.vue
@@ -4,6 +4,7 @@
       <div class="d-flex flex-fill">
         <!-- 刷新 -->
         <a-button
+          v-if="showSync"
           class="flex-shrink-0"
           :disabled="loading"
           @click="handleRefresh">
@@ -17,6 +18,7 @@
             class="flex-shrink-0"
             :options="groupActions"
             button-type="default"
+            :show-sync="showSync"
             @clear-selected="() => $emit('clear-selected')" />
         </template>
         <!-- 批量后面追加内容 slot -->
@@ -76,6 +78,11 @@ export default {
     id: String,
     // 是否加载中
     loading: Boolean,
+    // 是否显示刷新按钮
+    showSync: {
+      type: Boolean,
+      default: true,
+    },
     // 是否显示批量操作区域
     showGroupActions: {
       type: Boolean,

--- a/src/components/PageList/index.vue
+++ b/src/components/PageList/index.vue
@@ -2,6 +2,7 @@
   <div>
     <page-list-header
       :id="id"
+      :show-sync="showSync"
       :show-group-actions="showGroupActions"
       :loading="loading"
       :group-actions="groupActions"
@@ -96,6 +97,11 @@ export default {
     list: {
       type: Object,
       required: true,
+    },
+    // 是否展示刷新按钮
+    showSync: {
+      type: Boolean,
+      default: true,
     },
     // 是否显示批量操作区域
     showGroupActions: {


### PR DESCRIPTION


**What this PR does / why we need it**:

隐藏价格清单列表刷新按钮
扩展page-list,允许隐藏刷新按钮

**Does this PR need to be backport to the previous release branch?**:

- release/3.7
