### PR TITLE
feat(cloudaccount): account column add cloudprovider

### DIFF
--- a/containers/Compute/views/vminstance/components/List.vue
+++ b/containers/Compute/views/vminstance/components/List.vue
@@ -33,6 +33,7 @@ import {
   getVpcFilter,
   getOsArchFilter,
   getRegionFilter,
+  getCloudProviderFilter,
 } from '@/utils/common/tableFilter'
 import { disableDeleteAction } from '@/utils/common/tableActions'
 import expectStatus from '@/constants/expectStatus'
@@ -125,6 +126,7 @@ export default {
       vcpu_count: {
         label: 'CPU',
       },
+      manager: getCloudProviderFilter(),
       // disk: {
       //   label: this.$t('table.title.disk'),
       // },

--- a/containers/Compute/views/vminstance/mixins/columns.js
+++ b/containers/Compute/views/vminstance/mixins/columns.js
@@ -12,6 +12,7 @@ import {
   getBillingTableColumn,
   getTimeTableColumn,
   getOsArch,
+  getAccountTableColumn,
 } from '@/utils/common/tableColumn'
 import SystemIcon from '@/sections/SystemIcon'
 import { sizestr } from '@/utils/utils'
@@ -259,11 +260,12 @@ export default {
       }),
       getBillingTableColumn({ vm: this, hiddenSetBtn: () => this.$isScopedPolicyMenuHidden('vminstance_hidden_menus.server_perform_cancel_expire') }),
       getBrandTableColumn(),
-      getCopyWithContentTableColumn({
-        field: 'account',
-        title: i18nLocale.t('res.cloudaccount'),
-        hidden: () => this.$store.getters.isProjectMode,
-      }),
+      // getCopyWithContentTableColumn({
+      //   field: 'account',
+      //   title: i18nLocale.t('res.cloudaccount'),
+      //   hidden: () => this.$store.getters.isProjectMode,
+      // }),
+      getAccountTableColumn(),
       {
         field: 'host',
         title: i18nLocale.t('res.host'),

--- a/containers/DB/views/rds/components/List.vue
+++ b/containers/DB/views/rds/components/List.vue
@@ -15,7 +15,7 @@
 import ColumnsMixin from '../mixins/columns'
 import SingleActionsMixin from '../mixins/singleActions'
 import ListMixin from '@/mixins/list'
-import { getNameFilter, getFilter, getTenantFilter, getDomainFilter, getStatusFilter, getBrandFilter } from '@/utils/common/tableFilter'
+import { getNameFilter, getFilter, getTenantFilter, getDomainFilter, getStatusFilter, getBrandFilter, getCloudProviderFilter } from '@/utils/common/tableFilter'
 import { disableDeleteAction } from '@/utils/common/tableActions'
 import expectStatus from '@/constants/expectStatus'
 import WindowsMixin from '@/mixins/windows'
@@ -81,6 +81,7 @@ export default {
             label: this.$t('db.text_40'),
           },
           project_domains: getDomainFilter(),
+          manager: getCloudProviderFilter(),
         },
         responseData: this.responseData,
         hiddenColumns: ['metadata', 'vcpu_count', 'account'],

--- a/containers/DB/views/rds/mixins/columns.js
+++ b/containers/DB/views/rds/mixins/columns.js
@@ -1,6 +1,6 @@
 import { DBINSTANCE_CATEGORY } from '../constants/index.js'
 import { sizestr } from '@/utils/utils'
-import { getProjectTableColumn, getStatusTableColumn, getNameDescriptionTableColumn, getBrandTableColumn, getBillingTableColumn, getTagTableColumn } from '@/utils/common/tableColumn'
+import { getProjectTableColumn, getStatusTableColumn, getNameDescriptionTableColumn, getBrandTableColumn, getBillingTableColumn, getTagTableColumn, getAccountTableColumn } from '@/utils/common/tableColumn'
 import i18n from '@/locales'
 
 export default {
@@ -96,11 +96,7 @@ export default {
       },
       getBillingTableColumn({ vm: this }),
       getBrandTableColumn(),
-      {
-        field: 'account',
-        minWidth: 100,
-        title: i18n.t('db.text_67'),
-      },
+      getAccountTableColumn(),
       getProjectTableColumn(),
       {
         field: 'region',

--- a/containers/DB/views/redis/components/List.vue
+++ b/containers/DB/views/redis/components/List.vue
@@ -16,7 +16,7 @@ import { ENGINE_ARCH } from '../constants/index.js'
 import ColumnsMixin from '../mixins/columns'
 import SingleActionsMixin from '../mixins/singleActions'
 import ListMixin from '@/mixins/list'
-import { getNameFilter, getStatusFilter, getTenantFilter, getFilter, getDomainFilter, getBrandFilter } from '@/utils/common/tableFilter'
+import { getNameFilter, getStatusFilter, getTenantFilter, getFilter, getDomainFilter, getBrandFilter, getCloudProviderFilter } from '@/utils/common/tableFilter'
 import { disableDeleteAction } from '@/utils/common/tableActions'
 import expectStatus from '@/constants/expectStatus'
 import WindowsMixin from '@/mixins/windows'
@@ -90,6 +90,7 @@ export default {
           region: {
             label: this.$t('db.text_40'),
           },
+          manager: getCloudProviderFilter(),
         },
         responseData: this.responseData,
         hiddenColumns: ['metadata', 'instance_type', 'account'],

--- a/containers/DB/views/redis/mixins/columns.js
+++ b/containers/DB/views/redis/mixins/columns.js
@@ -1,7 +1,7 @@
 import { ENGINE_ARCH } from '../constants/index.js'
 import PasswordFetcher from '@Compute/sections/PasswordFetcher'
 import { sizestr } from '@/utils/utils'
-import { getProjectTableColumn, getRegionTableColumn, getStatusTableColumn, getNameDescriptionTableColumn, getBrandTableColumn, getTagTableColumn, getBillingTableColumn } from '@/utils/common/tableColumn'
+import { getProjectTableColumn, getRegionTableColumn, getStatusTableColumn, getNameDescriptionTableColumn, getBrandTableColumn, getTagTableColumn, getBillingTableColumn, getAccountTableColumn } from '@/utils/common/tableColumn'
 import i18n from '@/locales'
 
 export default {
@@ -115,16 +115,7 @@ export default {
       },
       getBillingTableColumn({ vm: this }),
       getBrandTableColumn(),
-      {
-        field: 'account',
-        title: i18n.t('db.text_67'),
-        minWidth: 100,
-        slots: {
-          default: ({ row }) => {
-            return row.account
-          },
-        },
-      },
+      getAccountTableColumn(),
       getProjectTableColumn(),
       getRegionTableColumn(),
     ]

--- a/containers/Network/views/lb/components/List.vue
+++ b/containers/Network/views/lb/components/List.vue
@@ -20,7 +20,7 @@ import { validateEnabled, validateDisable } from '../utils'
 import { surpportLb } from '@Network/views/lb/constants'
 import ListMixin from '@/mixins/list'
 import WindowsMixin from '@/mixins/windows'
-import { getNameFilter, getBrandFilter, getTenantFilter, getDomainFilter, getAccountFilter, getStatusFilter } from '@/utils/common/tableFilter'
+import { getNameFilter, getBrandFilter, getTenantFilter, getDomainFilter, getAccountFilter, getStatusFilter, getCloudProviderFilter } from '@/utils/common/tableFilter'
 import { getEnabledSwitchActions, disableDeleteAction } from '@/utils/common/tableActions'
 import expectStatus from '@/constants/expectStatus'
 import { changeToArr } from '@/utils/utils'
@@ -68,6 +68,7 @@ export default {
       zone: {
         label: this.$t('compute.text_270'),
       },
+      manager: getCloudProviderFilter(),
     }
     const { path } = this.$route
     if (path.includes('/cluster')) {

--- a/containers/Storage/views/bucket/components/List.vue
+++ b/containers/Storage/views/bucket/components/List.vue
@@ -19,7 +19,7 @@ import SingleActionsMixin from '../mixins/singleActions'
 import { ACL_TYPE } from '@Storage/constants/index.js'
 import WindowsMixin from '@/mixins/windows'
 import ListMixin from '@/mixins/list'
-import { getNameFilter, getTenantFilter, getBrandFilter, getStatusFilter, getAccountFilter, getDomainFilter } from '@/utils/common/tableFilter'
+import { getNameFilter, getTenantFilter, getBrandFilter, getStatusFilter, getAccountFilter, getDomainFilter, getCloudProviderFilter } from '@/utils/common/tableFilter'
 import { getSetPublicAction } from '@/utils/common/tableActions'
 import expectStatus from '@/constants/expectStatus'
 import GlobalSearchMixin from '@/mixins/globalSearch'
@@ -74,6 +74,7 @@ export default {
             label: this.$t('dictionary.region'),
           },
           project_domains: getDomainFilter(),
+          manager: getCloudProviderFilter(),
         },
         responseData: this.responseData,
         hiddenColumns: ['storage_class', 'account', 'public_scope'],

--- a/src/utils/common/tableColumn.js
+++ b/src/utils/common/tableColumn.js
@@ -421,7 +421,7 @@ export const getAccountTableColumn = ({
         const ret = []
         ret.push(
           <list-body-cell-wrap hide-field copy field={field} row={row}>
-            <span style={{ color: '#0A1F44' }}>{ val }</span>
+            <span style={{ color: '#0A1F44' }}>{ val || '-' }</span>
           </list-body-cell-wrap>,
         )
         if (row.manager) {

--- a/src/utils/common/tableFilter.js
+++ b/src/utils/common/tableFilter.js
@@ -117,6 +117,19 @@ export function getAccountFilter () {
   }
 }
 
+export function getCloudProviderFilter () {
+  return {
+    label: i18n.t('compute.text_653'),
+    dropdown: true,
+    multiple: false,
+    distinctField: {
+      type: 'extra_field',
+      key: 'manager',
+    },
+    hidden: () => store.getters.isProjectMode,
+  }
+}
+
 export function getIpFilter () {
   return {
     label: 'IP',


### PR DESCRIPTION
**What this PR does / why we need it**:

云账号列表项改为云账号+云订阅的格式
涉及虚拟机/RDS/REDIS/LB/存储桶

**Does this PR need to be backport to the previous release branch?**:

- release/3.7
