### PR TITLE
fix(k8s): ingresses manager get rawdata

### DIFF
--- a/containers/K8S/views/ingress/mixins/singleActions.js
+++ b/containers/K8S/views/ingress/mixins/singleActions.js
@@ -6,7 +6,7 @@ export default {
         label: i18n.t('k8s.text_215'),
         permission: 'k8s_ingresses_update',
         action: async obj => {
-          const manager = new this.$Manager('ingress', 'v1')
+          const manager = new this.$Manager('ingresses', 'v1')
           async function fetchData () {
             const { cluster, namespace } = obj
             const { data } = await manager.getSpecific({ id: obj.id, spec: 'rawdata', params: { cluster, namespace } })


### PR DESCRIPTION
**What this PR does / why we need it**:

K8S ingress manager should use plural.

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- release/3.7
- release/3.6