### PR TITLE
Automated cherry pick of #596: fix(cloudenv): add success tip when account sync success

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/mixins/singleActions.js
+++ b/containers/Cloudenv/views/cloudaccount/mixins/singleActions.js
@@ -35,6 +35,8 @@ export default {
                 force: true,
               },
             },
+          }).then(res => {
+            this.$message.success(this.$t('cloudenv.text_381'))
           })
         },
         meta: (obj) => this.syncPolicy(obj),


### PR DESCRIPTION
Cherry pick of #596 on release/3.7.

#596: fix(cloudenv): add success tip when account sync success