### PR TITLE
fix(cloudenv): cloudgroup list add domain filter

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/sidepage/index.vue
+++ b/containers/Cloudenv/views/cloudaccount/sidepage/index.vue
@@ -102,6 +102,7 @@ export default {
       } else if (this.params.windowData.currentTab === 'cloudgroup-list') {
         return {
           provider: this.data.data && this.data.data.provider,
+          domain_id: this.data.data && this.data.data.domain_id,
         }
       } else if (this.params.windowData.currentTab === 'externalproject-list') {
         return () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

云用户组列表添加云账号归属域的过滤条件

**Does this PR need to be backport to the previous release branch?**:

- release/3.7
