### PR TITLE
Automated cherry pick of #699: fix: 云账号导出的参数项应与自定义列表的参数项一致，目前缺少域、项目等信息

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/components/List.vue
+++ b/containers/Cloudenv/views/cloudaccount/components/List.vue
@@ -89,7 +89,7 @@ export default {
           { label: this.$t('cloudenv.text_99'), key: 'guest_count' },
           { label: this.$t('cloudenv.text_100'), key: 'balance' },
           { label: this.$t('cloudenv.text_101'), key: 'host_count' },
-          { label: this.$t('cloudenv.text_12'), key: 'account' },
+          { label: this.$t('cloudenv.text_94'), key: 'account' },
           { label: this.$t('cloudenv.text_102'), key: 'brand' },
           { label: this.$t('cloudenv.text_83'), key: 'enable_auto_sync' },
           { label: this.$t('cloudenv.text_103'), key: 'last_auto_sync' },
@@ -99,6 +99,14 @@ export default {
             hidden: () => {
               return !this.$store.getters.l3PermissionEnable && (this.$store.getters.scopeResource && this.$store.getters.scopeResource.domain.includes('cloudaccounts'))
             },
+          },
+          {
+            label: this.$t('table.title.owner_domain'),
+            key: 'project_domain',
+          },
+          {
+            label: this.$t('scope.text_573', [this.$t('dictionary.project')]),
+            key: 'tenant',
           },
         ],
       },


### PR DESCRIPTION
Cherry pick of #699 on release/3.7.

#699: fix: 云账号导出的参数项应与自定义列表的参数项一致，目前缺少域、项目等信息