### PR TITLE
Automated cherry pick of #701: fix: enable openstack vm migrate

### DIFF
--- a/containers/Compute/views/vminstance/components/List.vue
+++ b/containers/Compute/views/vminstance/components/List.vue
@@ -939,7 +939,7 @@ export default {
                         ret.validate = false
                         return ret
                       }
-                      if (this.list.selectedItems.some(item => item.hypervisor !== 'kvm')) {
+                      if (this.list.selectedItems.some(item => item.hypervisor !== 'kvm' && item.hypervisor !== 'openstack')) {
                         ret.validate = false
                         return ret
                       }

--- a/containers/Compute/views/vminstance/dialogs/Transfer.vue
+++ b/containers/Compute/views/vminstance/dialogs/Transfer.vue
@@ -114,9 +114,13 @@ export default {
       return this.params.data.length === 1
     },
     hostsParams () {
+      let hostType = 'hypervisor'
+      if (this.firstData.hypervisor !== 'kvm') {
+        hostType = this.firstData.hypervisor
+      }
       const ret = {
         scope: this.scope,
-        host_type: 'hypervisor',
+        host_type: hostType,
         limit: 20,
         enabled: 1,
         host_status: 'online',

--- a/containers/Compute/views/vminstance/mixins/singleActions.js
+++ b/containers/Compute/views/vminstance/mixins/singleActions.js
@@ -1346,7 +1346,7 @@ export default {
                       ret.tooltip = i18n.t('migration.project.error')
                       return ret
                     }
-                    if (obj.hypervisor !== typeClouds.hypervisorMap.kvm.key) {
+                    if (obj.hypervisor !== typeClouds.hypervisorMap.kvm.key && obj.hypervisor !== typeClouds.hypervisorMap.openstack.key) {
                       ret.tooltip = i18n.t('compute.text_473', [PROVIDER_MAP[provider].label])
                       return ret
                     }

--- a/containers/Compute/views/vminstance/utils.js
+++ b/containers/Compute/views/vminstance/utils.js
@@ -211,7 +211,7 @@ const actionEableMap = {
       vmware: false,
       baremetal: false,
       huawei: false,
-      openstack: false,
+      openstack: true,
       zstack: false,
       dstack: false,
       ucloud: false,


### PR DESCRIPTION
Cherry pick of #701 on release/3.7.

#701: fix: enable openstack vm migrate