### PR TITLE
fix [3.7] 磁盘信息使用配置文件和i18n双重翻译, 以免新增的磁盘i18n信息不全

### DIFF
--- a/containers/Compute/sections/DataDisk/index.vue
+++ b/containers/Compute/sections/DataDisk/index.vue
@@ -480,7 +480,16 @@ export default {
       if (this.getHypervisor() === HYPERVISORS_MAP.esxi.key) {
         return this.$te(`common.storage.${diskTypeLabel}`) ? this.$t(`common.storage.${diskTypeLabel}`) : diskTypeLabel
       }
-      return i === 0 ? '' : this.$te(`common.storage.${diskTypeLabel}`) ? this.$t(`common.storage.${diskTypeLabel}`) : diskTypeLabel
+      if (i === 0) {
+        return ''
+      }
+      if (this.$te(`common.storage.${diskTypeLabel}`)) {
+        return this.$t(`common.storage.${diskTypeLabel}`)
+      }
+      if (_.get(this.typesMap, `[${diskTypeLabel}].label`)) {
+        return _.get(this.typesMap, `[${diskTypeLabel}].label`)
+      }
+      return diskTypeLabel
     },
     isSomeLocal (types) {
       const localTypes = types.filter(item => item.indexOf('local') !== -1)

--- a/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
+++ b/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
@@ -904,7 +904,7 @@ export default {
             if (_.get(dataDisks, '[0].diskType.key')) {
               // 针对kvm-local盘特殊处理
               let diskKey = _.get(dataDisks, '[0].diskType.key') // 默认添加的盘和第一块保持一致
-              if (diskKey.indexOf('local') !== -1 && this.selectedItem.hypervisor === HYPERVISORS_MAP.kvm.hypervisor) {
+              if (diskKey.indexOf('local') !== -1 && (this.selectedItem.hypervisor === HYPERVISORS_MAP.kvm.hypervisor || this.selectedItem.hypervisor === HYPERVISORS_MAP.cloudpods.hypervisor)) {
                 diskKey = diskKey.split('-')[0]
               }
               diskObj.backend = diskKey
@@ -929,7 +929,7 @@ export default {
           }
         }
         // 磁盘介质
-        const { key: dataDiskKey = '' } = values.dataDiskTypes[key]
+        const { key: dataDiskKey = '' } = values.dataDiskTypes[key] || {}
         if (dataDiskKey.split('-')[1]) {
           diskObj.medium = dataDiskKey.split('-')[1]
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

fix [3.7] 磁盘信息使用配置文件和i18n双重翻译, 以免新增的磁盘i18n信息不全

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
- release/3.7
