### PR TITLE
Automated cherry pick of #969: fix [3.7] 磁盘信息使用配置文件和i18n双重翻译, 以免新增的磁盘i18n信息不全

### DIFF
--- a/containers/Compute/sections/DataDisk/index.vue
+++ b/containers/Compute/sections/DataDisk/index.vue
@@ -473,7 +473,16 @@ export default {
       if (this.getHypervisor() === HYPERVISORS_MAP.esxi.key) {
         return this.$te(`common.storage.${diskTypeLabel}`) ? this.$t(`common.storage.${diskTypeLabel}`) : diskTypeLabel
       }
-      return i === 0 ? '' : this.$te(`common.storage.${diskTypeLabel}`) ? this.$t(`common.storage.${diskTypeLabel}`) : diskTypeLabel
+      if (i === 0) {
+        return ''
+      }
+      if (this.$te(`common.storage.${diskTypeLabel}`)) {
+        return this.$t(`common.storage.${diskTypeLabel}`)
+      }
+      if (_.get(this.typesMap, `[${diskTypeLabel}].label`)) {
+        return _.get(this.typesMap, `[${diskTypeLabel}].label`)
+      }
+      return diskTypeLabel
     },
   },
 }


### PR DESCRIPTION
Cherry pick of #969 on release/3.7.

#969: fix [3.7] 磁盘信息使用配置文件和i18n双重翻译, 以免新增的磁盘i18n信息不全