### PR TITLE
Automated cherry pick of #975: feat: #3328 新建主机前端磁盘的判断逻辑，只针对openstack，其他平台暂不支持限制

### DIFF
--- a/containers/Compute/views/vminstance/create/components/SystemDisk.vue
+++ b/containers/Compute/views/vminstance/create/components/SystemDisk.vue
@@ -230,7 +230,7 @@ export default {
         isError: false,
       }
       if (this.ignoreStorageStatus || !this.form.fd.systemDiskType || !this.form.fd.systemDiskType.key) return statusMap
-      if (this.capabilityData.storage_types3 && this.hypervisor && !this.isPublic && this.hypervisor !== HYPERVISORS_MAP.hcso.hypervisor) {
+      if (this.capabilityData.storage_types3 && this.hypervisor && this.hypervisor === HYPERVISORS_MAP.openstack.hypervisor) {
         const storageTypes3 = this.capabilityData.storage_types3[this.hypervisor] || {}
         const storages = []
         for (const prop in storageTypes3) {


### PR DESCRIPTION
Cherry pick of #975 on release/3.7.

#975: feat: #3328 新建主机前端磁盘的判断逻辑，只针对openstack，其他平台暂不支持限制