### PR TITLE
fix[3.7]: 阿里云rds调整配置时禁用存储类型

### DIFF
--- a/containers/DB/views/rds/dialogs/SetConfig.vue
+++ b/containers/DB/views/rds/dialogs/SetConfig.vue
@@ -61,7 +61,7 @@ export default {
     disableds () {
       const _ = {
         Huawei: ['engine', 'engine_version', 'zones', 'category', 'storage_type'],
-        Aliyun: ['engine', 'engine_version', 'zones'],
+        Aliyun: ['engine', 'engine_version', 'zones', 'storage_type'],
         Google: ['engine', 'engine_version', 'zones', 'category'],
       }
       return _[this.rdsItem.brand]


### PR DESCRIPTION
**What this PR does / why we need it**:

阿里云rds调整配置时禁用存储类型

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
- release/3.7
