### PR TITLE
Automated cherry pick of #996: fix[3.7]: 阿里云rds调整配置时禁用存储类型

### DIFF
--- a/containers/DB/views/rds/dialogs/SetConfig.vue
+++ b/containers/DB/views/rds/dialogs/SetConfig.vue
@@ -61,7 +61,7 @@ export default {
     disableds () {
       const _ = {
         Huawei: ['engine', 'engine_version', 'zones', 'category', 'storage_type'],
-        Aliyun: ['engine', 'engine_version', 'zones'],
+        Aliyun: ['engine', 'engine_version', 'zones', 'storage_type'],
         Google: ['engine', 'engine_version', 'zones', 'category'],
       }
       return _[this.rdsItem.brand]


### PR DESCRIPTION
Cherry pick of #996 on release/3.7.

#996: fix[3.7]: 阿里云rds调整配置时禁用存储类型