### PR TITLE
Automated cherry pick of #1002: fix[3.7]: 修复rds备份操作按钮与详情状态不一致

### DIFF
--- a/containers/DB/views/rds-backup/mixins/singleActions.js
+++ b/containers/DB/views/rds-backup/mixins/singleActions.js
@@ -25,11 +25,11 @@ export default {
             validate = false
             tooltip = i18n.t('db.text_224')
           }
-          if (this.data.provider === 'Qcloud') {
+          if (obj.provider === 'Qcloud') {
             validate = false
             tooltip = this.$t('db.text_343')
           }
-          if (this.data.provider === 'Aliyun' && (obj.backup_method === 'Logical' || obj.backup_method === 'Snapshot')) {
+          if (obj.provider === 'Aliyun' && (obj.backup_method === 'Logical' || obj.backup_method === 'Snapshot')) {
             validate = false
             tooltip = i18n.t('db.text_375')
           }
@@ -67,8 +67,8 @@ export default {
             refresh: this.refresh,
           })
         },
-        meta: () => {
-          if (this.data.brand === 'Aliyun') {
+        meta: (obj) => {
+          if (obj.brand === 'Aliyun') {
             return {
               validate: false,
               tooltip: i18n.t('db.text_214'),


### PR DESCRIPTION
Cherry pick of #1002 on release/3.7.

#1002: fix[3.7]: 修复rds备份操作按钮与详情状态不一致