### PR TITLE
Automated cherry pick of #1027: monitor overview add disk used percent

### DIFF
--- a/containers/Monitor/components/MonitorCard/OverviewCard/metrics.js
+++ b/containers/Monitor/components/MonitorCard/OverviewCard/metrics.js
@@ -6,6 +6,7 @@ const ServerMetricOptions = [
   { label: i18n.t('monitor.overview_tab_bps_sent'), measurement: 'vm_netio', field: 'bps_sent', format: '0.00 Bps', value: 2 },
   { label: i18n.t('monitor.overview_tab_read_bps'), measurement: 'vm_diskio', field: 'read_bps', format: '0.00 b', value: 3 },
   { label: i18n.t('monitor.overview_tab_write_bps'), measurement: 'vm_diskio', field: 'write_bps', format: '0.00 b', value: 4 },
+  { label: i18n.t('monitor.metrics_disk_used_percent'), measurement: 'agent_disk', field: 'used_percent', format: '0.00 %', value: 5 },
 ]
 
 const HostMetricOptions = [


### PR DESCRIPTION
Cherry pick of #1027 on release/3.8.

#1027: monitor overview add disk used percent