### PR TITLE
fix: #7738 新建虚拟机且添加数据盘时CPU架构不应该从X86自动跳到aarch64

### DIFF
--- a/containers/Compute/views/vminstance/create/form/mixin.js
+++ b/containers/Compute/views/vminstance/create/form/mixin.js
@@ -102,6 +102,8 @@ export default {
           sysDiskDisabled: false, // 系统盘是否禁用
           cpuDisabled: false,
           memDisabled: false,
+          dataDiskMedium: '',
+          networkVpcObj: {},
         },
         fd: { ...initFd, os: '' },
       },


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix: #7738 新建虚拟机且添加数据盘时CPU架构不应该从X86自动跳到aarch64

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.8
- release/3.7