### PR TITLE
Automated cherry pick of #1049: fix: #7738 新建虚拟机且添加数据盘时CPU架构不应该从X86自动跳到aarch64

### DIFF
--- a/containers/Compute/views/vminstance/create/form/mixin.js
+++ b/containers/Compute/views/vminstance/create/form/mixin.js
@@ -102,6 +102,8 @@ export default {
           sysDiskDisabled: false, // 系统盘是否禁用
           cpuDisabled: false,
           memDisabled: false,
+          dataDiskMedium: '',
+          networkVpcObj: {},
         },
         fd: { ...initFd, os: '' },
       },


### PR DESCRIPTION
Cherry pick of #1049 on release/3.7.

#1049: fix: #7738 新建虚拟机且添加数据盘时CPU架构不应该从X86自动跳到aarch64