### PR TITLE
fix: #7767 新建云账号，当项目为“自动创建项目”时，如果项目列表为空，表单会校验失败

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/components/DomainProject.vue
+++ b/containers/Cloudenv/views/cloudaccount/components/DomainProject.vue
@@ -248,6 +248,7 @@ export default {
     handleAutoCreateProjectChange (e) {
       const checked = e.target.checked
       this.disableProjectSelect = checked
+      this.$bus.$emit('updateAutoCreate', checked)
     },
   },
 }

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/Aliyun.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/Aliyun.vue
@@ -110,15 +110,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/Apsara.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/Apsara.vue
@@ -121,15 +121,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/AwsHuawei.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/AwsHuawei.vue
@@ -121,15 +121,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/Azure.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/Azure.vue
@@ -130,15 +130,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/Cloudpods.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/Cloudpods.vue
@@ -113,15 +113,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/Google.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/Google.vue
@@ -103,15 +103,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/HCSO.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/HCSO.vue
@@ -163,15 +163,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/OpenstackZstack.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/OpenstackZstack.vue
@@ -131,15 +131,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/Qcloud.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/Qcloud.vue
@@ -99,15 +99,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/S3CephXsky.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/S3CephXsky.vue
@@ -99,15 +99,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/Ucloud.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/Ucloud.vue
@@ -121,15 +121,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/VMware.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/VMware.vue
@@ -103,15 +103,6 @@ export default {
             ],
           },
         ],
-        project: [
-          'project',
-          {
-            initialValue: this.$store.getters.userInfo.projectId,
-            rules: [
-              { validator: isRequired(), message: this.$t('rules.project'), trigger: 'change' },
-            ],
-          },
-        ],
         auto_create_project: [
           'auto_create_project',
           {

--- a/containers/Cloudenv/views/cloudaccount/create/form/components/createMixin.js
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/createMixin.js
@@ -32,6 +32,17 @@ export default {
         },
       },
       domainProjectShow: false,
+      decorators: {
+        project: [
+          'project',
+          {
+            initialValue: this.$store.getters.userInfo.projectId,
+            rules: [
+              { validator: this.handleProject, message: this.$t('rules.project'), trigger: 'change' },
+            ],
+          },
+        ],
+      },
     }
   },
   computed: {
@@ -54,6 +65,11 @@ export default {
     this.domainProjectShow = false
     if (this.keepAliveFields) return
     this.form.fc.resetFields()
+  },
+  created () {
+    this.$bus.$on('updateAutoCreate', (v) => {
+      this.handleProjectChange(v)
+    })
   },
   methods: {
     validateForm () {
@@ -83,19 +99,31 @@ export default {
       }
     },
     async handleValuesChange (vm, changedFields) {
-      await this.$nextTick()
+      // await this.$nextTick()
       const fields = Object.keys(changedFields)
       if (changedFields && fields.length > 0) {
         fields.forEach(field => {
-          if (changedFields.hasOwnProperty('domain') || changedFields.hasOwnProperty('environment')) {
-            this.form.fd[field] = changedFields[field]
-          }
+          this.form.fd[field] = changedFields[field]
           const fn = this[`${field}_change`]
           if (fn && typeof fn === 'function') {
             fn()
           }
         })
       }
+    },
+    handleProject (rule, value, callback) {
+      const { auto_create_project } = this.form.fd
+
+      if (auto_create_project || value?.key) {
+        callback()
+      } else {
+        callback(Error)
+      }
+    },
+    handleProjectChange (v) {
+      this.$nextTick(() => {
+        this.form.fc.validateFields(['project'], { force: true })
+      })
     },
   },
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix: #7767 新建云账号，当项目为“自动创建项目”时，如果项目列表为空，表单会校验失败

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.8