### PR TITLE
fix: 新建虚拟机和价格清单过滤掉京东云和移动云等只读的云平台

### DIFF
--- a/containers/Cloudenv/views/server-price-comparator/create/form/Public.vue
+++ b/containers/Cloudenv/views/server-price-comparator/create/form/Public.vue
@@ -383,6 +383,10 @@ export default {
           })
         }
       }
+      // 过滤京东云和移动云等只读的云
+      list = list.filter(item => {
+        return ![HYPERVISORS_MAP.jdcloud.key, HYPERVISORS_MAP.ecloud.key].includes(item.name.toLowerCase())
+      })
       this.$set(this.form.fi, 'providerList', list)
       return list
     },

--- a/containers/Compute/views/vminstance/create/form/Public.vue
+++ b/containers/Compute/views/vminstance/create/form/Public.vue
@@ -507,6 +507,10 @@ export default {
           })
         }
       }
+      // 过滤京东云和移动云等只读的云
+      list = list.filter(item => {
+        return ![HYPERVISORS_MAP.jdcloud.key, HYPERVISORS_MAP.ecloud.key].includes(item.name.toLowerCase())
+      })
       this.$set(this.form.fi, 'providerList', list)
       return list
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

新建虚拟机和价格清单过滤掉京东云和移动云等只读的云平台

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
