### PR TITLE
Automated cherry pick of #1089: fix: #7756 mongodb的批量设置删除保护的文案需要修改

### DIFF
--- a/containers/DB/views/mongodb/components/List.vue
+++ b/containers/DB/views/mongodb/components/List.vue
@@ -100,7 +100,7 @@ export default {
                 label: this.$t('common_277'),
                 action: (row) => {
                   this.createDialog('ChangeDisableDelete', {
-                    name: this.$t('compute.text_97'),
+                    name: this.$t('dictionary.mongodb'),
                     columns: this.columns,
                     onManager: this.onManager,
                     data: this.list.selectedItems,


### PR DESCRIPTION
Cherry pick of #1089 on release/3.8.

#1089: fix: #7756 mongodb的批量设置删除保护的文案需要修改