### PR TITLE
fix[3.7]: update auto_delete status before unmount disk

### DIFF
--- a/containers/Compute/views/disk/dialogs/UnMountUpdateDialog.vue
+++ b/containers/Compute/views/disk/dialogs/UnMountUpdateDialog.vue
@@ -53,8 +53,18 @@ export default {
       })
   },
   methods: {
-    doUpdate (data) {
+    async doUpdate (data) {
       const guestId = this.params.data[0] && this.params.data[0].guests[0] && this.params.data[0].guests[0].id
+      const diskId = this.params.data[0] && this.params.data[0].id
+      // 删除前先先将auto_delete改为true
+      if (data.keep_disk) {
+        await new this.$Manager('disks').update({
+          id: diskId,
+          data: {
+            auto_delete: true,
+          },
+        })
+      }
       return new this.$Manager('servers').performAction({
         action: 'detachdisk',
         id: guestId,


### PR DESCRIPTION


**What this PR does / why we need it**:

卸载硬盘若勾选同时删除,先将auto_delete状态改为true

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
- release/3.7
