### PR TITLE
fix[3.8]: NetworkConfig component add vpc filter for network

### DIFF
--- a/containers/Compute/sections/ServerNetwork/NetworkConfig.vue
+++ b/containers/Compute/sections/ServerNetwork/NetworkConfig.vue
@@ -311,19 +311,27 @@ export default {
     },
     fetchNetworkOpts (params, item) {
       this.networkLoading = true
-      this.networkOpts = []
-      new this.$Manager('networks').list({ params }).then((res) => {
-        this.networkOpts = res.data.data || []
-        this.$nextTick(() => {
-          this.form.fc.setFieldsValue({ [`networks[${item.key}]`]: this.networkOpts?.[0]?.id })
+      // 未获取vpc时，network也不展示
+      if (!params.vpc) {
+        this.networkOpts = []
+        item.network = {}
+        this.form.fc.setFieldsValue({ [`networks[${item.key}]`]: '' })
+        this.networkLoading = false
+      } else {
+        this.networkOpts = []
+        new this.$Manager('networks').list({ params }).then((res) => {
+          this.networkOpts = res.data.data || []
+          this.$nextTick(() => {
+            this.form.fc.setFieldsValue({ [`networks[${item.key}]`]: this.networkOpts?.[0]?.id })
+          })
+          item.network = this.networkOpts[0]
+          this.networkLoading = false
+        }).catch((err) => {
+          this.networkLoading = false
+          console.log(err)
+          throw err
         })
-        item.network = this.networkOpts[0]
-        this.networkLoading = false
-      }).catch((err) => {
-        this.networkLoading = false
-        console.log(err)
-        throw err
-      })
+      }
     },
   },
 }


### PR DESCRIPTION


**What this PR does / why we need it**:

网络组件,vpc未获取时,不展示network

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
