### PR TITLE
Automated cherry pick of #1167: fix(baremetal): rename AACRaid to AdaptecRaid

### DIFF
--- a/containers/Compute/views/baremetal/dialogs/Create.vue
+++ b/containers/Compute/views/baremetal/dialogs/Create.vue
@@ -261,7 +261,7 @@ export default {
             step: 2,
           },
         ],
-        AACRaid: [
+        AdaptecRaid: [
           {
             value: 'none',
             label: this.$t('compute.text_325'),


### PR DESCRIPTION
Cherry pick of #1167 on release/3.6.

#1167: fix(baremetal): rename AACRaid to AdaptecRaid