### PR TITLE
fix[3.7]: cloudprovider effets the network for public cloud

### DIFF
--- a/containers/Compute/views/vminstance/create/form/Public.vue
+++ b/containers/Compute/views/vminstance/create/form/Public.vue
@@ -129,7 +129,8 @@
           :networkVpcParams="networkVpcParams"
           :vpcResource="vpcResource"
           :serverCount="form.fd.count"
-          :networkResourceMapper="networkResourceMapper" />
+          :networkResourceMapper="networkResourceMapper"
+          :cloudprovider="form.fd.cloudprovider" />
       </a-form-item>
       <a-form-item :label="$t('compute.text_1154')" class="mb-0">
         <tag


### PR DESCRIPTION


**What this PR does / why we need it**:

公有云新建主机,云订阅切换,网络跟随切换

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
- release/3.7
