### PR TITLE
feat[3.7]: wire add cloudenv options

### DIFF
--- a/containers/Network/views/wire/components/List.vue
+++ b/containers/Network/views/wire/components/List.vue
@@ -32,6 +32,12 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    cloudEnv: {
+      type: String,
+    },
+    cloudEnvOptions: {
+      type: Array,
+    },
   },
   data () {
     return {
@@ -196,6 +202,26 @@ export default {
         },
       ],
     }
+  },
+  watch: {
+    cloudEnv (val) {
+      switch (val) {
+        case 'onpremise':
+          this.envParams = { is_on_premise: true }
+          break
+        case 'private':
+          this.envParams = { private_cloud: true }
+          break
+        default:
+          this.envParams = {}
+      }
+      const params = this.list.getParams
+      delete params.is_on_premise
+      delete params.private_cloud
+      delete params.public_cloud
+      this.list.getParams = { ...params, ...this.envParams }
+      this.list.fetchData()
+    },
   },
   created () {
     this.initSidePageTab('wire-detail')

--- a/containers/Network/views/wire/index.vue
+++ b/containers/Network/views/wire/index.vue
@@ -1,14 +1,18 @@
 <template>
   <div>
-    <page-header :title="$t('network.text_571')" />
+    <page-header :title="$t('network.text_571')" :tabs="cloudEnvOptions" :current-tab.sync="cloudEnv" />
     <page-body>
-      <wire-list :id="listId" />
+      <wire-list
+      :id="listId"
+      :cloud-env="cloudEnv"
+      :cloudEnvOptions="cloudEnvOptions" />
     </page-body>
   </div>
 </template>
 
 <script>
 import WireList from './components/List'
+import { getCloudEnvOptions } from '@/utils/common/hypervisor'
 
 export default {
   name: 'WireIndex',
@@ -18,6 +22,8 @@ export default {
   data () {
     return {
       listId: 'WireList',
+      cloudEnvOptions: getCloudEnvOptions('network_engine_brands').filter(item => item.key !== 'public'),
+      cloudEnv: '',
     }
   },
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

二层网络添加cloudenv的过滤


**Does this PR need to be backport to the previous release branch?**:

- release/3.8
- release/3.7
