### PR TITLE
feat[3.8]: mongodb add tag filter

### DIFF
--- a/containers/DB/views/mongodb/components/List.vue
+++ b/containers/DB/views/mongodb/components/List.vue
@@ -5,7 +5,9 @@
     :list="list"
     :single-actions="singleActions"
     :showGroupActions="showGroupActions"
-    :export-data-options="exportDataOptions" />
+    :export-data-options="exportDataOptions"
+    :show-tag-columns="true"
+    :show-tag-filter="true" />
 </template>
 
 <script>
@@ -96,6 +98,21 @@ export default {
           label: this.$t('db.text_213'),
           actions: (obj) => {
             return [
+              {
+                label: this.$t('compute.text_283'),
+                // permission: 'dns_recordsets_perform_set_user_metadata',
+                action: () => {
+                  this.createDialog('SetTagDialog', {
+                    data: this.list.selectedItems,
+                    columns: this.columns,
+                    onManager: this.onManager,
+                    params: {
+                      resources: 'mongodbs',
+                    },
+                    mode: 'add',
+                  })
+                },
+              },
               {
                 label: this.$t('common_277'),
                 action: (row) => {

--- a/src/constants/permission.js
+++ b/src/constants/permission.js
@@ -726,6 +726,7 @@ export const PERMISSION = {
   mongodb_delete: ['compute', 'mongodb', 'delete'],
   mongodb_perform_delete: ['compute', 'mongodb', 'perform', 'delete'],
   mongodb_perform_syncstatus: ['compute', 'mongodb', 'perform', 'syncstatus'],
+  mongodb_perform_set_user_metadata: ['compute', 'mongodb', 'perform', 'set-user-metadata'],
 
   /**
    * 预留IP


### PR DESCRIPTION


**What this PR does / why we need it**:

mongodb支持标签批量编辑和过滤

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
