### PR TITLE
Automated cherry pick of #1268: feat[3.8]: monitor overview show empty data

### DIFF
--- a/containers/Monitor/components/MonitorCard/sections/table/index.vue
+++ b/containers/Monitor/components/MonitorCard/sections/table/index.vue
@@ -15,7 +15,11 @@
           ref="overviewTable"
           :columns="tableData.columns"
           max-height="400"
-          :data="tableData.rows" />
+          :data="tableData.rows">
+          <template v-slot:empty>
+            <loader :loading="loading" :noDataText="$t('common.notData')" />
+          </template>
+        </vxe-grid>
         <div class="vxe-grid--pager-wrapper">
           <div class="vxe-pager size--mini">
             <div class="vxe-pager--wrapper">

--- a/containers/Monitor/views/overview/components/SummaryCards.vue
+++ b/containers/Monitor/views/overview/components/SummaryCards.vue
@@ -1,10 +1,13 @@
 <template>
   <div>
     <a-icon type="sync" spin v-if="loading" />
-    <a-row v-else type="flex" style="margin-left: 128px;">
+    <a-row v-else-if="cards.length > 0" type="flex" style="margin-left: 128px;">
       <a-col v-for="card in cards" :key="card.title" :span="8" style="width: 400px" class="mt-4">
         <overview-summary-card :card="card" />
       </a-col>
+    </a-row>
+    <a-row v-else type="flex" style="justify-content:center">
+      <data-empty :description="emptyContent" />
     </a-row>
   </div>
 </template>
@@ -59,6 +62,9 @@ export default {
       manager: new this.$Manager('monitorresources', 'v1'),
       loading: false,
       data: {},
+      emptyContent: {
+        default: this.$t('common.notData'),
+      },
     }
   },
   computed: {


### PR DESCRIPTION
Cherry pick of #1268 on release/3.8.

#1268: feat[3.8]: monitor overview show empty data