### PR TITLE
fix[3.7]: alert recivers add domain filter

### DIFF
--- a/containers/Monitor/views/commonalert/sidepage/Detail.vue
+++ b/containers/Monitor/views/commonalert/sidepage/Detail.vue
@@ -64,6 +64,7 @@ export default {
               scope: this.$store.getters.scope,
               with_meta: true,
               limit: 0,
+              project_domain_filter: true,
             },
           })
         this.baseInfo.push(recipientsColumn(recipientList))


### PR DESCRIPTION


**What this PR does / why we need it**:

告警接收人列表查询增加域过滤

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
- release/3.7
