### PR TITLE
fix: hide price info when hasn't meter service

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/mixins/singleActions.js
+++ b/containers/Cloudenv/views/cloudaccount/mixins/singleActions.js
@@ -4,6 +4,7 @@ import expectStatus from '@/constants/expectStatus'
 import { getEnabledSwitchActions } from '@/utils/common/tableActions'
 import i18n from '@/locales'
 import { findPlatform } from '@/utils/common/hypervisor'
+import { hasMeterService } from '@/utils/auth'
 
 const steadyStatus = {
   status: Object.values(expectStatus.cloudaccount).flat(),
@@ -149,6 +150,9 @@ export default {
                   return ret
                 }
                 return ret
+              },
+              hidden: () => {
+                return !hasMeterService()
               },
             },
             {

--- a/containers/Cloudenv/views/cloudaccount/sidepage/Detail.vue
+++ b/containers/Cloudenv/views/cloudaccount/sidepage/Detail.vue
@@ -18,6 +18,7 @@ import {
 import { getBrandTableColumn, getEnabledTableColumn, getStatusTableColumn } from '@/utils/common/tableColumn'
 import { findPlatform } from '@/utils/common/hypervisor'
 import WindowsMixin from '@/mixins/windows'
+import { hasMeterService } from '@/utils/auth'
 
 export default {
   name: 'CloudaccountDetail',
@@ -90,6 +91,7 @@ export default {
               title: this.$t('cloudaccount.table.title.discount'),
               slots: {
                 default: () => {
+                  if (!hasMeterService()) return '-'
                   if (!this.discountLoaded) {
                     return [<a-icon type='loading' style='font-size: 12px;' class='primary-color' />]
                   }
@@ -111,6 +113,7 @@ export default {
   },
   methods: {
     async fetchDiscount () {
+      if (!hasMeterService()) return
       try {
         const response = await this.$http({
           method: 'GET',


### PR DESCRIPTION


**What this PR does / why we need it**:

没有meter服务时,隐藏套餐价格

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
- release/3.7
