### PR TITLE
fix: fetch nofify template when notify type is mobile

### DIFF
--- a/containers/IAM/views/notifyconfig/sidepage/Detail.vue
+++ b/containers/IAM/views/notifyconfig/sidepage/Detail.vue
@@ -226,7 +226,9 @@ export default {
   },
   methods: {
     fetchNotifyTpl () {
-      this.notifytemplatesManager.list({ params: { contact_type: 'mobile' } })
+      const { type } = this.data
+      if (type !== 'mobile') return
+      this.notifytemplatesManager.list({ params: { contact_type: type } })
         .then(res => {
           const { data: { data } } = res
           data.forEach(v => {


### PR DESCRIPTION


**What this PR does / why we need it**:

通知渠道为短信时,再获取通知渠道模板

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
