### PR TITLE
fix: GCP billing use bigquery as default source

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/create/form/BigQueryBillForm.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/BigQueryBillForm.vue
@@ -5,8 +5,8 @@
       <a-divider orientation="left">{{$t('cloudenv.text_199')}}</a-divider>
       <a-form-item :label="$t('cloudenv.text_200')">
         <a-radio-group v-model="billingType">
-          <a-radio-button :value="1">{{$t('cloudenv.text_201')}}</a-radio-button>
           <a-radio-button :value="2">{{$t('cloudenv.text_202')}}</a-radio-button>
+          <a-radio-button :value="1">{{$t('cloudenv.text_201')}}</a-radio-button>
         </a-radio-group>
       </a-form-item>
       <a-form-item :label="$t('cloudenv.text_201')" v-if="billingType === 2" :extra="$t('cloudenv.text_203')">
@@ -61,7 +61,7 @@ export default {
       cloudAccounts: [],
       cloudAccountLoading: false,
       cloudAccount: {},
-      billingType: 1,
+      billingType: 2,
       form: {
         fc: this.$form.createForm(this),
       },


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: GCP billing use bigquery as default source

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @Easy-MJ 