### PR TITLE
fix: cloudgroup add export columns

### DIFF
--- a/containers/Cloudenv/views/cloudgroup/components/List.vue
+++ b/containers/Cloudenv/views/cloudgroup/components/List.vue
@@ -48,7 +48,11 @@ export default {
         items: [
           { label: 'ID', key: 'id' },
           { label: this.$t('table.title.name'), key: 'name' },
-          { label: this.$t('table.title.brand'), key: 'brand' },
+          { label: this.$t('cloudenv.text_98'), key: 'status' },
+          { label: this.$t('cloudenv.text_329'), key: 'cloudpolicies' },
+          { label: this.$t('table.title.brand'), key: 'provider' },
+          { label: this.$t('table.title.share_range'), key: 'public_scope' },
+          { label: this.$t('table.title.owner_domain'), key: 'project_domain' },
         ],
       },
       groupActions: [

--- a/containers/Cloudenv/views/cloudgroup/sidepage/CloudpolicyList.vue
+++ b/containers/Cloudenv/views/cloudgroup/sidepage/CloudpolicyList.vue
@@ -45,7 +45,7 @@ export default {
         items: [
           { label: 'ID', key: 'id' },
           { label: this.$t('table.title.name'), key: 'name' },
-          { label: this.$t('table.title.brand'), key: 'brand' },
+          { label: this.$t('table.title.desc'), key: 'description' },
         ],
       },
       groupActions: [

--- a/containers/Cloudenv/views/cloudgroup/sidepage/ClouduserList.vue
+++ b/containers/Cloudenv/views/cloudgroup/sidepage/ClouduserList.vue
@@ -45,7 +45,12 @@ export default {
         items: [
           { label: 'ID', key: 'id' },
           { label: this.$t('table.title.name'), key: 'name' },
+          { label: this.$t('cloudenv.clouduser_list_t5'), key: 'is_console_login' },
+          { label: this.$t('cloudenv.text_98'), key: 'status' },
+          { label: this.$t('cloudenv.clouduser_list_t3'), key: 'iam_login_url' },
+          { label: this.$t('cloudenv.clouduser_list_t4'), key: 'owner_name' },
           { label: this.$t('table.title.brand'), key: 'brand' },
+          { label: this.$t('common.text00108'), key: 'cloudaccount' },
         ],
       },
       groupActions: [

--- a/containers/Cloudenv/views/cloudgroupcache/components/List.vue
+++ b/containers/Cloudenv/views/cloudgroupcache/components/List.vue
@@ -43,8 +43,9 @@ export default {
       exportDataOptions: {
         items: [
           { label: 'ID', key: 'id' },
-          { label: this.$t('table.title.name'), key: 'name' },
-          { label: this.$t('table.title.brand'), key: 'brand' },
+          { label: this.$t('cloudenv.text_332'), key: 'name' },
+          { label: this.$t('cloudenv.text_98'), key: 'status' },
+          { label: this.$t('dictionary.cloudaccount'), key: 'cloudaccount' },
         ],
       },
       groupActions: [


### PR DESCRIPTION


**What this PR does / why we need it**:

云用户组增加导出项

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
- release/3.7
