### PR TITLE
fix: add eip filter on set network dialog

### DIFF
--- a/containers/Compute/sections/ServerNetwork/NetworkConfig.vue
+++ b/containers/Compute/sections/ServerNetwork/NetworkConfig.vue
@@ -151,6 +151,7 @@ export default {
     },
     showVpc: {
       type: Boolean,
+      default: true,
     },
   },
   data () {

--- a/containers/Compute/views/vminstance/dialogs/SetNetwork.vue
+++ b/containers/Compute/views/vminstance/dialogs/SetNetwork.vue
@@ -107,7 +107,7 @@ export default {
       const { data } = this.params
       const resItem = data && data.length > 0 ? data[0] : {}
       return {
-        filter: 'server_type.notin(ipmi, pxe)',
+        filter: 'server_type.notin(ipmi, pxe, eip)',
         usable: true,
         cloudregion: resItem.cloudregion_id,
         zone: resItem.zone_id,


### PR DESCRIPTION


**What this PR does / why we need it**:

虚拟机设置网卡,展示vpc,添加eip过滤

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
