### PR TITLE
Automated cherry pick of #1608: fix: wrong permission for disk create snapshot

### DIFF
--- a/containers/Compute/views/disk/mixins/singleActions.js
+++ b/containers/Compute/views/disk/mixins/singleActions.js
@@ -130,7 +130,7 @@ export default {
             },
             {
               label: i18n.t('compute.disk_perform_create_snapshot'),
-              permission: 'disks_perform_create_snapshot',
+              permission: 'snapshots_create',
               action: () => {
                 this.createDialog('DiskCreateSnapshotDialog', {
                   data: [obj],


### PR DESCRIPTION
Cherry pick of #1608 on release/3.8.

#1608: fix: wrong permission for disk create snapshot