### PR TITLE
Automated cherry pick of #1680: feat: #3523 将block_stream状态的主机的状态标记为运行中

### DIFF
--- a/src/constants/expectStatus.js
+++ b/src/constants/expectStatus.js
@@ -7,7 +7,7 @@ export default {
     danger: ['create_failed', 'delete_failed', 'update_tags_fail'],
   },
   server: {
-    success: ['running'],
+    success: ['running', 'block_stream'],
     info: ['ready', 'deallocated', 'unknown', 'suspend', 'converted'],
     // danger: [new RegExp('fail')] // 这条会在 base组件 中默认存在
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -68,7 +68,7 @@
       "rebuild_root_fail": "Fail to reset OS",
       "snapshot_start": "Start snapshotting",
       "snapshot": "Snapshotting",
-      "block_stream": "Disk data synchronization",
+      "block_stream": "Running",
       "snapshot_succ": "Snapshot successfully",
       "snapshot_failed": "Fail to snapshot",
       "syncing": "Syncing",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -68,7 +68,7 @@
       "rebuild_root_fail": "重装系统失败",
       "snapshot_start": "开始创建快照",
       "snapshot": "正在创建快照",
-      "block_stream": "数据同步",
+      "block_stream": "运行中",
       "snapshot_succ": "快照创建成功",
       "snapshot_failed": "快照创建失败",
       "syncing": "同步中",


### PR DESCRIPTION
Cherry pick of #1680 on release/3.8.

#1680: feat: #3523 将block_stream状态的主机的状态标记为运行中