### PR TITLE
fix: 路由表详情中的VPC应该可以超链接跳转， 列表以及详情的所属VPC改成VPC

### DIFF
--- a/containers/Network/views/route-table/utils/columns.js
+++ b/containers/Network/views/route-table/utils/columns.js
@@ -1,8 +1,15 @@
 export const getVpcTableColumn = (vm) => {
   return {
     field: 'vpc',
-    title: vm.$t('network.text_535'),
+    title: 'VPC',
     minWidth: 120,
     showOverflow: 'ellipsis',
+    slots: {
+      default: ({ row }, h) => {
+        return [
+          <side-page-trigger name='VpcSidePage' id={row.vpc_id} vm={vm}>{row.vpc}</side-page-trigger>,
+        ]
+      },
+    },
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix: 路由表详情中的VPC应该可以超链接跳转， 列表以及详情的所属VPC改成VPC

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- NONE
