### PR TITLE
feat: cloudprovider region support enable switch

### DIFF
--- a/containers/Cloudenv/views/cloudproviderregion/components/List.vue
+++ b/containers/Cloudenv/views/cloudproviderregion/components/List.vue
@@ -7,11 +7,12 @@
 </template>
 
 <script>
-import ColumnsMixin from '../mixins/columns'
-import SingleActionsMixin from '../mixins/singleActions'
 import WindowsMixin from '@/mixins/windows'
 import ListMixin from '@/mixins/list'
 import expectStatus from '@/constants/expectStatus'
+import { getEnabledSwitchActions } from '@/utils/common/tableActions'
+import SingleActionsMixin from '../mixins/singleActions'
+import ColumnsMixin from '../mixins/columns'
 
 export default {
   name: 'CloudproviderregionList',
@@ -74,6 +75,47 @@ export default {
             }
           },
         },
+        ...getEnabledSwitchActions(this, undefined, undefined, {
+          actions: [
+            async (obj) => {
+              await this.pM.performAction({
+                id: this.cloudproviderId,
+                action: 'set-syncing',
+                data: {
+                  cloudregion_ids: this.list.selectedItems.map(item => item.cloudregion_id),
+                  enabled: true,
+                },
+              })
+              this.refresh()
+            },
+            async (obj) => {
+              await this.pM.performAction({
+                id: this.cloudproviderId,
+                action: 'set-syncing',
+                data: {
+                  cloudregion_ids: this.list.selectedItems.map(item => item.cloudregion_id),
+                  enabled: false,
+                },
+              })
+              this.refresh()
+            },
+          ],
+          fields: ['cloudregion', 'enabled', 'last_auto_sync'],
+          metas: [
+            () => {
+              const isDisable = !!this.list.selectedItems.find(item => !item.enabled)
+              return {
+                validate: this.list.selectedItems.length && isDisable,
+              }
+            },
+            () => {
+              const isEnable = !!this.list.selectedItems.find(item => item.enabled)
+              return {
+                validate: this.list.selectedItems.length && isEnable,
+              }
+            },
+          ],
+        }),
       ],
     }
   },
@@ -89,6 +131,9 @@ export default {
     this.list.fetchData()
   },
   methods: {
+    refresh () {
+      this.list.refresh()
+    },
     fetchRegionList () {
       const params = {
         manager: this.cloudproviderId,

--- a/containers/Cloudenv/views/cloudproviderregion/mixins/singleActions.js
+++ b/containers/Cloudenv/views/cloudproviderregion/mixins/singleActions.js
@@ -1,7 +1,9 @@
 import i18n from '@/locales'
+import { getEnabledSwitchActions } from '@/utils/common/tableActions'
 
 export default {
   created () {
+    this.pM = new this.$Manager('cloudproviders')
     const ownerDomain = obj => this.$store.getters.isAdminMode || obj.cloudaccount_domain_id === this.$store.getters.userInfo.projectDomainId
     this.singleActions = [
       {
@@ -48,6 +50,48 @@ export default {
             validate: isIdle,
             tooltip: !isIdle && i18n.t('cloudenv.text_368', [this.$t('status.cloudaccountSyncStatus')[obj.sync_status]]),
           }
+        },
+      },
+      {
+        label: i18n.t('compute.text_352'),
+        actions: (obj) => {
+          return [
+            ...getEnabledSwitchActions(this, undefined, undefined, {
+              actions: [
+                async (obj) => {
+                  await this.pM.performAction({
+                    id: this.cloudproviderId,
+                    action: 'set-syncing',
+                    data: {
+                      cloudregion_ids: [obj.cloudregion_id],
+                      enabled: true,
+                    },
+                  })
+                  this.refresh()
+                },
+                async (obj) => {
+                  await this.pM.performAction({
+                    id: this.cloudproviderId,
+                    action: 'set-syncing',
+                    data: {
+                      cloudregion_ids: [obj.cloudregion_id],
+                      enabled: false,
+                    },
+                  })
+                  this.refresh()
+                },
+              ],
+              fields: ['cloudregion', 'enabled', 'last_auto_sync'],
+              metas: [
+                () => ({
+                  validate: !obj.enabled,
+                }),
+                () => ({
+                  validate: obj.enabled,
+                }),
+              ],
+            }),
+          ]
         },
       },
     ]


### PR DESCRIPTION


**What this PR does / why we need it**:

云订阅的区域支持启用禁用

**Does this PR need to be backport to the previous release branch?**:

NONE
