### PR TITLE
fix: host action refresh list

### DIFF
--- a/containers/Compute/views/host/components/List.vue
+++ b/containers/Compute/views/host/components/List.vue
@@ -425,7 +425,7 @@ export default {
   },
   methods: {
     refresh () {
-      console.log('refresh')
+      this.list.fetchData()
     },
     extraExportParams ({ currentExportType }) {
       if (currentExportType === 'all') return { baremetal: false }


### PR DESCRIPTION


**What this PR does / why we need it**:

块存储关联宿主机操作后刷新列表

**Does this PR need to be backport to the previous release branch?**:

- release/3.8
- release/3.7
