### PR TITLE
Automated cherry pick of #1866: fix: disassociate vip refresh instancesgroup

### DIFF
--- a/containers/Compute/views/host/sidepage/index.vue
+++ b/containers/Compute/views/host/sidepage/index.vue
@@ -59,7 +59,7 @@ export default {
         { label: this.$t('compute.text_91'), key: 'vminstance-list' },
         { label: this.$t('compute.text_104'), key: 'network-list' },
         { label: this.$t('compute.text_99'), key: 'storage-list' },
-        { label: this.$t('compute.text_607'), key: 'gpu-list' },
+        { label: this.$t('compute.text_113'), key: 'gpu-list' },
         { label: this.$t('compute.text_114'), key: 'server-recovery' },
         { label: this.$t('compute.text_608'), key: 'monitor' },
         // { label: '报警', key: 'alert' },

--- a/containers/Compute/views/instance-group/mixins/singleActions.js
+++ b/containers/Compute/views/instance-group/mixins/singleActions.js
@@ -46,7 +46,6 @@ export default {
                   tooltip = this.$t('compute.too_many_instance_group_vip')
                 }
                 return {
-                  buttonType: 'primary',
                   validate: (obj.network_id !== '' && obj.vips.length < 1),
                   tooltip,
                 }

--- a/containers/Compute/views/instance-group/sidepage/VIPList.vue
+++ b/containers/Compute/views/instance-group/sidepage/VIPList.vue
@@ -58,7 +58,6 @@ export default {
             })
           },
           meta: () => {
-            console.log(this.data)
             let tooltip = null
             if (!this.data.network_id) {
               tooltip = this.$t('compute.instance_group_no_network_id')
@@ -88,6 +87,10 @@ export default {
         id,
         resource: 'networks',
       })
+    },
+    refresh () {
+      this.list.refresh()
+      this.$bus.$emit('InstanceGroupListRefresh')
     },
   },
 }


### PR DESCRIPTION
Cherry pick of #1866 on release/3.8.

#1866: fix: disassociate vip refresh instancesgroup