### PR TITLE
Automated cherry pick of #1879: fix: #8085 新建本地IDC的弹性eip时计费方式应该是按带宽计费

### DIFF
--- a/containers/Network/views/eip/create/index.vue
+++ b/containers/Network/views/eip/create/index.vue
@@ -320,7 +320,10 @@ export default {
         { label: this.$t('network.text_194'), value: 'bandwidth' },
         { label: this.$t('network.text_193'), value: 'traffic' },
       ]
-      if ((this.showBandwidth && this.cloudEnv === 'onpremise') || !this.showBandwidth) {
+      if (this.cloudEnv === 'onpremise') {
+        return [arr[0]]
+      }
+      if (!this.showBandwidth) {
         arr.shift()
       }
       return arr


### PR DESCRIPTION
Cherry pick of #1879 on feature/r-3.8-diankeyun.

#1879: fix: #8085 新建本地IDC的弹性eip时计费方式应该是按带宽计费