### PR TITLE
Automated cherry pick of #1960: fix: #8103 vpc互联详情路由tab中应该去掉状态列

### DIFF
--- a/containers/Network/views/vpc-network/sidepage/RouteSet.vue
+++ b/containers/Network/views/vpc-network/sidepage/RouteSet.vue
@@ -9,7 +9,7 @@
 <script>
 import {
   getCopyWithContentTableColumn,
-  getStatusTableColumn,
+  // getStatusTableColumn,
   getEnabledTableColumn,
   getRegionTableColumn,
 } from '@/utils/common/tableColumn'
@@ -54,7 +54,7 @@ export default {
           title: this.$t('network.text_244'),
           sortable: true,
         }),
-        getStatusTableColumn({ statusModule: 'routeSet' }),
+        // getStatusTableColumn({ statusModule: 'routeSet' }),
         getEnabledTableColumn(),
         {
           field: 'vpc',


### PR DESCRIPTION
Cherry pick of #1960 on release/3.9.

#1960: fix: #8103 vpc互联详情路由tab中应该去掉状态列