### PR TITLE
Automated cherry pick of #2012: fix: #8101 云账号第一次新建定时任务后 后端返回值不应该为空

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/dialogs/ScheduledtaskCreate.vue
+++ b/containers/Cloudenv/views/cloudaccount/dialogs/ScheduledtaskCreate.vue
@@ -209,7 +209,7 @@ export default {
       try {
         const values = await this.form.fc.validateFields()
         const params = this.generateData(values)
-        new this.$Manager('scheduledtasks', 'v1').create({ data: params })
+        await new this.$Manager('scheduledtasks', 'v1').create({ data: params })
         this.params.callback && this.params.callback()
         this.cancelDialog()
       } catch (error) {


### PR DESCRIPTION
Cherry pick of #2012 on release/3.9.

#2012: fix: #8101 云账号第一次新建定时任务后 后端返回值不应该为空