### PR TITLE
fix: #8132 dns record tag is not required

### DIFF
--- a/containers/Network/views/dns-recordset/dialogs/Create.vue
+++ b/containers/Network/views/dns-recordset/dialogs/Create.vue
@@ -153,13 +153,13 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { providers, policy_types, policy_values } from '../constants'
-import { getDnsTypes, getDnsProviders, getTtls } from '../utils'
 import { uuid } from '@/utils/utils'
 import validateForm, { validate } from '@/utils/validate'
 import DialogMixin from '@/mixins/dialog'
 import WindowsMixin from '@/mixins/windows'
 import Tag from '@/sections/Tag'
+import { getDnsTypes, getDnsProviders, getTtls } from '../utils'
+import { providers, policy_types, policy_values } from '../constants'
 
 export default {
   name: 'DnsRecordSetCreateDialog',
@@ -352,7 +352,7 @@ export default {
           {
             initialValue: this.params?.data[0]?.metadata,
             rules: [
-              { required: true, message: this.$t('cloudenv.text_451') },
+              { required: false, message: this.$t('cloudenv.text_451') },
               { validator: validateForm('tagName') },
             ],
           },


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: #8132 dns record tag is not required

**Does this PR need to be backport to the previous release branch?**:

- release/3.9
- release/3.8
