### PR TITLE
Automated cherry pick of #2067: fix(#8149): 新建Nutanx虚拟机高级选项中 应该去掉安全组选项

### DIFF
--- a/containers/Compute/views/vminstance/create/form/Private.vue
+++ b/containers/Compute/views/vminstance/create/form/Private.vue
@@ -126,7 +126,7 @@
       <!-- <a-divider orientation="left">{{$t('compute.text_309')}}</a-divider> -->
       <a-collapse :bordered="false" v-model="collapseActive">
         <a-collapse-panel :header="$t('compute.text_309')" key="1">
-          <a-form-item :label="$t('compute.text_105')">
+          <a-form-item :label="$t('compute.text_105')" v-if="showSecgroup">
             <secgroup-config
               :decorators="decorators.secgroup"
               :secgroup-params="secgroupParams"
@@ -324,6 +324,10 @@ export default {
         params.zone = this.form.fd.zone
       }
       return params
+    },
+    showSecgroup () {
+      const hiddenSecCloudprovider = ['Nutanix']
+      return !hiddenSecCloudprovider.includes(this.cloudprovider)
     },
   },
   methods: {


### PR DESCRIPTION
Cherry pick of #2067 on release/3.8.

#2067: fix(#8149): 新建Nutanx虚拟机高级选项中 应该去掉安全组选项