### PR TITLE
Automated cherry pick of #2227: fix: get stats error when router beforeeach to check permission

### DIFF
--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -8,6 +8,7 @@ export default {
   userInfo: state => state.auth.info,
   capability: state => state.auth.capability,
   permission: state => state.auth.permission,
+  stats: state => state.auth.stats,
   scopeResource: state => state.auth.scopeResource,
   windows: state => state.window.windows,
   common: state => state.common,


### PR DESCRIPTION
Cherry pick of #2227 on release/3.8.

#2227: fix: get stats error when router beforeeach to check permission