### PR TITLE
Automated cherry pick of #2253: fix: #8220 反亲和组关联虚拟机时，输入字符时过滤条件应该用filter

### DIFF
--- a/containers/Compute/views/instance-group/dialogs/BindServer.vue
+++ b/containers/Compute/views/instance-group/dialogs/BindServer.vue
@@ -158,7 +158,7 @@ export default {
       this.selectedServers = val
     },
     remoteFn (query) {
-      if (/^[a-z]\w+$/.test(query)) {
+      if (/^[a-z]\w+/.test(query) || /[\u4e00-\u9fa5]/.test(query)) {
         return {
           filter: `name.contains(${query})`,
         }


### PR DESCRIPTION
Cherry pick of #2253 on release/3.9.

#2253: fix: #8220 反亲和组关联虚拟机时，输入字符时过滤条件应该用filter