### PR TITLE
Automated cherry pick of #2348: fix: #8249 新建公有云IP子网时获取zone的接口应该加上排序的参数

### DIFF
--- a/containers/Network/views/network/Create.vue
+++ b/containers/Network/views/network/Create.vue
@@ -498,6 +498,8 @@ export default {
         scope: this.scope,
         show_emulated: true,
         'filter.0': 'status.equals(enable)',
+        order: 'asc',
+        order_by: 'external_id',
       }
       if (this.isAdminMode) {
         params.project_domain = this.project_domain


### PR DESCRIPTION
Cherry pick of #2348 on release/3.9.

#2348: fix: #8249 新建公有云IP子网时获取zone的接口应该加上排序的参数