### PR TITLE
Automated cherry pick of #2388: fix: #8247 主机备份失败的虚拟机无法删除，应可以强制删除记录

### DIFF
--- a/containers/Compute/views/instance-backup/components/List.vue
+++ b/containers/Compute/views/instance-backup/components/List.vue
@@ -37,6 +37,9 @@ export default {
   },
   data () {
     return {
+      deleteResProps: {
+        force_delete: false,
+      },
       list: this.$list.createList(this, {
         id: this.id,
         resource: 'instancebackups',
@@ -139,6 +142,13 @@ export default {
                     onManager: this.onManager,
                     title: this.$t('compute.perform_delete'),
                     name: this.$t('compute.text_462'),
+                    content: () => {
+                      const change = (bool) => {
+                        this.deleteResProps.force_delete = bool
+                      }
+                      return <a-checkbox onInput={ change }>{ this.$t('compute.text_655') }</a-checkbox>
+                    },
+                    requestParams: this.deleteResProps,
                   })
                 },
                 meta: () => {

--- a/containers/Compute/views/instance-backup/mixins/singleActions.js
+++ b/containers/Compute/views/instance-backup/mixins/singleActions.js
@@ -60,6 +60,13 @@ export default {
                   title: i18n.t('compute.perform_delete'),
                   onManager: this.onManager,
                   name: i18n.t('compute.text_462'),
+                  content: () => {
+                    const change = (bool) => {
+                      this.deleteResProps.force_delete = bool
+                    }
+                    return <a-checkbox onInput={ change }>{ this.$t('compute.text_655') }</a-checkbox>
+                  },
+                  requestParams: this.deleteResProps,
                 })
               },
               meta: obj => {


### PR DESCRIPTION
Cherry pick of #2388 on release/3.9.

#2388: fix: #8247 主机备份失败的虚拟机无法删除，应可以强制删除记录