### PR TITLE
fix: fail to update lb listener when lbredirect=off

### DIFF
--- a/containers/Network/views/loadbalancerbackendgroup/mixins/singleActions.js
+++ b/containers/Network/views/loadbalancerbackendgroup/mixins/singleActions.js
@@ -18,7 +18,7 @@ export default {
           })
         },
         meta: (obj) => {
-          if (obj.provider.toLowerCase() === 'azure' || obj.provider.toLowerCase() === 'google') {
+          if (obj.provider && (obj.provider.toLowerCase() === 'azure' || obj.provider.toLowerCase() === 'google')) {
             return {
               validate: false,
               tooltip: i18n.t('network.text_309', [PROVIDER_MAP[obj.provider].label]),

--- a/containers/Network/views/loadbalancerlistener/dialogs/Form.vue
+++ b/containers/Network/views/loadbalancerlistener/dialogs/Form.vue
@@ -18,12 +18,12 @@
     </div>
     <div slot="footer">
       <template v-if="isLbRedirected">
-        <a-button type="primary" class="mr-2" @click="isUpdate ? update() : validateForm() " :loading="loading">{{$t('network.text_30')}}</a-button>
+        <a-button type="primary" class="mr-2" @click="isUpdate ? update() : validateForm() " :loading="loading">{{ buttonText }}</a-button>
       </template>
       <template v-else>
         <a-button @click="prev" v-if="!isFirstStep" class="mr-2">{{$t('network.text_466')}}</a-button>
         <a-button type="primary" class="mr-2" @click="next" :loading="isUpdate ? false : loading" v-if="!isLastStep">{{ nextStepTitle }}</a-button>
-        <a-button type="primary" class="mr-2" v-if="isLastStep" @click="isUpdate ? update() : validateForm()" :loading="loading">{{$t('network.text_30')}}</a-button>
+        <a-button type="primary" class="mr-2" v-if="isLastStep" @click="isUpdate ? update() : validateForm()" :loading="loading">{{ buttonText }}</a-button>
       </template>
       <a-button @click="cancel">{{$t('network.text_31')}}</a-button>
     </div>
@@ -85,6 +85,13 @@ export default {
   computed: {
     isLbRedirected () {
       return this.$store.getters.common.lbRedirected.isLbRedirected
+    },
+    buttonText () {
+      if (this.isUpdate) {
+        return this.$t('network.text_130')
+      } else {
+        return this.$t('network.text_30')
+      }
     },
   },
   created () {
@@ -170,6 +177,9 @@ export default {
         }
         if (data.health_check === 'off') {
           data = filterObj((val, k) => !k.startsWith('health_check_'), data)
+        }
+        if (data.redirect === 'off') {
+          data = filterObj((val, k) => !k.startsWith('redirect_'), data)
         }
         await this.params.onManager('update', {
           id: this.params.listenerData.id,

--- a/containers/Network/views/loadbalancerlistener/mixins/singleActions.js
+++ b/containers/Network/views/loadbalancerlistener/mixins/singleActions.js
@@ -67,7 +67,7 @@ export default {
                 tooltip = i18n.t('network.text_473')
               }
             }
-            if (obj.provider.toLowerCase() === 'azure' || obj.provider.toLowerCase() === 'google') {
+            if (obj.provider && (obj.provider.toLowerCase() === 'azure' || obj.provider.toLowerCase() === 'google')) {
               return {
                 validate: false,
                 tooltip: i18n.t('network.text_309', [PROVIDER_MAP[obj.provider].label]),
@@ -93,7 +93,7 @@ export default {
             })
           },
           meta: obj => {
-            if (obj.provider.toLowerCase() === 'azure' || obj.provider.toLowerCase() === 'google') {
+            if (obj.provider && (obj.provider.toLowerCase() === 'azure' || obj.provider.toLowerCase() === 'google')) {
               return {
                 validate: false,
                 tooltip: i18n.t('network.text_309', [PROVIDER_MAP[obj.provider].label]),
@@ -203,7 +203,7 @@ export default {
             },
           ],
           meta: (obj) => {
-            if (obj.provider.toLowerCase() === 'azure' || obj.provider.toLowerCase() === 'google') {
+            if (obj.provider && (obj.provider.toLowerCase() === 'azure' || obj.provider.toLowerCase() === 'google')) {
               return {
                 validate: false,
                 tooltip: i18n.t('network.text_309', [PROVIDER_MAP[obj.provider].label]),

--- a/src/constants/expectStatus.js
+++ b/src/constants/expectStatus.js
@@ -328,7 +328,7 @@ export default {
     danger: ['refused', 'expired'],
   },
   lbRedirect: {
-    info: ['off'],
+    info: [false, '', 'off'],
     success: ['raw'],
     danger: [],
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -798,6 +798,7 @@
     },
     "lbRedirect": {
       "raw": "Opened",
+      "false": "Not open",
       "off": "Not open"
     },
     "scheduledtask": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -806,6 +806,7 @@
     },
     "lbRedirect": {
       "raw": "已开启",
+      "false": "未开启",
       "off": "未开启"
     },
     "scheduledtask": {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: fail to update lb listender when redirect turned off

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8
- release/3.7

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @Easy-MJ @GuoLiBin6 