### PR TITLE
Automated cherry pick of #2471: fix: #8247 主机备份失败的虚拟机无法删除，应可以强制删除记录

### DIFF
--- a/containers/Compute/views/instance-backup/components/List.vue
+++ b/containers/Compute/views/instance-backup/components/List.vue
@@ -38,7 +38,7 @@ export default {
   data () {
     return {
       deleteResProps: {
-        force_delete: false,
+        force: false,
       },
       list: this.$list.createList(this, {
         id: this.id,
@@ -145,7 +145,7 @@ export default {
                     alert: this.$t('compute.instance_backup_delete_alert'),
                     content: () => {
                       const change = (bool) => {
-                        this.deleteResProps.force_delete = bool
+                        this.deleteResProps.force = bool
                       }
                       return <a-checkbox onInput={ change }>{ this.$t('compute.text_655') }</a-checkbox>
                     },

--- a/containers/Compute/views/instance-backup/mixins/singleActions.js
+++ b/containers/Compute/views/instance-backup/mixins/singleActions.js
@@ -63,7 +63,7 @@ export default {
                   alert: i18n.t('compute.instance_backup_delete_alert'),
                   content: () => {
                     const change = (bool) => {
-                      this.deleteResProps.force_delete = bool
+                      this.deleteResProps.force = bool
                     }
                     return <a-checkbox onInput={ change }>{ this.$t('compute.text_655') }</a-checkbox>
                   },


### PR DESCRIPTION
Cherry pick of #2471 on release/3.9.

#2471: fix: #8247 主机备份失败的虚拟机无法删除，应可以强制删除记录