### PR TITLE
feat: #3705 宿主机列表存储字段支持排序

### DIFF
--- a/containers/Compute/views/host/mixins/columns.js
+++ b/containers/Compute/views/host/mixins/columns.js
@@ -175,6 +175,7 @@ export default {
         field: 'storage',
         title: i18n.t('compute.text_565'),
         minWidth: 80,
+        sortable: true,
         slots: {
           default: ({ row }) => {
             if (this.isPreLoad && !row.storage) return [<data-loading />]

--- a/containers/Compute/views/host/mixins/columns.js
+++ b/containers/Compute/views/host/mixins/columns.js
@@ -176,6 +176,7 @@ export default {
         title: i18n.t('compute.text_565'),
         minWidth: 80,
         sortable: true,
+        sortBy: 'order_by_storage',
         slots: {
           default: ({ row }) => {
             if (this.isPreLoad && !row.storage) return [<data-loading />]


### PR DESCRIPTION
**What this PR does / why we need it**:

feat: #3705 宿主机列表存储字段支持排序

**Does this PR need to be backport to the previous release branch?**:

- release/3.9
- release/3.8