### PR TITLE
fix: #8325 镜像操作按钮顺序调整

### DIFF
--- a/containers/Compute/views/host-image/components/List.vue
+++ b/containers/Compute/views/host-image/components/List.vue
@@ -159,6 +159,22 @@ export default {
                 },
               },
               {
+                label: this.$t('table.action.set_tag'),
+                permission: 'guestimages_perform_set_user_metadata',
+                action: () => {
+                  this.createDialog('SetTagDialog', {
+                    data: this.list.selectedItems,
+                    columns: this.columns,
+                    onManager: this.onManager,
+                    mode: 'add',
+                    params: {
+                      resources: 'guestimage',
+                    },
+                    tipName: this.$t('dictionary.guestimage'),
+                  })
+                },
+              },
+              {
                 label: this.$t('common_277'),
                 permission: 'guestimages_update',
                 action: () => {
@@ -175,22 +191,6 @@ export default {
                     validate: validate,
                     tooltip: !validate && this.$t('compute.text_616'),
                   }
-                },
-              },
-              {
-                label: this.$t('table.action.set_tag'),
-                permission: 'guestimages_perform_set_user_metadata',
-                action: () => {
-                  this.createDialog('SetTagDialog', {
-                    data: this.list.selectedItems,
-                    columns: this.columns,
-                    onManager: this.onManager,
-                    mode: 'add',
-                    params: {
-                      resources: 'guestimage',
-                    },
-                    tipName: this.$t('dictionary.guestimage'),
-                  })
                 },
               },
               {

--- a/containers/Compute/views/image/components/List.vue
+++ b/containers/Compute/views/image/components/List.vue
@@ -215,6 +215,22 @@ export default {
                 hidden: () => this.$isScopedPolicyMenuHidden('image_hidden_menus.image_change_project'),
               },
               {
+                label: this.$t('table.action.set_tag'),
+                permission: 'images_perform_set_user_metadata',
+                action: () => {
+                  this.createDialog('SetTagDialog', {
+                    data: this.list.selectedItems,
+                    columns: this.columns,
+                    onManager: this.onManager,
+                    mode: 'add',
+                    params: {
+                      resources: 'image',
+                    },
+                    tipName: this.$t('compute.text_97'),
+                  })
+                },
+              },
+              {
                 label: this.$t('common_277'),
                 permission: 'images_update',
                 action: (row) => {
@@ -272,22 +288,6 @@ export default {
                   return { validate: true, tooltip: '' }
                 },
                 hidden: () => this.$isScopedPolicyMenuHidden('image_hidden_menus.image_set_delete_protection'),
-              },
-              {
-                label: this.$t('table.action.set_tag'),
-                permission: 'images_perform_set_user_metadata',
-                action: () => {
-                  this.createDialog('SetTagDialog', {
-                    data: this.list.selectedItems,
-                    columns: this.columns,
-                    onManager: this.onManager,
-                    mode: 'add',
-                    params: {
-                      resources: 'image',
-                    },
-                    tipName: this.$t('compute.text_97'),
-                  })
-                },
               },
               {
                 label: this.$t('compute.perform_delete'),


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: #8325 镜像操作按钮顺序调整

**Does this PR need to be backport to the previous release branch?**:

- release/3.9
- release/3.8
- release/3.7
