### PR TITLE
fix: #8334 定时任务-活动历史api接口应该用v1版本

### DIFF
--- a/containers/Cloudenv/views/scheduledtask/sidepage/TaskHistory.vue
+++ b/containers/Cloudenv/views/scheduledtask/sidepage/TaskHistory.vue
@@ -28,6 +28,7 @@ export default {
       list: this.$list.createList(this, {
         id: this.id,
         resource: 'scheduledtaskactivities',
+        apiVersion: 'v1',
         getParams: { details: true, scheduled_task: this.resId },
         filterOptions: {
           name: {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix: #8334 定时任务-活动历史api接口应该用v1版本

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.9