### PR TITLE
Automated cherry pick of #2541: fix: #8334 定时任务-活动历史api接口应该用v1版本

### DIFF
--- a/containers/Cloudenv/views/scheduledtask/sidepage/TaskHistory.vue
+++ b/containers/Cloudenv/views/scheduledtask/sidepage/TaskHistory.vue
@@ -28,6 +28,7 @@ export default {
       list: this.$list.createList(this, {
         id: this.id,
         resource: 'scheduledtaskactivities',
+        apiVersion: 'v1',
         getParams: { details: true, scheduled_task: this.resId },
         filterOptions: {
           name: {


### PR DESCRIPTION
Cherry pick of #2541 on release/3.9.

#2541: fix: #8334 定时任务-活动历史api接口应该用v1版本