### PR TITLE
Automated cherry pick of #2551: fix: #8274 公有云硬盘更多操作中 新建备份 按钮应该禁用

### DIFF
--- a/containers/Compute/views/disk/mixins/singleActions.js
+++ b/containers/Compute/views/disk/mixins/singleActions.js
@@ -183,6 +183,11 @@ export default {
               },
               meta: () => {
                 const guestStatus = ['running', 'ready']
+                if (obj.cloud_env === 'public') {
+                  return {
+                    validate: false,
+                  }
+                }
                 if (obj.guest && !guestStatus.includes(obj.guest_status)) {
                   return {
                     validate: false,


### PR DESCRIPTION
Cherry pick of #2551 on release/3.9.

#2551: fix: #8274 公有云硬盘更多操作中 新建备份 按钮应该禁用