### PR TITLE
fix: isArm should use aarch64 not arm

### DIFF
--- a/containers/Compute/views/vminstance/dialogs/Update.vue
+++ b/containers/Compute/views/vminstance/dialogs/Update.vue
@@ -159,7 +159,7 @@ export default {
       return this.params.data.length >= 1 && this.params.data[0].hypervisor === 'kvm'
     },
     isArm () {
-      return this.params.data.length >= 1 && this.params.data[0].os_arch === 'arm'
+      return this.params.data.length >= 1 && (this.params.data[0].os_arch === 'arm' || this.params.data[0].os_arch === 'aarch64')
     },
   },
   created () {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: isArm should use os_arch of aarch64 instead of arm

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.9
- release/3.8

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @zexi 