### PR TITLE
Automated cherry pick of #2553: fix: isArm should use aarch64 not arm

### DIFF
--- a/containers/Compute/views/vminstance/dialogs/Update.vue
+++ b/containers/Compute/views/vminstance/dialogs/Update.vue
@@ -159,7 +159,7 @@ export default {
       return this.params.data.length >= 1 && this.params.data[0].hypervisor === 'kvm'
     },
     isArm () {
-      return this.params.data.length >= 1 && this.params.data[0].os_arch === 'arm'
+      return this.params.data.length >= 1 && (this.params.data[0].os_arch === 'arm' || this.params.data[0].os_arch === 'aarch64')
     },
   },
   created () {


### PR DESCRIPTION
Cherry pick of #2553 on release/3.8.

#2553: fix: isArm should use aarch64 not arm