### PR TITLE
Automated cherry pick of #2572: fix: #8291 新建OpenStack、DStack、ZStack、飞天、CloudPods和HCSO云账号时应该去掉 配置同步资源区域的操作

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/constants.js
+++ b/containers/Cloudenv/views/cloudaccount/constants.js
@@ -566,4 +566,10 @@ export const notSupportSelectRegion = [
   providerMap.s3.key,
   providerMap.xsky.key,
   providerMap.bingocloud.key,
+  providerMap.openstack.key,
+  providerMap.dstack.key,
+  providerMap.zstack.key,
+  providerMap.apsara.key,
+  providerMap.cloudpods.key,
+  providerMap.hcso.key,
 ]


### PR DESCRIPTION
Cherry pick of #2572 on release/3.9.

#2572: fix: #8291 新建OpenStack、DStack、ZStack、飞天、CloudPods和HCSO云账号时应该去掉 配置同步资源区域的操作