### PR TITLE
fix: set first disk driver of ide for windows only

### DIFF
--- a/containers/Compute/utils/createServer.js
+++ b/containers/Compute/utils/createServer.js
@@ -688,7 +688,7 @@ export class GenCreateData {
     if (type === 'sys' && this.fd.imageType !== IMAGES_TYPE_MAP.iso.key) {
       ret.image_id = this.fd.image.key
     }
-    if (type === 'sys' && this.fd.imageType === IMAGES_TYPE_MAP.iso.key) {
+    if (type === 'sys' && this.fd.imageType === IMAGES_TYPE_MAP.iso.key && this.isWindows()) {
       ret.driver = 'ide'
     }
     if (item.medium) {
@@ -713,6 +713,16 @@ export class GenCreateData {
       ret.backend = ret.backend.split('-')[0]
     }
     return ret
+  }
+
+  isWindows () {
+    let isWindows = false
+    const osType = (_.get(this.fi, 'imageMsg.info.properties.os_type') || '').toLowerCase()
+    const os = (_.get(this.fd, 'os') || '').toLowerCase()
+    if (~[osType, os].indexOf('windows')) {
+      isWindows = true
+    }
+    return isWindows
   }
 
   _getDataDiskType (dataDiskTypes) {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: set first disk driver of ide for windows only

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
NONE
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

/cc @Easy-MJ @GuoLiBin6 