### PR TITLE
fix: #3735 当虚拟机状态为失败时，增加查看日志的快捷入口

### DIFF
--- a/containers/Compute/views/vminstance/mixins/columns.js
+++ b/containers/Compute/views/vminstance/mixins/columns.js
@@ -96,10 +96,13 @@ export default {
         minWidth: 180,
         statusModule: 'server',
         slotCallback: row => {
+          const log = <side-page-trigger class="ml-1" name='VmInstanceSidePage' id={row.id} tab='event-drawer' vm={this} init>{ i18nLocale.t('common.view_logs') }</side-page-trigger>
+
           return [
             <div class='d-flex align-items-center text-truncate'>
               <status status={ row.status } statusModule='server' process={ row.progress } />
               { row.metadata && getToolTip(row) }
+              { row.status?.includes('fail') ? log : null }
             </div>,
           ]
         },

--- a/containers/Compute/views/vminstance/sidepage/index.vue
+++ b/containers/Compute/views/vminstance/sidepage/index.vue
@@ -198,6 +198,7 @@ export default {
     },
   },
   created () {
+    this.initChangeTab()
     this.$bus.$on('agentStatusQuery', (val) => {
       if (this.agent_status === 'failed') {
         this.agent_status = 'applying'
@@ -211,6 +212,11 @@ export default {
     this.isPageDestroyed = true
   },
   methods: {
+    initChangeTab () {
+      if (this.params.tab) {
+        this.handleTabChange(this.params.tab)
+      }
+    },
     async fetchDataCallback () {
       try {
         if (!this.data.data) return

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5117,5 +5117,6 @@
   "common.sort_asc": "Ascending {0}: lowest to highest",
   "common.sort_desc": "Descending {0}：highest to lowest",
   "common.permission_tip": "Permission prompt",
-  "common.permission_no_dashboard": "You do not have permission to access the console"
+  "common.permission_no_dashboard": "You do not have permission to access the console",
+  "common.view_logs": "View logs"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -5131,5 +5131,6 @@
   "common.sort_asc": "第{0}列升序：最低到最高",
   "common.sort_desc": "第{0}列降序：最高到最低",
   "common.permission_tip": "权限提示",
-  "common.permission_no_dashboard": "您无权访问控制台"
+  "common.permission_no_dashboard": "您无权访问控制台",
+  "common.view_logs": "查看日志"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix: #3735 当虚拟机状态为失败时，增加查看日志的快捷入口

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.8
