### PR TITLE
fix: #8374 指定调度标签时，偏好不与调度标签的默认偏好联动

### DIFF
--- a/containers/Compute/sections/Disk/index.vue
+++ b/containers/Compute/sections/Disk/index.vue
@@ -38,7 +38,7 @@
         <a-button class="mt-1" type="link" @click="() => showMountpoint = !showMountpoint">{{ showMountpoint ? $t('compute.text_135') : $t('compute.text_134') }}</a-button>
     </template>
     <template v-if="has('schedtag') && !showStorage">
-      <schedtag-policy v-if="showSchedtag" :form="form" :decorators="{ schedtag: decorator.schedtag, policy: decorator.policy }" :schedtag-params="schedtagParams" />
+      <schedtag-policy v-if="showSchedtag" :form="form" :decorators="{ schedtag: decorator.schedtag, policy: decorator.policy }" :schedtag-params="schedtagParams" :policyReactInSchedtag="false" />
       <a-button v-if="!disabled" v-show="!simplify" class="mt-1" type="link" @click="() => showSchedtag = !showSchedtag">{{ showSchedtag ? $t('compute.text_135') : $t('compute.text_1315') }}</a-button>
     </template>
     <template v-if="has('storage') && !showSchedtag">

--- a/containers/Compute/sections/SchedPolicy/PolicySchedtag.vue
+++ b/containers/Compute/sections/SchedPolicy/PolicySchedtag.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="policy-schedtag">
     <div class="d-flex align-items-start mb-2" v-for="(item, i) in schedtagPolicyList" :key="item.key">
-      <schedtag-policy :form="form" class="w-50" :decorators="genDecorator(item.key)" :schedtag-params="schedtagParams" />
+      <schedtag-policy :form="form" class="w-50" :decorators="genDecorator(item.key)" :schedtag-params="schedtagParams" :policyReactInSchedtag="false" />
       <a-button shape="circle" icon="minus" size="small" @click="decrease(item.key, i)" class="mt-2" />
     </div>
     <a-button type="primary" shape="circle" icon="plus" size="small" @click="add" />

--- a/containers/Compute/sections/ServerNetwork/NetworkSchedtag.vue
+++ b/containers/Compute/sections/ServerNetwork/NetworkSchedtag.vue
@@ -2,7 +2,7 @@
   <div class="network-schedtag">
     <div class="d-flex align-items-start mb-2" v-for="(item, i) in schedtagList" :key="item.key">
       <a-tag color="blue" class="mr-1 mt-2">{{ isBonding ? 'bond' : $t('compute.text_193')}}{{i}}</a-tag>
-      <schedtag-policy :form="form" :decorators="genDecorator(item.key)" :schedtag-params="schedtagParams" />
+      <schedtag-policy :form="form" :decorators="genDecorator(item.key)" :schedtag-params="schedtagParams" :policyReactInSchedtag="false" />
       <a-button shape="circle" icon="minus" size="small" @click="decrease(item.key, i)" class="mt-2" />
     </div>
     <div class="d-flex align-items-center" v-if="schedtagCountRemaining > 0">

--- a/src/sections/SchedtagPolicy/index.vue
+++ b/src/sections/SchedtagPolicy/index.vue
@@ -42,6 +42,10 @@ export default {
       type: Object,
       validator: val => !val || val.fc, // 不传 或者 传就有fc
     },
+    policyReactInSchedtag: { // 策略是否与调度标签联动
+      type: Boolean,
+      default: () => true,
+    },
   },
   data () {
     return {
@@ -60,9 +64,11 @@ export default {
             }
           }
           this.form.fc.getFieldDecorator(this.decorators.policy[0], this.decorators.policy[1])
-          this.form.fc.setFieldsValue({
-            [this.decorators.policy[0]]: defaultStrategy,
-          })
+          if (this.policyReactInSchedtag) {
+            this.form.fc.setFieldsValue({
+              [this.decorators.policy[0]]: defaultStrategy,
+            })
+          }
         }
       })
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: #8374 指定调度标签时，偏好不与调度标签的默认偏好联动

**Does this PR need to be backport to the previous release branch?**:

- release/3.9
