### PR TITLE
fix: #8374 虚拟机新建-调度标签取消默认值

### DIFF
--- a/containers/Compute/utils/createServer.js
+++ b/containers/Compute/utils/createServer.js
@@ -262,7 +262,7 @@ export const createVmDecorators = type => {
       policy: [
         'systemDiskPolicy',
         {
-          initialValue: 'require',
+          initialValue: '',
           validateTrigger: ['blur', 'change'],
           rules: [{
             required: true,
@@ -310,7 +310,7 @@ export const createVmDecorators = type => {
       policy: i => [
         `dataDiskPolicys[${i}]`,
         {
-          initialValue: 'require',
+          initialValue: '',
           validateTrigger: ['blur', 'change'],
           rules: [{
             required: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: #8374 虚拟机新建-调度标签取消默认值

**Does this PR need to be backport to the previous release branch?**:

- release/3.9
- release/3.8
