### PR TITLE
fix: #8389 judge whether to use AES Encrypt according to 'encrpyt_passwd'

### DIFF
--- a/src/sections/Auth/Login/components/LoginChallenge.vue
+++ b/src/sections/Auth/Login/components/LoginChallenge.vue
@@ -143,6 +143,7 @@
 <script>
 import * as R from 'ramda'
 import { mapState } from 'vuex'
+import { Base64 } from 'js-base64'
 import { aesEncrypt } from '@/utils/crypto'
 import { setLoginDomain, getLoginDomain } from '@/utils/common/cookie'
 // import { removeQueryKeys } from '@/utils/utils'
@@ -315,7 +316,10 @@ export default {
         // 检查parent是否要处理表单数据
         const fd = this.formDataMapper ? this.formDataMapper({ ...this.fd }) : { ...this.fd }
         data.username = fd.username
-        data.password = aesEncrypt(fd.password)
+        data.password = Base64.encode(fd.password)
+        if (this.regions.encrypt_passwd) {
+          data.password = aesEncrypt(fd.password)
+        }
         if (fd.captcha) data.captcha = fd.captcha
         if (fd.region) {
           data.region = fd.region

--- a/src/sections/DialogManager/components/UpdateUserPassword.vue
+++ b/src/sections/DialogManager/components/UpdateUserPassword.vue
@@ -28,7 +28,8 @@
 
 <script>
 import * as R from 'ramda'
-import { mapGetters } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
+import { Base64 } from 'js-base64'
 import { aesEncrypt } from '@/utils/crypto'
 import { passwordLevel } from '@/utils/utils'
 import DialogMixin from '@/mixins/dialog'
@@ -138,7 +139,12 @@ export default {
       },
     }
   },
-  computed: mapGetters(['userInfo']),
+  computed: {
+    ...mapState('auth', {
+      regions: state => state.regions,
+    }),
+    ...mapGetters(['userInfo']),
+  },
   destroyed () {
     this.manager = null
   },
@@ -174,11 +180,19 @@ export default {
       this.loading = true
       try {
         const values = await this.validateForm()
-        const data = {
-          password_confirm: aesEncrypt(values.password_new),
-          password_old: aesEncrypt(values.password_old),
-          password_new: aesEncrypt(values.password_new),
-          com_password: aesEncrypt(values.com_password),
+        let data = {
+          password_confirm: Base64.encode(values.password_new),
+          password_old: Base64.encode(values.password_old),
+          password_new: Base64.encode(values.password_new),
+          com_password: Base64.encode(values.com_password),
+        }
+        if (this.regions.encrypt_passwd) {
+          data = {
+            password_confirm: aesEncrypt(values.password_new),
+            password_old: aesEncrypt(values.password_old),
+            password_new: aesEncrypt(values.password_new),
+            com_password: aesEncrypt(values.com_password),
+          }
         }
         this.loading = true
         await this.doUpdatePassword(data)


### PR DESCRIPTION




**What this PR does / why we need it**:

根据encrpyt_passwd判断是否需要AES加密

**Does this PR need to be backport to the previous release branch?**:

- release/3.9
- release/3.8