### PR TITLE
fix: #8417 更正 策略定义-通知渠道设置权限控制

### DIFF
--- a/containers/IAM/router/index.js
+++ b/containers/IAM/router/index.js
@@ -322,7 +322,7 @@ export default {
             label: i18n.t('system.text_19'),
             permission: 'notifyconfigs_list',
             hidden: () => {
-              if (isScopedPolicyMenuHidden('sub_hidden_menus.mailconfig')) {
+              if (isScopedPolicyMenuHidden('sub_hidden_menus.notifyconfig')) {
                 return true
               }
               if (!(store.getters.isAdminMode || store.getters.isDomainMode)) {


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: #8417 更正 策略定义-通知渠道设置权限控制

**Does this PR need to be backport to the previous release branch?**:

- release/3.9
- release/3.8
