### PR TITLE
Automated cherry pick of #2880: fix: #8385 物理机转换宿主机时指定IP子网时样式不应该错乱

### DIFF
--- a/containers/Compute/views/physicalmachine/dialogs/Convert.vue
+++ b/containers/Compute/views/physicalmachine/dialogs/Convert.vue
@@ -83,7 +83,8 @@
             :schedtag-params="resourcesParams.schedtag"
             :networkVpcParams="resourcesParams.vpcParams"
             :vpcResource="vpcResource"
-            :vpcResourceMapper="vpcResourceMapper" />
+            :vpcResourceMapper="vpcResourceMapper"
+            :isDialog="true" />
         </a-form-item>
         <a-form-item :wrapper-col="{ span: 18, offset: 4 }" v-if="isShowNetwork">
           <a-checkbox v-model="isBonding">{{$t('compute.text_310')}}</a-checkbox>


### PR DESCRIPTION
Cherry pick of #2880 on release/3.9.

#2880: fix: #8385 物理机转换宿主机时指定IP子网时样式不应该错乱