### PR TITLE
fix: #8369 安全组-缓存列表展示vpc云上id

### DIFF
--- a/containers/Compute/locales/en.json
+++ b/containers/Compute/locales/en.json
@@ -1569,5 +1569,6 @@
   "compute.create_snapshot_backup": "Create Snapshot/Backup",
   "compute.set_usb_gpu": "Set GPU Card/USB",
   "compute.disk.rotate_gpssd": "GPSSD",
-  "compute.qemu_cmdline": "Qemu Cmdline"
+  "compute.qemu_cmdline": "Qemu Cmdline",
+  "compute.vpc_extrnal_id": "VPC Extrnal ID"
 }

--- a/containers/Compute/locales/zh-CN.json
+++ b/containers/Compute/locales/zh-CN.json
@@ -1569,5 +1569,6 @@
   "compute.create_snapshot_backup": "创建快照/备份",
   "compute.set_usb_gpu": "设置GPU卡/USB透传",
   "compute.disk.rotate_gpssd": "通用型SSD",
-  "compute.qemu_cmdline": "启动命令行"
+  "compute.qemu_cmdline": "启动命令行",
+  "compute.vpc_extrnal_id": "VPC云上ID"
 }

--- a/containers/Compute/views/secgroup/sidepage/Cache.vue
+++ b/containers/Compute/views/secgroup/sidepage/Cache.vue
@@ -13,6 +13,7 @@ import {
   getStatusTableColumn,
   getBrandTableColumn,
   getRegionTableColumn,
+  getCopyWithContentTableColumn,
 } from '@/utils/common/tableColumn'
 
 export default {
@@ -80,15 +81,17 @@ export default {
             return this.$moment(cellValue).format()
           },
         },
-        {
-          field: 'vpc',
-          title: 'VPC',
-          minWidth: 70,
-          showOverflow: 'ellipsis',
-          formatter: ({ cellValue }) => {
-            return cellValue || '-'
+        getCopyWithContentTableColumn({
+          field: 'vpc_id',
+          title: this.$t('compute.vpc_extrnal_id'),
+          hideField: true,
+          message: (row) => {
+            return row.vpc_id || ''
           },
-        },
+          slotCallback: (row) => {
+            return row.vpc_id || '-'
+          },
+        }),
         getBrandTableColumn(),
         getRegionTableColumn(),
         {


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: #8369 安全组-缓存列表展示vpc云上id

**Does this PR need to be backport to the previous release branch?**:

- release/3.9
- release/3.8
