### PR TITLE
Automated cherry pick of #2902: fix: #8419 VMware主机更换镜像后，不会更新系统盘的大小

### DIFF
--- a/containers/Compute/views/vminstance/create/components/SystemDisk.vue
+++ b/containers/Compute/views/vminstance/create/components/SystemDisk.vue
@@ -115,6 +115,9 @@ export default {
     isIDC () {
       return this.type === 'idc'
     },
+    isVMware () {
+      return this.form.fd.hypervisor === HYPERVISORS_MAP.esxi.key
+    },
     imageMinDisk () {
       const image = this.image
       let minSize = 0
@@ -270,6 +273,15 @@ export default {
       }
       this.$bus.$emit('VMCreateDisabled', statusMap.isError)
       return statusMap
+    },
+  },
+  watch: {
+    imageMinDisk (val) {
+      if (this.isVMware) {
+        this.form.fc.setFieldsValue({
+          [this.decorator.size[0]]: val,
+        })
+      }
     },
   },
   created () {


### PR DESCRIPTION
Cherry pick of #2902 on release/3.9.

#2902: fix: #8419 VMware主机更换镜像后，不会更新系统盘的大小