### PR TITLE
Automated cherry pick of #2945: feat: 支持图标扫描文件夹下的子文件中的图标

### DIFF
--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -2,7 +2,7 @@ import { Icon as AntIcon } from 'ant-design-vue'
 import { mergeProps } from 'ant-design-vue/lib/_util/props-util'
 
 const commonContext = require.context('./assets', false, /\.svg$/)
-const scopeContext = require.context('@scope/assets', false, /\.svg$/)
+const scopeContext = require.context('@scope/assets', true, /\.svg$/)
 
 const requireAll = (commonContext, scopeContext) => {
   const commonFilePath = []


### PR DESCRIPTION
Cherry pick of #2945 on release/3.9.

#2945: feat: 支持图标扫描文件夹下的子文件中的图标