### PR TITLE
Automated cherry pick of #3114: fix: #8462 镜像市场从ISO导入arm的镜像后，该ISO的cpu架构不应该是x86的

### DIFF
--- a/containers/Compute/views/image/mixins/columns.js
+++ b/containers/Compute/views/image/mixins/columns.js
@@ -49,7 +49,7 @@ export default {
           return cellValue && cellValue.toUpperCase()
         },
       },
-      getOsArch('properties.os_arch'),
+      getOsArch({ field: 'properties.os_arch' }),
       {
         field: 'os_type',
         title: i18n.t('table.title.os'),


### PR DESCRIPTION
Cherry pick of #3114 on release/3.8.

#3114: fix: #8462 镜像市场从ISO导入arm的镜像后，该ISO的cpu架构不应该是x86的