### PR TITLE
fix: #8480 rds 监控使用内存使用率指标

### DIFF
--- a/containers/DB/constants/index.js
+++ b/containers/DB/constants/index.js
@@ -384,11 +384,11 @@ export const RDS_MONITOR_OPTS = {
       transfer: 1,
     },
     {
-      name: 'diskio',
-      label: i18n.t('db.text_385'), // io使用率
+      name: 'mem',
+      label: i18n.t('db.text_12'),
       seleteItem: 'used_percent',
-      fromItem: 'rds_diskio',
-      as: i18n.t('db.text_385'),
+      fromItem: 'rds_mem',
+      as: i18n.t('db.text_12'),
       unit: '%',
       transfer: 1,
     },
@@ -398,6 +398,15 @@ export const RDS_MONITOR_OPTS = {
       seleteItem: 'used_percent',
       as: i18n.t('db.text_13'),
       fromItem: 'rds_disk',
+      unit: '%',
+      transfer: 1,
+    },
+    {
+      name: 'diskio',
+      label: i18n.t('db.text_385'), // io使用率
+      seleteItem: 'used_percent',
+      fromItem: 'rds_diskio',
+      as: i18n.t('db.text_385'),
       unit: '%',
       transfer: 1,
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: #8480 rds 监控使用内存使用率指标

**Does this PR need to be backport to the previous release branch?**:

- release/3.9
- release/3.8
