### PR TITLE
fix: 消息通知渠道 短信参数文档地址更正

### DIFF
--- a/containers/IAM/views/notifyconfig/create/components/smsaliyun.vue
+++ b/containers/IAM/views/notifyconfig/create/components/smsaliyun.vue
@@ -90,6 +90,7 @@
 </template>
 
 <script>
+import { getNotifyDocsUrl } from '../../utils/docs'
 export default {
   name: 'smsaliyun',
   props: {
@@ -152,6 +153,7 @@ export default {
           'errorCodeEn',
         ],
       },
+      docUrl: getNotifyDocsUrl('mobile_aliyun'),
     }
   },
 }

--- a/containers/IAM/views/notifyconfig/create/components/smshuawei.vue
+++ b/containers/IAM/views/notifyconfig/create/components/smshuawei.vue
@@ -151,6 +151,7 @@
 </template>
 
 <script>
+import { getNotifyDocsUrl } from '../../utils/docs'
 export default {
   name: 'smshuawei',
   props: {
@@ -239,6 +240,7 @@ export default {
           'errorCodeEnChannel',
         ],
       },
+      docUrl: getNotifyDocsUrl('mobile_huawei'),
     }
   },
 }

--- a/containers/IAM/views/notifyconfig/utils/docs.js
+++ b/containers/IAM/views/notifyconfig/utils/docs.js
@@ -7,6 +7,12 @@ export const getNotifyDocsUrl = (type) => {
     case 'mobile':
       baseUrl += '/#阿里云获取短信参数步骤'
       break
+    case 'mobile_aliyun':
+      baseUrl += '/#阿里云获取短信参数步骤'
+      break
+    case 'mobile_huawei':
+      baseUrl += '/#华为云获取短信参数步骤'
+      break
     case 'dingtalk':
       baseUrl += '/#钉钉平台获取参数步骤'
       break


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: 消息通知渠道 短信参数文档地址更正

**Does this PR need to be backport to the previous release branch?**:

- NONE(3.10)