### PR TITLE
Automated cherry pick of #3480: fix: #8559 新建每天触发时且未填有效时间的定时任务时前端不应该少传参数

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/dialogs/ScheduledtaskCreate.vue
+++ b/containers/Cloudenv/views/cloudaccount/dialogs/ScheduledtaskCreate.vue
@@ -7,6 +7,9 @@
       <a-form :form="form.fc" v-bind="formItemLayout" hideRequiredMark>
         <a-form-item :label="$t('cloudenv.text_95')">
           <a-input :placeholder="$t('cloudenv.text_190')" v-decorator="decorators.name" />
+          <template v-slot:extra>
+            <name-repeated res="scheduledtasks" :name="form.fd.name" />
+          </template>
         </a-form-item>
         <a-form-item :label="$t('cloudenv.text_360')">
           {{ $t('cloudenv.sync_account') }}
@@ -65,11 +68,15 @@ import {
   getStatusTableColumn,
   getEnabledTableColumn,
 } from '@/utils/common/tableColumn'
+import NameRepeated from '@/sections/NameRepeated'
 import DialogMixin from '@/mixins/dialog'
 import WindowsMixin from '@/mixins/windows'
 
 export default {
   name: 'ScheduledtaskCreateDialog',
+  components: {
+    NameRepeated,
+  },
   mixins: [DialogMixin, WindowsMixin],
   data () {
     return {
@@ -141,7 +148,16 @@ export default {
         ],
       },
       form: {
-        fc: this.$form.createForm(this),
+        fc: this.$form.createForm(this, {
+          onValuesChange: (props, values) => {
+            Object.keys(values).forEach((key) => {
+              this.form.fd[key] = values[key]
+            })
+          },
+        }),
+        fd: {
+          name: '',
+        },
       },
       columns: [
         {
@@ -178,7 +194,7 @@ export default {
         label_type: 'id',
         labels: [this.params.resId],
         operation: 'sync',
-        name: values.name,
+        generate_name: values.name,
       }
       if (values.cycleTimer.cycle_type === 'one') {
         params.scheduled_type = 'timing'
@@ -208,7 +224,7 @@ export default {
         })
       } else {
         // 未设置有效时间时，有效时间为 今天-100年
-        params.cycle_timer = {}
+        params.cycle_timer = { ...values.cycleTimer }
         params.cycle_timer.startTime = this.$moment()
         params.cycle_timer.endTime = this.$moment().add('year', 100)
       }

--- a/containers/Cloudenv/views/scheduledtask/create/index.vue
+++ b/containers/Cloudenv/views/scheduledtask/create/index.vue
@@ -8,6 +8,9 @@
         </a-form-item>
         <a-form-item :label="$t('cloudenv.text_95')">
           <a-input :placeholder="$t('cloudenv.text_190')" v-decorator="decorators.name" />
+          <template v-slot:extra>
+            <name-repeated res="scheduledtasks" :name="form.fd.name" />
+          </template>
         </a-form-item>
         <a-form-item :label="$t('common.description')">
           <a-textarea :auto-size="{ minRows: 1, maxRows: 3 }" v-decorator="decorators.description" :placeholder="$t('common_367')" />
@@ -90,11 +93,12 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import ResourcePropsMixin from '../mixins/resourceProps'
 import Tag from '@/sections/Tag'
 import DomainProject from '@/sections/DomainProject'
 import ListSelect from '@/sections/ListSelect'
 import validateForm, { isRequired } from '@/utils/validate'
+import NameRepeated from '@/sections/NameRepeated'
+import ResourcePropsMixin from '../mixins/resourceProps'
 
 export default {
   name: 'ScheduledtaskCreateIndex',
@@ -102,6 +106,7 @@ export default {
     DomainProject,
     Tag,
     ListSelect,
+    NameRepeated,
   },
   mixins: [ResourcePropsMixin],
   data () {
@@ -234,11 +239,17 @@ export default {
       form: {
         fc: this.$form.createForm(this, {
           onValuesChange: (props, values) => {
+            Object.keys(values).forEach((key) => {
+              this.form.fd[key] = values[key]
+            })
             if (values.hasOwnProperty('project')) {
               this.resourceProps.list.getParams.tenant = values.project && values.project.key
             }
           },
         }),
+        fd: {
+          name: '',
+        },
       },
       formItemLayout: {
         wrapperCol: {
@@ -333,7 +344,9 @@ export default {
         })
       } else {
         // 未设置有效时间时，有效时间为 今天-100年
-        params.cycle_timer = {}
+        params.cycle_timer = {
+          ...cycleTimer,
+        }
         params.cycle_timer.startTime = this.$moment()
         params.cycle_timer.endTime = this.$moment().add('year', 100)
       }


### PR DESCRIPTION
Cherry pick of #3480 on release/3.9.

#3480: fix: #8559 新建每天触发时且未填有效时间的定时任务时前端不应该少传参数