### PR TITLE
Automated cherry pick of #3492: feat: #3943 云账号新建-华为去除全球区类型

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/constants.js
+++ b/containers/Cloudenv/views/cloudaccount/constants.js
@@ -209,7 +209,7 @@ export function getCloudaccountDocs (scope) {
 
 export const ACCESS_URL = {
   huawei: {
-    InternationalCloud: i18n.t('cloudenv.text_139'),
+    // InternationalCloud: i18n.t('cloudenv.text_139'),
     ChinaCloud: i18n.t('cloudenv.text_140'),
   },
   aws: {


### PR DESCRIPTION
Cherry pick of #3492 on release/3.8.

#3492: feat: #3943 云账号新建-华为去除全球区类型