### PR TITLE
Automated cherry pick of #3533: fix: remove usable for cloudgroup

### DIFF
--- a/containers/Cloudenv/views/cloudgroup/components/List.vue
+++ b/containers/Cloudenv/views/cloudgroup/components/List.vue
@@ -103,7 +103,6 @@ export default {
   methods: {
     getParam () {
       const ret = {
-        usable: true,
         ...(R.is(Function, this.getParams) ? this.getParams() : this.getParams),
       }
       return ret


### PR DESCRIPTION
Cherry pick of #3533 on release/3.9.

#3533: fix: remove usable for cloudgroup