### PR TITLE
fix(k8s): lb-network should be filtered by vpc_id of cluster

### DIFF
--- a/containers/K8S/sections/PortMapping/LbNetwork.vue
+++ b/containers/K8S/sections/PortMapping/LbNetwork.vue
@@ -17,12 +17,17 @@ export default {
       type: Array,
       required: true,
     },
+    vpcId: {
+      type: String,
+      required: true,
+    },
   },
   data () {
     return {
       params: {
         cloudregion: 'default',
         scope: this.$store.getters.scope,
+        vpc_id: this.vpcId,
       },
     }
   },

--- a/containers/K8S/sections/PortMapping/index.vue
+++ b/containers/K8S/sections/PortMapping/index.vue
@@ -8,12 +8,12 @@
         <a-radio-button value="nodePort">{{$t('k8s.node_port')}}</a-radio-button>
       </a-radio-group>
     </a-form-item>
-    <lb-network
-      v-if="!isImportCluster && form.fc.getFieldValue(decorators.serviceType[0]) === 'external'"
-      :decorator="decorators.loadBalancerNetwork" />
     <lb-cluster
       v-if="!isImportCluster && form.fc.getFieldValue(decorators.serviceType[0]) === 'external' && isAdminMode"
       :decorator="decorators.loadBalancerCluster" />
+    <lb-network
+      v-if="!isImportCluster && form.fc.getFieldValue(decorators.serviceType[0]) === 'external'"
+      :decorator="decorators.loadBalancerNetwork" :vpc-id="vpcId" />
     <div class="mt-3" v-if="form.fc.getFieldValue(decorators.serviceType[0]) !== 'none'">
       <div class="d-flex" v-for="(item, i) in portList" :key="item.key">
         <port :decorators="getDecorators(item)" :protocolDisabled="getProtocolDisabled(i)" :serviceType="getServiceType()" @protocolChange="protocolChange" />
@@ -49,9 +49,9 @@ export default {
       required: true,
       validator: val => val.fc,
     },
-    isImportCluster: {
-      type: Boolean,
-      default: false,
+    clusterObj: {
+      type: Object,
+      required: true,
     },
     ignoreNone: {
       type: Boolean,
@@ -68,6 +68,15 @@ export default {
   },
   computed: {
     ...mapGetters(['isAdminMode']),
+    isImportCluster () {
+      if (this.clusterObj.mode === 'import') { // 导入的集群新建外部服务时不能选择网络
+        return true
+      }
+      return false
+    },
+    vpcId () {
+      return this.clusterObj.vpc_id
+    },
   },
   methods: {
     add () {

--- a/containers/K8S/views/daemonset/create/Form.vue
+++ b/containers/K8S/views/daemonset/create/Form.vue
@@ -24,7 +24,7 @@
         <port-mapping
           :form="form"
           :decorators="decorators.portMappings"
-          :is-import-cluster="isImportCluster" />
+          :cluster-obj="clusterObj" />
       </a-form-item>
       <a-form-item :label="$t('k8s.text_221')">
         <restart-policy-select
@@ -91,14 +91,6 @@ export default {
       clusterObj: {},
       namespaceObj: {},
     }
-  },
-  computed: {
-    isImportCluster () {
-      if (this.clusterObj.mode === 'import') { // 导入的集群新建外部服务时不能选择网络
-        return true
-      }
-      return false
-    },
   },
   methods: {
     validateForm () {

--- a/containers/K8S/views/deployment/create/Form.vue
+++ b/containers/K8S/views/deployment/create/Form.vue
@@ -24,7 +24,7 @@
         <port-mapping
           :form="form"
           :decorators="decorators.portMappings"
-          :is-import-cluster="isImportCluster" />
+          :cluster-obj="clusterObj" />
       </a-form-item>
       <a-form-item :label="$t('k8s.text_221')">
         <restart-policy-select
@@ -99,14 +99,6 @@ export default {
       clusterObj: {},
       namespaceObj: {},
     }
-  },
-  computed: {
-    isImportCluster () {
-      if (this.clusterObj.mode === 'import') { // 导入的集群新建外部服务时不能选择网络
-        return true
-      }
-      return false
-    },
   },
   methods: {
     validateForm () {

--- a/containers/K8S/views/service/create/Form.vue
+++ b/containers/K8S/views/service/create/Form.vue
@@ -5,7 +5,7 @@
         <a-input :placeholder="$t('k8s.text_60')" v-decorator="decorators.name" />
       </a-form-item>
       <a-form-item :label="$t('k8s.text_19')">
-        <cluster-select v-decorator="decorators.cluster" @input="setCluster" />
+        <cluster-select v-decorator="decorators.cluster" @input="setCluster" :clusterObj.sync="clusterObj" />
       </a-form-item>
       <a-form-item :label="$t('k8s.text_23')">
         <namespace-select v-decorator="decorators.namespace" @input="setNamespace" :cluster="cluster" :namespaceObj.sync="namespaceObj" />
@@ -31,7 +31,8 @@
         <port-mapping
           :form="form"
           ignore-none
-          :decorators="decorators.portMappings" />
+          :decorators="decorators.portMappings"
+          :cluster-obj="clusterObj" />
       </a-form-item>
     </a-form>
   </div>
@@ -155,6 +156,7 @@ export default {
           },
         ],
       },
+      clusterObj: {},
       namespaceObj: {},
     }
   },

--- a/containers/K8S/views/statefulset/create/Form.vue
+++ b/containers/K8S/views/statefulset/create/Form.vue
@@ -24,7 +24,7 @@
         <port-mapping
           :form="form"
           :decorators="decorators.portMappings"
-          :is-import-cluster="isImportCluster" />
+          :cluster-obj="clusterObj" />
       </a-form-item>
       <a-form-item :label="$t('k8s.text_221')">
         <restart-policy-select
@@ -91,14 +91,6 @@ export default {
       clusterObj: {},
       namespaceObj: {},
     }
-  },
-  computed: {
-    isImportCluster () {
-      if (this.clusterObj.mode === 'import') { // 导入的集群新建外部服务时不能选择网络
-        return true
-      }
-      return false
-    },
   },
   methods: {
     validateForm () {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.9
/cc @swordqiu 