### PR TITLE
feat: #4001 server (running) support acttach gpu remove from 3.9

### DIFF
--- a/containers/Compute/views/vminstance/utils.js
+++ b/containers/Compute/views/vminstance/utils.js
@@ -505,7 +505,7 @@ const actionEableMap = {
   acttachGpu: {
     cn: i18n.t('compute.text_1304'),
     brand: {
-      onecloud: ['ready', 'running'],
+      onecloud: ['ready'],
       vmware: false,
       bingocloud: false,
       remotefile: false,


### PR DESCRIPTION
**What this PR does / why we need it**:

feat: #4001 server (running) support acttach gpu remove from 3.9

**Does this PR need to be backport to the previous release branch?**:

- NONE(3.9)
