### PR TITLE
fix: #8663 rds/redis private platform donot support price calc

### DIFF
--- a/containers/DB/views/rds/create/components/BottomBar.vue
+++ b/containers/DB/views/rds/create/components/BottomBar.vue
@@ -20,7 +20,7 @@
       </div>
     </template>
     <template v-slot:right>
-      <price-fetcher :values="values" :customPriceKey="customPriceKey" :extraPriceItems="extraPriceItems" :cloudAccountId="cloudAccountId" />
+      <price-fetcher v-if="!isPrivate" :values="values" :customPriceKey="customPriceKey" :extraPriceItems="extraPriceItems" :cloudAccountId="cloudAccountId" />
       <div class="btns-wrapper d-flex align-items-center">
         <a-button @click="doCreate" :loading="loading" type="primary" class="ml-3">{{$t('db.text_41')}}</a-button>
       </div>
@@ -31,6 +31,8 @@
 import { sizestr } from '@/utils/utils'
 import { Manager } from '@/utils/manager'
 import PriceFetcher from '@/components/PriceFetcher'
+import { SERVER_TYPE } from '@Compute/constants'
+import { findPlatform } from '@/utils/common/hypervisor'
 
 export default {
   name: 'BottomBar',
@@ -66,6 +68,12 @@ export default {
         ],
       ]
       return ret
+    },
+    provider () {
+      return this.form.fd.provider || ''
+    },
+    isPrivate () {
+      return findPlatform(this.provider.toLowerCase(), 'provider') === SERVER_TYPE.private
     },
   },
   methods: {

--- a/containers/DB/views/redis/create/components/BottomBar.vue
+++ b/containers/DB/views/redis/create/components/BottomBar.vue
@@ -21,7 +21,7 @@
       <!-- <div>{{$t('db.text_263')}}</div> -->
     </template>
     <template v-slot:right>
-      <price-fetcher :values="values" :customPriceKey="customPriceKey" :cloudAccountId="cloudAccountId" />
+      <price-fetcher v-if="!isPrivate" :values="values" :customPriceKey="customPriceKey" :cloudAccountId="cloudAccountId" />
       <div class="btns-wrapper d-flex align-items-center">
         <a-button @click="doCreate" :loading="loading" type="primary" class="ml-3">{{$t('db.text_41')}}</a-button>
       </div>
@@ -54,6 +54,8 @@ import { ENGINE_ARCH } from '@DB/views/redis/constants'
 import { sizestrWithUnit } from '@/utils/utils'
 import { Manager } from '@/utils/manager'
 import PriceFetcher from '@/components/PriceFetcher'
+import { SERVER_TYPE } from '@Compute/constants'
+import { findPlatform } from '@/utils/common/hypervisor'
 
 export default {
   name: 'BottomBar',
@@ -94,6 +96,12 @@ export default {
     },
     sku  () {
       return this.values.sku || null
+    },
+    provider () {
+      return this.form.fd.provider || ''
+    },
+    isPrivate () {
+      return findPlatform(this.provider.toLowerCase(), 'provider') === SERVER_TYPE.private
     },
   },
   methods: {


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: #8663 rds/redis private platform donot support price calc

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
- release/3.9
