### PR TITLE
Automated cherry pick of #3779: fix: #8666 手工上传arm的镜像后，镜像列表中架构不应该显示x86_64

### DIFF
--- a/src/utils/common/tableColumn.js
+++ b/src/utils/common/tableColumn.js
@@ -805,6 +805,9 @@ export const getOsArch = ({
     title,
     formatter: ({ row }) => {
       let arch = _.get(row, field)
+      if (!arch && field !== 'os_arch') {
+        arch = _.get(row, 'os_arch')
+      }
       if (arch === HOST_CPU_ARCHS.arm.capabilityKey) arch = HOST_CPU_ARCHS.arm.key
       if (arch === HOST_CPU_ARCHS.x86.capabilityKey) arch = HOST_CPU_ARCHS.x86.key
       if (arch) {


### PR DESCRIPTION
Cherry pick of #3779 on release/3.9.

#3779: fix: #8666 手工上传arm的镜像后，镜像列表中架构不应该显示x86_64