### PR TITLE
fix: #8711 vminstance sidepage detail lost statusTableColumn

### DIFF
--- a/containers/Compute/views/vminstance/sidepage/Detail.vue
+++ b/containers/Compute/views/vminstance/sidepage/Detail.vue
@@ -25,6 +25,7 @@ import {
   getOsArch,
   getIpsTableColumn,
   getServerMonitorAgentInstallStatus,
+  getStatusTableColumn,
 } from '@/utils/common/tableColumn'
 import WindowsMixin from '@/mixins/windows'
 import { findPlatform } from '@/utils/common/hypervisor'


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: #8711 vminstance sidepage detail lost statusTableColumn

**Does this PR need to be backport to the previous release branch?**:

NONE
