### PR TITLE
Automated cherry pick of #3854: fix: #8699 新建CDN域名界面指定云订阅应该只显示腾讯云

### DIFF
--- a/containers/Network/views/cdn/create/index.vue
+++ b/containers/Network/views/cdn/create/index.vue
@@ -197,7 +197,10 @@ export default {
           scope: this.$store.getters.scope,
           limit: 0,
         },
-        cloudprovider: {},
+        cloudprovider: {
+          scope: this.$store.getters.scope,
+          brand: 'Qcloud',
+        },
       },
       formItemLayout: {
         wrapperCol: {


### PR DESCRIPTION
Cherry pick of #3854 on release/3.10.

#3854: fix: #8699 新建CDN域名界面指定云订阅应该只显示腾讯云