### PR TITLE
fix: #8681 close dialog after vm set-boot-index successed

### DIFF
--- a/containers/Compute/views/vminstance/dialogs/VmChangeBootIndex.vue
+++ b/containers/Compute/views/vminstance/dialogs/VmChangeBootIndex.vue
@@ -106,15 +106,8 @@ export default {
             data,
           },
         })
-        // await this.params.onManager('batchPerformAction', {
-        //   id: [this.params.data[0].id],
-        //   managerArgs: {
-        //     action: 'set-boot-index',
-        //     data,
-        //   },
-        // })
         this.loading = false
-        // this.cancelDialog()
+        this.cancelDialog()
       } catch (error) {
         this.loading = false
       }


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: #8681 close dialog after vm set-boot-index successed

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
