### PR TITLE
Automated cherry pick of #3881: fix(k8s): use cluster_id as log params

### DIFF
--- a/containers/K8S/views/pod/sidepage/Log.vue
+++ b/containers/K8S/views/pod/sidepage/Log.vue
@@ -59,7 +59,7 @@ export default {
       const { data: { containers } } = await this.manager.get({
         id: this.data.id,
         params: {
-          cluster: this.data.clusterID,
+          cluster: this.data.cluster_id,
           namespace: this.data.namespace,
         },
       })
@@ -69,7 +69,7 @@ export default {
     },
     async fetchUrl (container) {
       const params = {
-        cluster: this.data.cluster,
+        cluster: this.data.cluster_id,
         namespace: this.data.namespace,
         name: this.data.name,
         container,


### PR DESCRIPTION
Cherry pick of #3881 on release/3.8.

#3881: fix(k8s): use cluster_id as log params