### PR TITLE
feat: #3735 主机模块状态为失败时，增加查看日志的快捷入口

### DIFF
--- a/containers/Compute/views/baremetal/components/List.vue
+++ b/containers/Compute/views/baremetal/components/List.vue
@@ -392,7 +392,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'BaremetalSidePage', {
         id: row.id,
         resource: 'servers',
@@ -400,6 +400,7 @@ export default {
         steadyStatus: Object.values(expectStatus.image).flat(),
       }, {
         list: this.list,
+        tab,
       })
     },
     defaultSearchKey (search) {

--- a/containers/Compute/views/baremetal/mixins/columns.js
+++ b/containers/Compute/views/baremetal/mixins/columns.js
@@ -18,7 +18,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'server' }),
+      getStatusTableColumn({ statusModule: 'server', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'server', columns: () => this.columns }),
       getIpsTableColumn({ field: 'ip', title: 'IP' }),
       {

--- a/containers/Compute/views/disk-backup/components/List.vue
+++ b/containers/Compute/views/disk-backup/components/List.vue
@@ -162,7 +162,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'DiskBackupSidePage', {
         id: row.id,
         resource: 'diskbackups',
@@ -170,6 +170,7 @@ export default {
         steadyStatus: this.list.steadyStatus,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Compute/views/disk-backup/mixins/columns.js
+++ b/containers/Compute/views/disk-backup/mixins/columns.js
@@ -28,7 +28,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'diskBackup' }),
+      getStatusTableColumn({ statusModule: 'diskBackup', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'diskbackups', columns: () => this.columns }),
       getDiskTypeTableColumn(),
       getDiskNameTableColumn(),

--- a/containers/Compute/views/disk/components/List.vue
+++ b/containers/Compute/views/disk/components/List.vue
@@ -314,7 +314,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.initSidePageTab('disk-detail')
       this.sidePageTriggerHandle(this, 'DiskSidePage', {
         id: row.id,
@@ -327,6 +327,7 @@ export default {
       }, {
         list: this.list,
         hiddenColumns: this.hiddenColumns,
+        tab,
       })
     },
     beforeShowMenu () {

--- a/containers/Compute/views/disk/mixins/columns.js
+++ b/containers/Compute/views/disk/mixins/columns.js
@@ -118,7 +118,7 @@ export default {
       getBrandTableColumn(),
       getRegionTableColumn({ vm: this }),
       getBillingTypeTableColumn(),
-      getStatusTableColumn({ statusModule: 'disk' }),
+      getStatusTableColumn({ statusModule: 'disk', vm: this }),
       getProjectTableColumn(),
       getAccountTableColumn({ vm: this }),
       {

--- a/containers/Compute/views/host-image/components/List.vue
+++ b/containers/Compute/views/host-image/components/List.vue
@@ -239,7 +239,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'HostImageSidePage', {
         id: row.id,
         resource: 'guestimages',
@@ -248,6 +248,7 @@ export default {
         steadyStatus: Object.values(expectStatus.image).flat(),
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Compute/views/host-image/mixins/columns.js
+++ b/containers/Compute/views/host-image/mixins/columns.js
@@ -18,7 +18,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'image' }),
+      getStatusTableColumn({ statusModule: 'image', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'guestimages', columns: () => this.columns }),
       {
         field: 'child_image',

--- a/containers/Compute/views/host/components/List.vue
+++ b/containers/Compute/views/host/components/List.vue
@@ -543,13 +543,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'HostSidePage', {
         id: row.id,
         resource: 'hosts',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
     defaultSearchKey (search) {

--- a/containers/Compute/views/host/mixins/columns.js
+++ b/containers/Compute/views/host/mixins/columns.js
@@ -56,6 +56,7 @@ export default {
       getStatusTableColumn({
         statusModule: 'host',
         minWidth: 100,
+        vm: this,
       }),
       getEnabledTableColumn(),
       getStatusTableColumn({

--- a/containers/Compute/views/image/mixins/columns.js
+++ b/containers/Compute/views/image/mixins/columns.js
@@ -32,9 +32,13 @@ export default {
         slots: {
           default: ({ row }, h) => {
             const fileProcess = row.status === 'saving' ? <FileProcess size={ row.size }></FileProcess> : null
+            const log = <side-page-trigger class="ml-1" onTrigger={ () => this.handleOpenSidepage(row, 'event-drawer') }>{ this.$t('common.view_logs') }</side-page-trigger>
             return [
               <div class='text-truncate'>
-                <status status={ row.status } statusModule={ 'image' } process={ row.progress } />
+                <div class="d-flex align-items-center">
+                  <status status={ row.status } statusModule={ 'image' } process={ row.progress } />
+                  { row.status?.includes('fail') ? log : null }
+                </div>
                 { fileProcess }
               </div>,
             ]

--- a/containers/Compute/views/instance-backup/components/List.vue
+++ b/containers/Compute/views/instance-backup/components/List.vue
@@ -191,7 +191,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'InstanceBackupSidePage', {
         id: row.id,
         resource: 'instancebackups',
@@ -199,6 +199,7 @@ export default {
         steadyStatus: this.list.steadyStatus,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Compute/views/instance-backup/mixins/columns.js
+++ b/containers/Compute/views/instance-backup/mixins/columns.js
@@ -28,7 +28,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'instanceBackup' }),
+      getStatusTableColumn({ statusModule: 'instanceBackup', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'instancebackups', columns: () => this.columns }),
       getBackupStorageNameTableColumn(),
       getSizeMbTableColumn(),

--- a/containers/Compute/views/instance-group/components/List.vue
+++ b/containers/Compute/views/instance-group/components/List.vue
@@ -127,13 +127,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'InstanceGroupSidePage', {
         id: row.id,
         resource: 'instancegroups',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Compute/views/instance-group/mixins/columns.js
+++ b/containers/Compute/views/instance-group/mixins/columns.js
@@ -20,7 +20,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'instanceGroup' }),
+      getStatusTableColumn({ statusModule: 'instanceGroup', vm: this }),
       getEnabledTableColumn(),
       {
         field: 'force_dispersion',

--- a/containers/Compute/views/physicalmachine/components/List.vue
+++ b/containers/Compute/views/physicalmachine/components/List.vue
@@ -330,7 +330,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'PhysicalmachineSidePage', {
         id: row.id,
         resource: 'hosts',
@@ -340,6 +340,7 @@ export default {
         },
       }, {
         list: this.list,
+        tab,
       })
     },
     defaultSearchKey (search) {

--- a/containers/Compute/views/physicalmachine/mixins/columns.js
+++ b/containers/Compute/views/physicalmachine/mixins/columns.js
@@ -34,7 +34,7 @@ export default {
           }
         },
       }),
-      getStatusTableColumn({ statusModule: 'host' }),
+      getStatusTableColumn({ statusModule: 'host', vm: this }),
       getEnabledTableColumn(),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'host', columns: () => this.columns }),
       {

--- a/containers/Compute/views/scaling-group/components/List.vue
+++ b/containers/Compute/views/scaling-group/components/List.vue
@@ -156,5 +156,17 @@ export default {
   created () {
     this.list.fetchData()
   },
+  methods: {
+    handleOpenSidepage (row, tab) {
+      this.sidePageTriggerHandle(this, 'ScalingGroupSidePage', {
+        id: row.id,
+        resource: 'scalinggroups',
+        getParams: this.getParam,
+      }, {
+        list: this.list,
+        tab,
+      })
+    },
+  },
 }
 </script>

--- a/containers/Compute/views/scaling-group/mixins/columns.js
+++ b/containers/Compute/views/scaling-group/mixins/columns.js
@@ -13,7 +13,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'scalinggroup', minWidth: 130 }),
+      getStatusTableColumn({ statusModule: 'scalinggroup', minWidth: 130, vm: this }),
       getEnabledTableColumn(),
       getCopyWithContentTableColumn({
         field: 'guest_template',

--- a/containers/Compute/views/secgroup/components/List.vue
+++ b/containers/Compute/views/secgroup/components/List.vue
@@ -227,7 +227,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'SecGroupSidePage', {
         id: row.id,
         resource: 'secgroups',
@@ -237,6 +237,7 @@ export default {
         hiddenSidepageTabs: this.hiddenSidepageTabs,
         hiddenColumns: this.hiddenColumns,
         hiddenActions: this.hiddenActions,
+        tab,
       })
     },
     async loadRules ({ row }) {

--- a/containers/Compute/views/secgroup/mixins/columns.js
+++ b/containers/Compute/views/secgroup/mixins/columns.js
@@ -24,7 +24,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'secgroup' }),
+      getStatusTableColumn({ statusModule: 'secgroup', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'secgroups', columns: () => this.columns }),
       {
         field: 'rules',

--- a/containers/Compute/views/servertemplate/components/List.vue
+++ b/containers/Compute/views/servertemplate/components/List.vue
@@ -173,13 +173,14 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'ServertemplateSidePage', {
         id: row.id,
         resource: 'servertemplates',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Compute/views/servertemplate/mixins/columns.js
+++ b/containers/Compute/views/servertemplate/mixins/columns.js
@@ -31,7 +31,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'servertemplate' }),
+      getStatusTableColumn({ statusModule: 'servertemplate', vm: this }),
       getOsArch({ field: 'content.os_arch' }),
       {
         field: 'instance_type',

--- a/containers/Compute/views/snapshot-instance/components/List.vue
+++ b/containers/Compute/views/snapshot-instance/components/List.vue
@@ -161,7 +161,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'SnapshotInstanceSidePage', {
         id: row.id,
         resource: 'instance_snapshots',
@@ -170,6 +170,7 @@ export default {
       }, {
         list: this.list,
         type: 'instance',
+        tab,
       })
     },
   },

--- a/containers/Compute/views/snapshot-instance/mixins/columns.js
+++ b/containers/Compute/views/snapshot-instance/mixins/columns.js
@@ -23,7 +23,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'snapshot' }),
+      getStatusTableColumn({ statusModule: 'snapshot', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'instance_snapshots', columns: () => this.columns }),
       {
         field: 'rules',

--- a/containers/Compute/views/snapshot/components/List.vue
+++ b/containers/Compute/views/snapshot/components/List.vue
@@ -197,7 +197,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'SnapshotSidePage', {
         id: row.id,
         resource: 'snapshots',
@@ -206,6 +206,7 @@ export default {
       }, {
         list: this.list,
         type: 'disk',
+        tab,
       })
     },
   },

--- a/containers/Compute/views/snapshot/mixins/columns.js
+++ b/containers/Compute/views/snapshot/mixins/columns.js
@@ -28,7 +28,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'snapshot' }),
+      getStatusTableColumn({ statusModule: 'snapshot', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'snapshots', columns: () => this.columns }),
       getOsArch(),
       {

--- a/containers/Compute/views/snapshotpolicy/components/List.vue
+++ b/containers/Compute/views/snapshotpolicy/components/List.vue
@@ -107,7 +107,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'SnapshotPolicySidePage', {
         id: row.id,
         resource: 'snapshotpolicies',
@@ -116,6 +116,7 @@ export default {
       }, {
         list: this.list,
         type: this.type,
+        tab,
       })
     },
   },

--- a/containers/Compute/views/snapshotpolicy/mixins/columns.js
+++ b/containers/Compute/views/snapshotpolicy/mixins/columns.js
@@ -19,7 +19,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'snapshotpolicy' }),
+      getStatusTableColumn({ statusModule: 'snapshotpolicy', vm: this }),
       {
         field: 'binding_disk_count',
         title: i18n.t('table.title.bind_disk_count'),

--- a/containers/Compute/views/vminstance/components/List.vue
+++ b/containers/Compute/views/vminstance/components/List.vue
@@ -1206,7 +1206,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'VmInstanceSidePage', {
         id: row.id,
         resource: 'servers',
@@ -1214,6 +1214,7 @@ export default {
         steadyStatus: Object.values(expectStatus.server).flat(),
       }, {
         list: this.list,
+        tab,
       })
     },
     beforeShowMenu () {

--- a/containers/Compute/views/vminstance/mixins/columns.js
+++ b/containers/Compute/views/vminstance/mixins/columns.js
@@ -96,7 +96,7 @@ export default {
         minWidth: 180,
         statusModule: 'server',
         slotCallback: row => {
-          const log = <side-page-trigger class="ml-1" name='VmInstanceSidePage' id={row.id} tab='event-drawer' vm={this} init>{ i18nLocale.t('common.view_logs') }</side-page-trigger>
+          const log = <side-page-trigger class="ml-1" onTrigger={ () => this.handleOpenSidepage(row, 'event-drawer') }>{ this.$t('common.view_logs') }</side-page-trigger>
           const cancel = <a class="ml-1"
             onClick={ () => this.createDialog('VmLiveMigrateCancelDialog', {
               data: [row],

--- a/containers/Compute/views/webapp/components/List.vue
+++ b/containers/Compute/views/webapp/components/List.vue
@@ -123,13 +123,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'WebAppSidePage', {
         id: row.id,
         resource: 'webapps',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Compute/views/webapp/mixins/columns.js
+++ b/containers/Compute/views/webapp/mixins/columns.js
@@ -26,7 +26,7 @@ export default {
         },
       }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'webapps', tipName: this.$t('compute.webapp'), columns: () => this.columns }),
-      getStatusTableColumn({ statusModule: 'webapp' }),
+      getStatusTableColumn({ statusModule: 'webapp', vm: this }),
       getTypeTableColumn(),
       getKindTableColumn(),
       getTechStackTableColumn(),

--- a/src/mixins/sidePage.js
+++ b/src/mixins/sidePage.js
@@ -198,7 +198,15 @@ export default {
       })
     }
   },
+  mounted () {
+    this.initChangeTab()
+  },
   methods: {
+    initChangeTab () {
+      if (this.params.tab) {
+        this.handleTabChange(this.params.tab)
+      }
+    },
     cancelSidePage () {
       if (this.params && R.is(Function, this.params.cancel)) {
         this.params.cancel()

--- a/src/utils/common/tableColumn.js
+++ b/src/utils/common/tableColumn.js
@@ -103,7 +103,7 @@ export const getBrandTableColumn = ({ field = 'brand', title = i18n.t('table.tit
   }
 }
 
-export const getStatusTableColumn = ({ field = 'status', title = i18n.t('common.status'), statusModule, sortable = true, minWidth = 80, slotCallback } = {}) => {
+export const getStatusTableColumn = ({ vm = {}, field = 'status', title = i18n.t('common.status'), statusModule, sortable = true, minWidth = 120, slotCallback } = {}) => {
   return {
     field,
     title,
@@ -119,9 +119,12 @@ export const getStatusTableColumn = ({ field = 'status', title = i18n.t('common.
         if (!statusModule) return 'status module undefined'
         const val = _.get(row, field) || false
         if (R.isNil(val) || !_.get(row, field)) return '-'
+        const log = <side-page-trigger class="ml-1" onTrigger={ () => vm.handleOpenSidepage(row, 'event-drawer') }>{ i18n.t('common.view_logs') }</side-page-trigger>
+        const isError = ['invalid', 'unknown'].includes(row.status) || /failed|fail$/.test(row.status)
         return [
-          <div class='text-truncate'>
+          <div class='d-flex align-items-center text-truncate'>
             <status status={ val } statusModule={ statusModule } />
+            { isError ? log : null }
           </div>,
         ]
       },


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- feat(3735):  主机模块状态为失败时，增加查看日志的快捷入口

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
