### PR TITLE
feat(3735): 网络模块状态为失败时，增加查看日志的快捷入口

### DIFF
--- a/containers/Network/views/cdn/components/List.vue
+++ b/containers/Network/views/cdn/components/List.vue
@@ -220,13 +220,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'CDNSidePage', {
         id: row.id,
         resource: 'cdn_domains',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Network/views/cdn/mixins/columns.js
+++ b/containers/Network/views/cdn/mixins/columns.js
@@ -86,7 +86,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'cdnDomain' }),
+      getStatusTableColumn({ statusModule: 'cdnDomain', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'cdn_domains', columns: () => this.columns }),
       getAreaColumn({}),
       getCnameTableColumn({}),

--- a/containers/Network/views/dns-zone/components/List.vue
+++ b/containers/Network/views/dns-zone/components/List.vue
@@ -172,12 +172,13 @@ export default {
     }, false)
   },
   methods: {
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'DnsZoneSidePage', {
         id: row.id,
         resource: 'dns_zones',
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Network/views/dns-zone/mixins/columns.js
+++ b/containers/Network/views/dns-zone/mixins/columns.js
@@ -37,7 +37,7 @@ export default {
       getZoneTypeTableColumns(),
       getDnsRecordsetCountTableColumns(),
       getVpcCountTableColumns(),
-      getStatusTableColumn({ statusModule: 'dnszone' }),
+      getStatusTableColumn({ statusModule: 'dnszone', vm: this }),
       getPublicScopeTableColumn({ vm: this, resource: 'dns_zones' }),
       getProjectDomainTableColumn(),
       getTimeTableColumn(),

--- a/containers/Network/views/eip/components/List.vue
+++ b/containers/Network/views/eip/components/List.vue
@@ -218,7 +218,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.initSidePageTab('eip-detail')
       this.sidePageTriggerHandle(this, 'EipSidePage', {
         id: row.id,
@@ -228,7 +228,7 @@ export default {
       }, {
         list: this.list,
         hiddenColumns: this.hiddenColumns,
-        tab: 'eip-detail',
+        tab,
       })
     },
     defaultSearchKey (search) {

--- a/containers/Network/views/eip/mixins/columns.js
+++ b/containers/Network/views/eip/mixins/columns.js
@@ -23,7 +23,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'eip' }),
+      getStatusTableColumn({ statusModule: 'eip', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'eips', columns: () => this.columns }),
       {
         field: 'ip_addr',

--- a/containers/Network/views/global-vpc/components/List.vue
+++ b/containers/Network/views/global-vpc/components/List.vue
@@ -202,13 +202,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'globalVpcSidePage', {
         id: row.id,
         resource: 'globalvpcs',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Network/views/global-vpc/mixins/columns.js
+++ b/containers/Network/views/global-vpc/mixins/columns.js
@@ -23,7 +23,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'globalVpc' }),
+      getStatusTableColumn({ statusModule: 'globalVpc', vm: this }),
       getTagTableColumn({ onManager: this.onManager, resource: 'network_globalvpcs', columns: () => this.columns, tipName: this.$t('dictionary.globalvpc') }),
       getBrandTableColumn(),
       {

--- a/containers/Network/views/ipv6-gateway/components/List.vue
+++ b/containers/Network/views/ipv6-gateway/components/List.vue
@@ -93,7 +93,7 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'Ipv6GatewaySidePage', {
         id: row.id,
         resource: 'ipv6_gateways',
@@ -104,6 +104,7 @@ export default {
       }, {
         row: row,
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Network/views/ipv6-gateway/mixins/columns.js
+++ b/containers/Network/views/ipv6-gateway/mixins/columns.js
@@ -23,7 +23,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'ipv6_gateway', title: i18n.t('network.text_27') }),
+      getStatusTableColumn({ statusModule: 'ipv6_gateway', title: i18n.t('network.text_27'), vm: this }),
       {
         field: 'vpc',
         title: 'VPC',

--- a/containers/Network/views/lb/components/List.vue
+++ b/containers/Network/views/lb/components/List.vue
@@ -375,7 +375,7 @@ export default {
       }
       return false
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'LbSidePage', {
         id: row.id,
         resource: 'loadbalancers',
@@ -386,6 +386,7 @@ export default {
       }, {
         row: row,
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Network/views/lb/mixins/columns.js
+++ b/containers/Network/views/lb/mixins/columns.js
@@ -28,7 +28,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'lb', title: i18n.t('network.text_27') }),
+      getStatusTableColumn({ statusModule: 'lb', title: i18n.t('network.text_27'), vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'lb_loadbalancers', columns: () => this.columns }),
       {
         field: 'address',

--- a/containers/Network/views/nats/components/List.vue
+++ b/containers/Network/views/nats/components/List.vue
@@ -371,13 +371,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'NatSidePage', {
         id: row.id,
         resource: 'natgateways',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Network/views/nats/mixins/columns.js
+++ b/containers/Network/views/nats/mixins/columns.js
@@ -46,7 +46,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'nat' }),
+      getStatusTableColumn({ statusModule: 'nat', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'natgateways', columns: () => this.columns }),
       getNatSpecColumn({}),
       getBillingTableColumn({ vm: this }),

--- a/containers/Network/views/network/components/List.vue
+++ b/containers/Network/views/network/components/List.vue
@@ -602,7 +602,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'NetworkSidePage', {
         id: row.id,
         resource: 'networks',
@@ -611,6 +611,7 @@ export default {
         list: this.list,
         hiddenActions: this.hiddenActions,
         hiddenColumns: this.hiddenColumns,
+        tab,
       })
     },
     defaultSearchKey (search) {

--- a/containers/Network/views/network/mixins/columns.js
+++ b/containers/Network/views/network/mixins/columns.js
@@ -50,7 +50,7 @@ export default {
           },
         },
       },
-      getStatusTableColumn({ statusModule: 'network' }),
+      getStatusTableColumn({ statusModule: 'network', vm: this }),
       getTagTableColumn({
         onManager: this.onManager,
         needExt: true,

--- a/containers/Network/views/route-table/components/List.vue
+++ b/containers/Network/views/route-table/components/List.vue
@@ -101,13 +101,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'RouteTableSidePage', {
         id: row.id,
         resource: 'route_tables',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Network/views/route-table/mixins/columns.js
+++ b/containers/Network/views/route-table/mixins/columns.js
@@ -22,7 +22,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'routeTable' }),
+      getStatusTableColumn({ statusModule: 'routeTable', vm: this }),
       getVpcTableColumn(this),
       getBrandTableColumn({
         hidden: () => this.hiddenColumns.includes('brand'),

--- a/containers/Network/views/vpc-network/components/List.vue
+++ b/containers/Network/views/vpc-network/components/List.vue
@@ -147,13 +147,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'VpcNetworkSidePage', {
         id: row.id,
         resource: 'inter_vpc_networks',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Network/views/vpc-network/mixins/columns.js
+++ b/containers/Network/views/vpc-network/mixins/columns.js
@@ -18,7 +18,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'vpcNetwork' }),
+      getStatusTableColumn({ statusModule: 'vpcNetwork', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'inter_vpc_networks', columns: () => this.columns }),
       {
         field: 'vpc_count',

--- a/containers/Network/views/vpc-peer-connect/components/List.vue
+++ b/containers/Network/views/vpc-peer-connect/components/List.vue
@@ -156,13 +156,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'VpcPeerConnectSidePage', {
         id: row.id,
         resource: 'vpc_peering_connections',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Network/views/vpc-peer-connect/mixins/columns.js
+++ b/containers/Network/views/vpc-peer-connect/mixins/columns.js
@@ -24,7 +24,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'vpcPeerConnect' }),
+      getStatusTableColumn({ statusModule: 'vpcPeerConnect', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'vpc_peering_connections', columns: () => this.columns }),
       getVpcTableColumn(this),
       getPeerVpcTableColumn(),

--- a/containers/Network/views/vpc/components/List.vue
+++ b/containers/Network/views/vpc/components/List.vue
@@ -299,7 +299,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'VpcSidePage', {
         id: row.id,
         resource: 'vpcs',
@@ -308,6 +308,7 @@ export default {
         list: this.list,
         hiddenActions: this.hiddenActions,
         hiddenColumns: this.hiddenColumns,
+        tab,
       })
     },
     defaultSearchKey (search) {

--- a/containers/Network/views/vpc/mixins/columns.js
+++ b/containers/Network/views/vpc/mixins/columns.js
@@ -24,7 +24,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'vpc' }),
+      getStatusTableColumn({ statusModule: 'vpc', vm: this }),
       getTagTableColumn({
         onManager: this.onManager,
         needExt: true,

--- a/containers/Network/views/waf/components/List.vue
+++ b/containers/Network/views/waf/components/List.vue
@@ -134,6 +134,7 @@ export default {
         refresh: this.refresh,
       }, {
         list: this.list,
+        tab,
       })
       this.initSidePageTab(tab)
     },

--- a/containers/Network/views/waf/mixins/columns.js
+++ b/containers/Network/views/waf/mixins/columns.js
@@ -25,7 +25,7 @@ export default {
         },
       }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'waf_instances', columns: () => this.columns, tipName: this.$t('network.waf') }),
-      getStatusTableColumn({ statusModule: 'waf' }),
+      getStatusTableColumn({ statusModule: 'waf', vm: this }),
       {
         field: 'type',
         title: i18n.t('network.waf.type'),

--- a/containers/Network/views/wire/components/List.vue
+++ b/containers/Network/views/wire/components/List.vue
@@ -297,13 +297,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'WireSidePage', {
         id: row.id,
         resource: 'wires',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Network/views/wire/mixins/columns.js
+++ b/containers/Network/views/wire/mixins/columns.js
@@ -24,7 +24,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'wire' }),
+      getStatusTableColumn({ statusModule: 'wire', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'wires', columns: () => this.columns }),
       getBandwidthTableColumn(),
       getCopyWithContentTableColumn({ field: 'vpc', title: 'VPC', sortable: true }),

--- a/src/utils/common/tableColumn.js
+++ b/src/utils/common/tableColumn.js
@@ -120,7 +120,7 @@ export const getStatusTableColumn = ({ vm = {}, field = 'status', title = i18n.t
         const val = _.get(row, field) || false
         if (R.isNil(val) || !_.get(row, field)) return '-'
         const log = <side-page-trigger class="ml-1" onTrigger={ () => vm.handleOpenSidepage(row, 'event-drawer') }>{ i18n.t('common.view_logs') }</side-page-trigger>
-        const isError = ['invalid', 'unknown'].includes(row.status) || /failed|fail$/.test(row.status)
+        const isError = ['invalid', 'unknown'].includes(val) || /failed|fail$/.test(val)
         return [
           <div class='d-flex align-items-center text-truncate'>
             <status status={ val } statusModule={ statusModule } />


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- feat(3735): 网络模块状态为失败时，增加查看日志的快捷入口

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.8
