### PR TITLE
feat(storage#3735): 存储模块状态为失败时，增加查看日志的快捷入口

### DIFF
--- a/containers/Storage/views/access-group/components/List.vue
+++ b/containers/Storage/views/access-group/components/List.vue
@@ -137,13 +137,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'AccessGroupSidePage', {
         id: row.id,
         resource: 'access_groups',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Storage/views/access-group/mixins/columns.js
+++ b/containers/Storage/views/access-group/mixins/columns.js
@@ -61,7 +61,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'accessGroup' }),
+      getStatusTableColumn({ statusModule: 'accessGroup', vm: this }),
       getPublicScopeTableColumn({ vm: this, resource: 'access_groups' }),
       getProjectDomainTableColumn(),
       getTimeTableColumn(),

--- a/containers/Storage/views/backup-storage/components/List.vue
+++ b/containers/Storage/views/backup-storage/components/List.vue
@@ -198,7 +198,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'BackupStorageSidePage', {
         id: row.id,
         resource: 'backupstorages',
@@ -206,6 +206,7 @@ export default {
         steadyStatus: this.list.steadyStatus,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Storage/views/backup-storage/mixins/columns.js
+++ b/containers/Storage/views/backup-storage/mixins/columns.js
@@ -24,7 +24,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'backupStorage' }),
+      getStatusTableColumn({ statusModule: 'backupStorage', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'backupstorages', columns: () => this.columns }),
       getStorageTypeColumns(),
       // getCapacityMbColumns(),

--- a/containers/Storage/views/blockstorage/components/List.vue
+++ b/containers/Storage/views/blockstorage/components/List.vue
@@ -308,16 +308,6 @@ export default {
           { label: this.$t('common.createdAt'), key: 'created_at' },
         ],
       },
-      handleOpenSidepage (row, tab) {
-        this.sidePageTriggerHandle(this, 'BlockStorageSidePage', {
-          id: row.id,
-          resource: 'storages',
-          getParams: this.getParam,
-        }, {
-          list: this.list,
-          tab,
-        })
-      },
     }
   },
   watch: {
@@ -343,6 +333,16 @@ export default {
         is_baremetal: this.cloudEnv === 'baremetal',
       }
       return ret
+    },
+    handleOpenSidepage (row, tab) {
+      this.sidePageTriggerHandle(this, 'BlockStorageSidePage', {
+        id: row.id,
+        resource: 'storages',
+        getParams: this.getParam,
+      }, {
+        list: this.list,
+        tab,
+      })
     },
   },
 }

--- a/containers/Storage/views/blockstorage/mixins/columns.js
+++ b/containers/Storage/views/blockstorage/mixins/columns.js
@@ -20,7 +20,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'blockstorage' }),
+      getStatusTableColumn({ statusModule: 'blockstorage', vm: this }),
       getEnabledTableColumn(),
       getTagTableColumn({
         onManager: this.onManager,

--- a/containers/Storage/views/bucket/components/List.vue
+++ b/containers/Storage/views/bucket/components/List.vue
@@ -284,7 +284,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'BucketStorageSidePage', {
         id: row.id,
         resource: 'buckets',
@@ -294,6 +294,7 @@ export default {
         cancel: () => {
           this.list.singleRefresh(row.id, Object.values(expectStatus.bucket).flat())
         },
+        tab,
       })
     },
   },

--- a/containers/Storage/views/bucket/mixins/columns.js
+++ b/containers/Storage/views/bucket/mixins/columns.js
@@ -19,7 +19,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'bucket' }),
+      getStatusTableColumn({ statusModule: 'bucket', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'buckets', columns: () => this.columns, tipName: this.$t('dictionary.bucket') }),
       {
         field: 'storage_class',

--- a/containers/Storage/views/file-system/components/List.vue
+++ b/containers/Storage/views/file-system/components/List.vue
@@ -197,13 +197,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'FileSystemSidePage', {
         id: row.id,
         resource: 'file_systems',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Storage/views/file-system/mixins/columns.js
+++ b/containers/Storage/views/file-system/mixins/columns.js
@@ -95,7 +95,7 @@ export default {
         },
       }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'file_systems', columns: () => this.columns }),
-      getStatusTableColumn({ statusModule: 'nas' }),
+      getStatusTableColumn({ statusModule: 'nas', vm: this }),
       getFileSystemTypeColumn(),
       getFileSystemStorageTypeColumn(),
       getFileSystemProtocolColumn(),

--- a/containers/Storage/views/tablestore/components/List.vue
+++ b/containers/Storage/views/tablestore/components/List.vue
@@ -107,7 +107,7 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'TablestoreSidePage', {
         id: row.id,
         resource: 'tablestores',
@@ -115,6 +115,7 @@ export default {
         steadyStatus: this.list.steadyStatus,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Storage/views/tablestore/mixins/columns.js
+++ b/containers/Storage/views/tablestore/mixins/columns.js
@@ -15,7 +15,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'tablestore' }),
+      getStatusTableColumn({ statusModule: 'tablestore', vm: this }),
       // {
       //   field: 'spec',
       //   title: i18n.t('storage.spec'),


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- feat(storage#3735): 存储模块状态为失败时，增加查看日志的快捷入口

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.8