### PR TITLE
Automated cherry pick of #3896: feat(storage#3735): 存储模块状态为失败时，增加查看日志的快捷入口

### DIFF
--- a/containers/Storage/views/access-group/components/List.vue
+++ b/containers/Storage/views/access-group/components/List.vue
@@ -136,13 +136,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'AccessGroupSidePage', {
         id: row.id,
         resource: 'access_groups',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Storage/views/access-group/mixins/columns.js
+++ b/containers/Storage/views/access-group/mixins/columns.js
@@ -61,7 +61,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'accessGroup' }),
+      getStatusTableColumn({ statusModule: 'accessGroup', vm: this }),
       getPublicScopeTableColumn({ vm: this, resource: 'access_groups' }),
       getProjectDomainTableColumn(),
       getTimeTableColumn(),

--- a/containers/Storage/views/blockstorage/components/List.vue
+++ b/containers/Storage/views/blockstorage/components/List.vue
@@ -238,16 +238,6 @@ export default {
           { label: this.$t('common.createdAt'), key: 'created_at' },
         ],
       },
-      handleOpenSidepage (row, tab) {
-        this.sidePageTriggerHandle(this, 'BlockStorageSidePage', {
-          id: row.id,
-          resource: 'storages',
-          getParams: this.getParam,
-        }, {
-          list: this.list,
-          tab,
-        })
-      },
     }
   },
   watch: {
@@ -273,6 +263,16 @@ export default {
         is_baremetal: this.cloudEnv === 'baremetal',
       }
       return ret
+    },
+    handleOpenSidepage (row, tab) {
+      this.sidePageTriggerHandle(this, 'BlockStorageSidePage', {
+        id: row.id,
+        resource: 'storages',
+        getParams: this.getParam,
+      }, {
+        list: this.list,
+        tab,
+      })
     },
   },
 }

--- a/containers/Storage/views/blockstorage/mixins/columns.js
+++ b/containers/Storage/views/blockstorage/mixins/columns.js
@@ -20,7 +20,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'blockstorage' }),
+      getStatusTableColumn({ statusModule: 'blockstorage', vm: this }),
       getEnabledTableColumn(),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'storage', columns: () => this.columns, tipName: this.$t('dictionary.blockstorage') }),
       {

--- a/containers/Storage/views/bucket/components/List.vue
+++ b/containers/Storage/views/bucket/components/List.vue
@@ -273,7 +273,7 @@ export default {
       if (this.cloudEnv) ret.cloud_env = this.cloudEnv
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'BucketStorageSidePage', {
         id: row.id,
         resource: 'buckets',
@@ -283,6 +283,7 @@ export default {
         cancel: () => {
           this.list.singleRefresh(row.id, Object.values(expectStatus.bucket).flat())
         },
+        tab,
       })
     },
   },

--- a/containers/Storage/views/bucket/mixins/columns.js
+++ b/containers/Storage/views/bucket/mixins/columns.js
@@ -19,8 +19,8 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'bucket' }),
-      getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'bucket', columns: () => this.columns, tipName: this.$t('dictionary.bucket') }),
+      getStatusTableColumn({ statusModule: 'bucket', vm: this }),
+      getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'buckets', columns: () => this.columns, tipName: this.$t('dictionary.bucket') }),
       {
         field: 'storage_class',
         title: i18n.t('storage.text_38'),

--- a/containers/Storage/views/file-system/components/List.vue
+++ b/containers/Storage/views/file-system/components/List.vue
@@ -193,13 +193,14 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'FileSystemSidePage', {
         id: row.id,
         resource: 'file_systems',
         getParams: this.getParam,
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/Storage/views/file-system/mixins/columns.js
+++ b/containers/Storage/views/file-system/mixins/columns.js
@@ -94,8 +94,8 @@ export default {
           )
         },
       }),
-      getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'file_system', columns: () => this.columns }),
-      getStatusTableColumn({ statusModule: 'nas' }),
+      getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'file_systems', columns: () => this.columns }),
+      getStatusTableColumn({ statusModule: 'nas', vm: this }),
       getFileSystemTypeColumn(),
       getFileSystemStorageTypeColumn(),
       getFileSystemProtocolColumn(),


### PR DESCRIPTION
Cherry pick of #3896 on release/3.8.

#3896: feat(storage#3735): 存储模块状态为失败时，增加查看日志的快捷入口