### PR TITLE
feat(DB#3735): 数据库模块状态为失败时，增加查看日志的快捷入口

### DIFF
--- a/containers/DB/views/mongodb/components/List.vue
+++ b/containers/DB/views/mongodb/components/List.vue
@@ -192,7 +192,7 @@ export default {
       }
       return status
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'MongoDBSidePage', {
         id: row.id,
         resource: 'mongodbs',
@@ -202,6 +202,7 @@ export default {
         steadyStatus: Object.values(expectStatus.mongodb).flat(),
       }, {
         list: this.list,
+        tab,
       })
     },
     booleanTransfer (val) {

--- a/containers/DB/views/mongodb/mixins/columns.js
+++ b/containers/DB/views/mongodb/mixins/columns.js
@@ -18,7 +18,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'mongodb' }),
+      getStatusTableColumn({ statusModule: 'mongodb', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'mongodbs', columns: () => this.columns }),
       {
         field: 'instance_type',

--- a/containers/DB/views/rds/components/List.vue
+++ b/containers/DB/views/rds/components/List.vue
@@ -349,7 +349,7 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'RDSSidePage', {
         id: row.id,
         resource: 'dbinstances',
@@ -359,6 +359,7 @@ export default {
         steadyStatus: Object.values(expectStatus.rds).flat(),
       }, {
         list: this.list,
+        tab,
       })
     },
     refresh () {

--- a/containers/DB/views/rds/mixins/columns.js
+++ b/containers/DB/views/rds/mixins/columns.js
@@ -21,7 +21,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'rds' }),
+      getStatusTableColumn({ statusModule: 'rds', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'rds_dbinstances', columns: () => this.columns }),
       {
         field: 'category',

--- a/containers/DB/views/redis/components/List.vue
+++ b/containers/DB/views/redis/components/List.vue
@@ -397,7 +397,7 @@ export default {
       }
       return status
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'RedisSidePage', {
         id: row.id,
         resource: 'elasticcaches',
@@ -407,6 +407,7 @@ export default {
         steadyStatus: Object.values(expectStatus.redis).flat(),
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/DB/views/redis/mixins/columns.js
+++ b/containers/DB/views/redis/mixins/columns.js
@@ -18,7 +18,7 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'redis' }),
+      getStatusTableColumn({ statusModule: 'redis', vm: this }),
       getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'redis_elasticcaches', columns: () => this.columns }),
       {
         field: 'arch_type',


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- feat(DB#3735): 数据库模块状态为失败时，增加查看日志的快捷入口

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.8