### PR TITLE
Automated cherry pick of #3900: feat(DB#3735): 数据库模块状态为失败时，增加查看日志的快捷入口

### DIFF
--- a/containers/DB/views/mongodb/components/List.vue
+++ b/containers/DB/views/mongodb/components/List.vue
@@ -183,7 +183,7 @@ export default {
       }
       return status
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'MongoDBSidePage', {
         id: row.id,
         resource: 'mongodbs',
@@ -193,6 +193,7 @@ export default {
         steadyStatus: Object.values(expectStatus.mongodb).flat(),
       }, {
         list: this.list,
+        tab,
       })
     },
     booleanTransfer (val) {

--- a/containers/DB/views/mongodb/mixins/columns.js
+++ b/containers/DB/views/mongodb/mixins/columns.js
@@ -18,8 +18,8 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'mongodb' }),
-      getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'mongodb', columns: () => this.columns }),
+      getStatusTableColumn({ statusModule: 'mongodb', vm: this }),
+      getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'mongodbs', columns: () => this.columns }),
       {
         field: 'instance_type',
         title: this.$t('cloudenv.text_459'),

--- a/containers/DB/views/rds/components/List.vue
+++ b/containers/DB/views/rds/components/List.vue
@@ -318,7 +318,7 @@ export default {
       }
       return ret
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'RDSSidePage', {
         id: row.id,
         resource: 'dbinstances',
@@ -328,6 +328,7 @@ export default {
         steadyStatus: Object.values(expectStatus.rds).flat(),
       }, {
         list: this.list,
+        tab,
       })
     },
     refresh () {

--- a/containers/DB/views/rds/mixins/columns.js
+++ b/containers/DB/views/rds/mixins/columns.js
@@ -21,8 +21,8 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'rds' }),
-      getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'dbinstance', columns: () => this.columns }),
+      getStatusTableColumn({ statusModule: 'rds', vm: this }),
+      getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'rds_dbinstances', columns: () => this.columns }),
       {
         field: 'category',
         title: i18n.t('db.text_61'),

--- a/containers/DB/views/redis/components/List.vue
+++ b/containers/DB/views/redis/components/List.vue
@@ -357,7 +357,7 @@ export default {
       }
       return status
     },
-    handleOpenSidepage (row) {
+    handleOpenSidepage (row, tab) {
       this.sidePageTriggerHandle(this, 'RedisSidePage', {
         id: row.id,
         resource: 'elasticcaches',
@@ -367,6 +367,7 @@ export default {
         steadyStatus: Object.values(expectStatus.redis).flat(),
       }, {
         list: this.list,
+        tab,
       })
     },
   },

--- a/containers/DB/views/redis/mixins/columns.js
+++ b/containers/DB/views/redis/mixins/columns.js
@@ -18,8 +18,8 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'redis' }),
-      getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'elasticcache', columns: () => this.columns }),
+      getStatusTableColumn({ statusModule: 'redis', vm: this }),
+      getTagTableColumn({ onManager: this.onManager, needExt: true, resource: 'redis_elasticcaches', columns: () => this.columns }),
       {
         field: 'arch_type',
         title: i18n.t('db.text_119'),


### PR DESCRIPTION
Cherry pick of #3900 on release/3.8.

#3900: feat(DB#3735): 数据库模块状态为失败时，增加查看日志的快捷入口