### PR TITLE
fix: cloudaccount details show account_id

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/sidepage/Detail.vue
+++ b/containers/Cloudenv/views/cloudaccount/sidepage/Detail.vue
@@ -80,6 +80,19 @@ export default {
           },
         },
         {
+          field: 'account_id',
+          title: this.$t('cloudenv.text_94') + 'ID',
+          slots: {
+            default: ({ row }) => {
+              return [
+                <div class='text-truncate'>
+                  <list-body-cell-wrap copy row={ row } field='account_id' title={ row.account_id } />
+                </div>,
+              ]
+            },
+          },
+        },
+        {
           field: 'proxy_setting.name',
           title: this.$t('cloudenv.text_14'),
           slots: {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: cloudaccount details show account_id
<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @easy-mj 