### PR TITLE
Automated cherry pick of #3924: fix: cloudaccount details show account_id

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/sidepage/Detail.vue
+++ b/containers/Cloudenv/views/cloudaccount/sidepage/Detail.vue
@@ -83,6 +83,19 @@ export default {
           },
         },
         {
+          field: 'account_id',
+          title: this.$t('cloudenv.text_94') + 'ID',
+          slots: {
+            default: ({ row }) => {
+              return [
+                <div class='text-truncate'>
+                  <list-body-cell-wrap copy row={ row } field='account_id' title={ row.account_id } />
+                </div>,
+              ]
+            },
+          },
+        },
+        {
           field: 'proxy_setting.name',
           title: this.$t('cloudenv.text_14'),
           slots: {


### PR DESCRIPTION
Cherry pick of #3924 on release/3.10.

#3924: fix: cloudaccount details show account_id