### PR TITLE
Automated cherry pick of #3956: fix(scope): use monitorresourcealerts api

### DIFF
--- a/scope/store/modules/app.js
+++ b/scope/store/modules/app.js
@@ -93,7 +93,7 @@ export default {
     fetchAlertingrecords ({ commit, rootGetters }, payload) {
       const params = { scope: rootGetters.scope, limit: 20, alerting: true, $t: getRequestT() }
       return new Promise((resolve, reject) => {
-        http.get('/v1/alertrecords', { params }).then(response => {
+        http.get('/v1/monitorresourcealerts', { params }).then(response => {
           const data = response.data || {}
           commit('SET_ALERTRECORDS', data)
           resolve(data)


### PR DESCRIPTION
Cherry pick of #3956 on release/3.8.

#3956: fix(scope): use monitorresourcealerts api