### PR TITLE
feat: #4086 账单汇总订阅新增账单数据范围和新通知类型角色

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5428,5 +5428,16 @@
   "common.staticstics.status.other": "Other",
   "common.staticstics.status.online": "Online",
   "common.staticstics.status.offline": "Offline",
-  "common.staticstics.status.unmount": "To be mounted"
+  "common.staticstics.status.unmount": "To be mounted",
+  "common.rangescope.system": "System overall data",
+  "common.rangescope.any_domain": "Data for each domain",
+  "common.rangescope.domain": "Specify domain data",
+  "common.rangescope.domain.all": "Domain overall data",
+  "common.rangescope.any_project": "Data for each project",
+  "common.rangescope.any_project_in_domain": "All project data under the specified domain",
+  "common.rangescope.project": "Specify project data",
+  "common.rangescope.project.all": "Project overall data",
+  "common.billing_scope": "Billing data scope",
+  "common.notify_type": "Notify Type",
+  "common.notify_type.receiver": "Subscription receiver"
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -5451,5 +5451,16 @@
   "common.staticstics.status.other": "其它",
   "common.staticstics.status.online": "在线",
   "common.staticstics.status.offline": "离线",
-  "common.staticstics.status.unmount": "待挂载"
+  "common.staticstics.status.unmount": "待挂载",
+  "common.rangescope.system": "系统整体数据",
+  "common.rangescope.any_domain": "各域数据",
+  "common.rangescope.domain": "指定域数据",
+  "common.rangescope.domain.all": "域整体数据",
+  "common.rangescope.any_project": "各项目数据",
+  "common.rangescope.any_project_in_domain": "指定域下全部项目数据",
+  "common.rangescope.project": "指定项目数据",
+  "common.rangescope.project.all": "项目整体数据",
+  "common.billing_scope": "账单数据范围",
+  "common.notify_type": "通知类型",
+  "common.notify_type.receiver": "订阅接收人"
 }

--- a/src/sections/RangeScope/index.vue
+++ b/src/sections/RangeScope/index.vue
@@ -1,0 +1,206 @@
+<template>
+  <div>
+    <a-radio-group v-model="range_scope" @change="billingScopeChangeHandler">
+      <a-radio-button
+        v-for="item in rangeScopeOptions"
+        :value="item.value"
+        :key="item.value">{{ item.label }}</a-radio-button>
+    </a-radio-group>
+    <!-- 域选择 -->
+    <a-select
+      v-if="isShowDomainSelect"
+      v-model="domain_id"
+      :loading="domainLoading"
+      :disabled="domainLoading"
+      style="width: 100%"
+      show-search
+      option-filter-prop="children"
+      :filter-option="filterDomainOption"
+      @search="handleDomainSearch"
+      @change="domainChangeHandler">
+      <a-select-option v-for="item in domainOptions" :value="item.value" :key="item.value">{{ item.label }}</a-select-option>
+    </a-select>
+    <!-- 项目选择 -->
+    <a-select
+      v-if="isShowProjectSelect"
+      v-model="project_id"
+      :loading="projectLoading"
+      :disabled="projectLoading"
+      style="width: 100%"
+      show-search
+      option-filter-prop="children"
+      :filter-option="filterProjectOption"
+      @search="handleDomainSearch"
+      @change="projectChangeHandler">
+      <a-select-option v-for="item in projectOptions" :value="item.value" :key="item.value">
+        <div class="d-flex">
+          <span class="text-truncate flex-fill mr-2" :title="item.label">{{ item.label }}</span>
+          <span style="color: #8492a6; font-size: 13px" v-if="isAdminMode && l3PermissionEnable">
+            {{ $t('common_257') }}{{ $t('dictionary.domain') }}: {{ item.project_domain }}
+          </span>
+        </div>
+      </a-select-option>
+    </a-select>
+  </div>
+</template>
+
+<script>
+import _ from 'lodash'
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'RangeScope',
+  props: {
+    value: {
+      type: Object,
+    },
+    subscriptionScope: {
+      type: String,
+      default: 'system',
+    },
+  },
+  data () {
+    const value = this.value || {}
+    return {
+      range_scope: value.range_scope,
+      domain_id: value.domain_id,
+      project_id: value.project_id,
+      domainOptions: [],
+      domainLoading: false,
+      domainLoaded: true,
+      projectOptions: [],
+      projectLoading: false,
+      projectLoaded: true,
+    }
+  },
+  computed: {
+    ...mapGetters(['l3PermissionEnable', 'scope', 'isAdminMode', 'userInfo']),
+    rangeScopeOptions () {
+      const domainLabel = this.subscriptionScope === 'domain' ? this.$t('common.rangescope.domain.all') : this.$t('common.rangescope.domain')
+      const projectLabel = this.subscriptionScope === 'project' ? this.$t('common.rangescope.project.all') : this.$t('common.rangescope.project')
+      const options = [
+        { label: this.$t('common.rangescope.system'), value: 'system', scope: ['system'] },
+        { label: this.$t('common.rangescope.any_domain'), value: 'any_domain', scope: ['system'] },
+        { label: domainLabel, value: 'domain', scope: ['system', 'domain'] },
+        { label: this.$t('common.rangescope.any_project'), value: 'any_project', scope: ['system', 'domain'] },
+        { label: this.$t('common.rangescope.any_project_in_domain'), value: 'any_project_in_domain', scope: ['system'] },
+        { label: projectLabel, value: 'project', scope: ['system', 'domain', 'project'] },
+      ]
+      return options.filter(item => item.scope.includes(this.subscriptionScope))
+    },
+    isShowDomainSelect () {
+      return this.l3PermissionEnable &&
+      ['domain', 'any_project_in_domain'].includes(this.range_scope) &&
+      this.subscriptionScope === 'system'
+    },
+    isShowProjectSelect () {
+      return this.range_scope === 'project' && this.subscriptionScope !== 'project'
+    },
+  },
+  watch: {
+    value (val = {}) {
+      this.range_scope = val.range_scope
+      this.domain_id = val.domain_id
+      this.project_id = val.project_id
+    },
+    subscriptionScope (val) {
+      this.range_scope = val
+      this.triggerChange({ range_scope: val })
+    },
+  },
+  created () {
+    this.dm = new this.$Manager('domains', 'v1')
+    this.pm = new this.$Manager('projects', 'v1')
+    this.initData()
+  },
+  methods: {
+    initData () {
+      this.initDomainData((data) => {
+        if (data && data.length > 0) {
+          this.domainOptions = data
+          const domain_id = this.userInfo.projectDomainId
+          this.domain_id = domain_id
+          this.triggerChange({ domain_id })
+        }
+      })
+      this.initProjectData((data) => {
+        if (data && data.length > 0) {
+          this.projectOptions = data
+          const project_id = this.userInfo.projectId
+          this.project_id = project_id
+          this.triggerChange({ project_id })
+        }
+      })
+    },
+    async initDomainData (callback) {
+      this.domainLoading = true
+      this.domainLoaded = false
+      this.domainOptions = []
+
+      try {
+        const params = { limit: 0, scope: this.scope }
+        const response = await this.dm.list({ params })
+        const domainOptions = response.data.data.map(item => {
+          return {
+            label: item.name,
+            value: item.id,
+          }
+        })
+        this.domainLoaded = true
+        callback && callback(domainOptions)
+      } catch (error) {
+        throw error
+      } finally {
+        this.domainLoading = false
+      }
+    },
+    async initProjectData (callback) {
+      this.projectLoading = true
+      this.projectLoaded = false
+      this.projectOptions = []
+
+      try {
+        const params = { limit: 0, scope: this.scope }
+        const response = await this.pm.list({ params })
+        const projectOptions = response.data.data.map(item => {
+          return {
+            label: item.name,
+            value: item.id,
+            project_domain: item.project_domain,
+          }
+        })
+        this.projectLoaded = true
+        callback && callback(projectOptions)
+      } catch (error) {
+        throw error
+      } finally {
+        this.projectLoading = false
+      }
+    },
+    billingScopeChangeHandler (e) {
+      this.triggerChange({ range_scope: e.target.value })
+    },
+    domainChangeHandler (domain_id) {
+      this.triggerChange({ domain_id })
+    },
+    projectChangeHandler (project_id) {
+      this.triggerChange({ project_id })
+    },
+    triggerChange (changedValue) {
+      this.$emit('change', Object.assign({}, _.pick(this.$data, ['range_scope', 'domain_id', 'project_id']), changedValue))
+    },
+    filterDomainOption (input, option) {
+      return (
+        option.componentOptions.children[0].text.toLowerCase().indexOf(input.toLowerCase()) >= 0
+      )
+    },
+    filterProjectOption (input, option) {
+      return (
+        option.componentOptions.children[0].children[0].children[0].text.toLowerCase().indexOf(input.toLowerCase()) >= 0
+      )
+    },
+  },
+}
+</script>
+
+<style></style>


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- feat: #4086 账单汇总订阅新增账单数据范围和新通知类型角色

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.10
