### PR TITLE
fix: 账单汇总订阅归属选择域，数据范围选择域整体，设置其他域新建后最终都会归属到default域

### DIFF
--- a/src/sections/RangeScope/index.vue
+++ b/src/sections/RangeScope/index.vue
@@ -200,6 +200,25 @@ export default {
       }
     },
     billingScopeChangeHandler (e) {
+      if (e.target.value === 'project') {
+        this.initProjectData((data) => {
+          if (data && data.length > 0) {
+            this.projectOptions = data
+            const project_id = data[0].value
+            this.project_id = project_id
+            this.triggerChange({ project_id })
+          }
+        })
+      } else if (e.target.value === 'domain') {
+        this.initDomainData((data) => {
+          if (data && data.length > 0) {
+            this.domainOptions = data
+            const domain_id = data[0].value
+            this.domain_id = domain_id
+            this.triggerChange({ domain_id })
+          }
+        })
+      }
       this.triggerChange({ range_scope: e.target.value })
     },
     domainChangeHandler (domain_id) {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix: 账单汇总订阅归属选择域，数据范围选择域整体，设置其他域新建后最终都会归属到default域

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.10