### PR TITLE
feat: #4100 vmtransfer add manager filter for hosts

### DIFF
--- a/containers/Compute/views/vminstance/dialogs/Transfer.vue
+++ b/containers/Compute/views/vminstance/dialogs/Transfer.vue
@@ -166,6 +166,12 @@ export default {
     hostsParams () {
       let hostType = 'hypervisor'
       const hostIds = this.forcastData?.filtered_candidates?.map(v => v.id) || []
+      const managerIds = []
+      this.params.data.map(item => {
+        if (item.manager_id && !managerIds.includes(item.manager_id)) {
+          managerIds.push(item.manager_id)
+        }
+      })
 
       if (!this.isKvm) {
         hostType = this.firstData.hypervisor
@@ -183,7 +189,10 @@ export default {
         ret.project_domain = this.params.data[0].domain_id
       }
       if (hostIds && hostIds.length > 0) {
-        ret.filter = `id.notin(${hostIds.join(',')})`
+        ret.filter = [`id.notin(${hostIds.join(',')})`]
+      }
+      if (managerIds.length) {
+        ret.filter = [...(ret.filter || []), `manager_id.in(${managerIds.join(',')})`]
       }
       return ret
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

feat: #4100 vmtransfer add manager filter for hosts

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
- release/3.9
