### PR TITLE
Automated cherry pick of #4019: fix: 修复宿主机批量操作时无法操作，提示共享宿主机不支持该操作

### DIFF
--- a/containers/Compute/views/host/components/List.vue
+++ b/containers/Compute/views/host/components/List.vue
@@ -363,7 +363,7 @@ export default {
                       validate: false,
                       tooltip: null,
                     }
-                    if (ownerDomain) {
+                    if (!ownerDomain) {
                       ret.tooltip = this.$t('compute.host.cpu.revert.share')
                       return ret
                     }


### PR DESCRIPTION
Cherry pick of #4019 on release/3.10.

#4019: fix: 修复宿主机批量操作时无法操作，提示共享宿主机不支持该操作