### PR TITLE
fix: #8752 monitor exploer update pager when data refresh

### DIFF
--- a/containers/Monitor/sections/MonitorLine/index.vue
+++ b/containers/Monitor/sections/MonitorLine/index.vue
@@ -240,6 +240,9 @@ export default {
     yMax () {
       this.showThreshold()
     },
+    pager (val) {
+      this.curPager = Object.assign({}, val || { seriesIndex: 0, total: 0, limit: 10, page: 0 })
+    },
   },
   created () {
     this.colorHash = new ColorHash({


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: #8752 monitor exploer update pager when data refresh

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
- release/3.9
