### PR TITLE
Automated cherry pick of #4051: fix: cloudaccount sync_net_failed status

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -253,6 +253,7 @@
       "connected": "Connected",
       "disconnected": "Disconnected",
       "sync_network": "Probing network",
+      "sync_net_failed": "Probe network failed",
       "start_sync": "Start sync",
       "syncing": "Syncing",
       "sync_status": "Syncing",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -253,6 +253,7 @@
       "connected": "已连接",
       "disconnected": "连接断开",
       "sync_network": "探测网络",
+      "sync_net_failed": "探测网络失败",
       "start_sync": "开始同步",
       "syncing": "正在同步",
       "sync_status": "同步中",


### PR DESCRIPTION
Cherry pick of #4051 on release/3.10.

#4051: fix: cloudaccount sync_net_failed status