### PR TITLE
fix(8820): 删除主机的网卡时，主机状态一直在”部署中“，除非手动刷新列表

### DIFF
--- a/containers/Compute/views/vminstance/dialogs/DetachNetwork.vue
+++ b/containers/Compute/views/vminstance/dialogs/DetachNetwork.vue
@@ -15,6 +15,7 @@
 <script>
 import DialogMixin from '@/mixins/dialog'
 import WindowsMixin from '@/mixins/windows'
+import expectStatus from '@/constants/expectStatus'
 
 export default {
   name: 'VmDetachNetworkDialog',
@@ -49,7 +50,7 @@ export default {
         await this.doDetachSubmit()
         this.loading = false
         this.params.refresh()
-        this.$bus.$emit('VMInstanceListSingleUpdate', [this.params.data[0].guest_id])
+        this.$bus.$emit('VMInstanceListSingleRefresh', [this.params.data[0].guest_id, Object.values(expectStatus.server).flat()])
         this.cancelDialog()
       } catch (error) {
         this.loading = false


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix(8820): 删除主机的网卡时，主机状态一直在”部署中“，除非手动刷新列表

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- release/3.10
- release/3.9