### PR TITLE
Automated cherry pick of #4207: fix(8820): 删除主机的网卡时，主机状态一直在”部署中“，除非手动刷新列表

### DIFF
--- a/containers/Compute/views/vminstance/dialogs/DetachNetwork.vue
+++ b/containers/Compute/views/vminstance/dialogs/DetachNetwork.vue
@@ -15,6 +15,7 @@
 <script>
 import DialogMixin from '@/mixins/dialog'
 import WindowsMixin from '@/mixins/windows'
+import expectStatus from '@/constants/expectStatus'
 
 export default {
   name: 'VmDetachNetworkDialog',
@@ -49,7 +50,7 @@ export default {
         await this.doDetachSubmit()
         this.loading = false
         this.params.refresh()
-        this.$bus.$emit('VMInstanceListSingleUpdate', [this.params.data[0].guest_id])
+        this.$bus.$emit('VMInstanceListSingleRefresh', [this.params.data[0].guest_id, Object.values(expectStatus.server).flat()])
         this.cancelDialog()
       } catch (error) {
         this.loading = false


### PR DESCRIPTION
Cherry pick of #4207 on release/3.10.

#4207: fix(8820): 删除主机的网卡时，主机状态一直在”部署中“，除非手动刷新列表