### PR TITLE
fix: ignore tags which is not startwith user | ext

### DIFF
--- a/src/sections/TagSelect/index.vue
+++ b/src/sections/TagSelect/index.vue
@@ -268,7 +268,7 @@ export default {
         const isUserKey = item.key.startsWith('user:')
         const isExtKey = item.key.startsWith('ext:')
         if (this.ignoreKeys.length > 0 && this.ignoreKeys.includes(item.key)) continue
-        let temp
+        let temp = []
         if (isUserKey) {
           temp = userRet
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: ignore tags which is not startwith user | ext

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
- release/3.9
