### PR TITLE
Automated cherry pick of #4249: feat(4198): 打开宿主机详情透传设备页面时，也应该调用 probe-isolated-devices 刷新宿主机透传设备列表

### DIFF
--- a/containers/Compute/views/gpu/components/List.vue
+++ b/containers/Compute/views/gpu/components/List.vue
@@ -24,6 +24,7 @@ export default {
     getParams: {
       type: [Function, Object],
     },
+    resId: String,
   },
   data () {
     return {
@@ -179,7 +180,7 @@ export default {
     }
   },
   created () {
-    this.list.fetchData()
+    this.init()
   },
   methods: {
     getParam () {
@@ -201,6 +202,20 @@ export default {
       }, {
         list: this.list,
       })
+    },
+    async init () {
+      this.resId && await this.updateProbeIsolatedDevices()
+      await this.list.fetchData()
+    },
+    async updateProbeIsolatedDevices () {
+      try {
+        await new this.$Manager('hosts', 'v1').performAction({
+          id: this.resId,
+          action: 'probe-isolated-devices',
+        })
+      } catch (err) {
+        throw err
+      }
     },
   },
 }


### PR DESCRIPTION
Cherry pick of #4249 on release/3.10.

#4249: feat(4198): 打开宿主机详情透传设备页面时，也应该调用 probe-isolated-devices 刷新宿主机透传设备列表