### PR TITLE
Automated cherry pick of #4255: feat(4198): 打开虚拟机详情透传设备页面时，也应该调用 probe-isolated-devices 刷新透传设备列表

### DIFF
--- a/containers/Compute/views/gpu/components/List.vue
+++ b/containers/Compute/views/gpu/components/List.vue
@@ -25,6 +25,7 @@ export default {
       type: [Function, Object],
     },
     resId: String,
+    isServer: Boolean,
   },
   data () {
     return {
@@ -197,10 +198,22 @@ export default {
       })
     },
     async init () {
-      this.resId && await this.updateProbeIsolatedDevices()
+      if (this.resId) {
+        this.isServer ? await this.updateServerProbeIsolatedDevices() : await this.updateHostProbeIsolatedDevices()
+      }
       await this.list.fetchData()
     },
-    async updateProbeIsolatedDevices () {
+    async updateServerProbeIsolatedDevices () {
+      try {
+        await new this.$Manager('servers', 'v1').performAction({
+          id: this.resId,
+          action: 'probe-isolated-devices',
+        })
+      } catch (err) {
+        throw err
+      }
+    },
+    async updateHostProbeIsolatedDevices () {
       try {
         await new this.$Manager('hosts', 'v1').performAction({
           id: this.resId,

--- a/containers/Compute/views/vminstance/sidepage/index.vue
+++ b/containers/Compute/views/vminstance/sidepage/index.vue
@@ -27,6 +27,7 @@
       :on-manager="onManager"
       :show-create-action="false"
       :isPageDestroyed="isPageDestroyed"
+      :is-server="true"
       @refresh="refresh"
       @single-refresh="singleRefresh"
       @tab-change="handleTabChange" />


### PR DESCRIPTION
Cherry pick of #4255 on release/3.9.

#4255: feat(4198): 打开虚拟机详情透传设备页面时，也应该调用 probe-isolated-devices 刷新透传设备列表