### PR TITLE
fix(8841): image recovery restore guest images error

### DIFF
--- a/containers/Compute/views/image-recovery/components/List.vue
+++ b/containers/Compute/views/image-recovery/components/List.vue
@@ -82,6 +82,7 @@ export default {
               data: this.list.selectedItems,
               columns: this.columns,
               refresh: this.refresh,
+              cloudEnv: this.cloudEnv,
             })
           },
           meta: () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

fix(8841): image recovery restore guest images error

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
- release/3.9
