### PR TITLE
Automated cherry pick of #4309: fix: 创建虚机的时候镜像列表这里，镜像是非uefi的，展示成uefi的了

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -203,7 +203,7 @@ export default {
       }
       if (this.uefi) {
         const imageOpts = imageOptions.map((item) => {
-          if (item.properties && item.properties.uefi_support && item.properties.uefi_support !== 'true') {
+          if (!item.properties?.uefi_support || item.properties?.uefi_support === 'false') {
             return {
               ...item,
               hidden: true,

--- a/containers/Compute/sections/OsSelect/ImageSelectTemplate.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelectTemplate.vue
@@ -85,7 +85,7 @@ export default {
       const size = sizestr(img.size, 'B', 1024)
       const props = img.properties || (img.info ? img.info.properties : undefined)
       const arch = props && props.os_arch && props.os_arch === 'aarch64' ? this.$t('compute.cpu_arch.aarch64') : props?.os_arch || 'x86_64'
-      const bios = props && props.uefi_support ? 'UEFI' : 'BIOS'
+      const bios = props && (!props.uefi_support || props.uefi_support === 'false') ? 'BIOS' : 'UEFI'
       const part = props && props.partition_type ? props.partition_type.toUpperCase() : 'MBR'
       return `${size}|${arch}|${part}|${bios}`
     },


### PR DESCRIPTION
Cherry pick of #4309 on release/3.8.

#4309: fix: 创建虚机的时候镜像列表这里，镜像是非uefi的，展示成uefi的了