### PR TITLE
Automated cherry pick of #4318: fix: 配置vga的时候默认过滤uefi镜像，镜像选择默认值错误问题

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -268,6 +268,10 @@ export default {
       if (R.equals(val, oldVal)) return
       this.getImagesInfo()
     },
+    uefi (val, oldVal) {
+      if (R.equals(val, oldVal)) return
+      this.getImagesInfo()
+    },
   },
   created () {
     this.imagesM = new Manager('images', 'v1')
@@ -493,6 +497,9 @@ export default {
           })
         }
       } else {
+        if (this.uefi) {
+          images = images.filter(item => item.properties?.uefi_support && item.properties?.uefi_support !== 'false')
+        }
         if (this.imageType !== IMAGES_TYPE_MAP.snapshot.key) {
           images = images.filter(item => {
             let diskFormat = item.disk_format


### PR DESCRIPTION
Cherry pick of #4318 on release/3.10.

#4318: fix: 配置vga的时候默认过滤uefi镜像，镜像选择默认值错误问题