### PR TITLE
Automated cherry pick of #4365: fix: 修复HCS虚拟机详情数据盘展示为空问题

### DIFF
--- a/containers/Compute/constants/index.js
+++ b/containers/Compute/constants/index.js
@@ -835,6 +835,15 @@ export const STORAGE_TYPES = {
       sysMax: 1024,
       sort: 1,
     },
+    volume_type1: {
+      label: 'volume_type1',
+      value: 'volume_type1',
+      min: 10,
+      max: 32768,
+      sysMin: 20,
+      sysMax: 1024,
+      sort: 4,
+    },
   },
   openstack: {
     iscsi: {


### PR DESCRIPTION
Cherry pick of #4365 on release/3.10.

#4365: fix: 修复HCS虚拟机详情数据盘展示为空问题