### PR TITLE
fix(8869): 块存储详情页面前端展示存储类型为空

### DIFF
--- a/containers/Storage/views/blockstorage/sidepage/Detail.vue
+++ b/containers/Storage/views/blockstorage/sidepage/Detail.vue
@@ -67,7 +67,7 @@ export default {
           title: this.$t('storage.text_38'),
           slots: {
             default: ({ row }) => {
-              return STORAGE_TYPES[row.storage_type] || '-'
+              return STORAGE_TYPES[row.storage_type] || row.storage_type || '-'
             },
           },
         },


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix(8869): 块存储详情页面前端展示存储类型为空

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.10
- release/3.9