### PR TITLE
Automated cherry pick of #4379: fix(8869): 块存储详情页面前端展示存储类型为空

### DIFF
--- a/containers/Storage/views/blockstorage/sidepage/Detail.vue
+++ b/containers/Storage/views/blockstorage/sidepage/Detail.vue
@@ -67,7 +67,7 @@ export default {
           title: this.$t('storage.text_38'),
           slots: {
             default: ({ row }) => {
-              return STORAGE_TYPES[row.storage_type] || '-'
+              return STORAGE_TYPES[row.storage_type] || row.storage_type || '-'
             },
           },
         },


### PR DESCRIPTION
Cherry pick of #4379 on release/3.10.

#4379: fix(8869): 块存储详情页面前端展示存储类型为空