### PR TITLE
fix: vm adjust config data disk show empty when there is no sysdisk

### DIFF
--- a/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
+++ b/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
@@ -737,7 +737,8 @@ export default {
         }
       }
 
-      const { medium_type: dataDiskMedium } = this.selectedItem.disks_info[1] || {}
+      const dataDisks = this.selectedItem.disks_info.filter(item => item.disk_type === 'data')
+      const { medium_type: dataDiskMedium } = dataDisks[0] || {}
       this.$nextTick(() => {
         this.diskLoaded = true
         this.form.fc.setFieldsValue({ vcpu: this.form.fd.vcpu_count, vmem: this.form.fd.vmem })


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: vm adjust config data disk show empty when there is no sysdisk

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
- release/3.9
