### PR TITLE
Automated cherry pick of #4386: fix: vm adjust config data disk show empty when there is no sysdisk

### DIFF
--- a/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
+++ b/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
@@ -740,7 +740,8 @@ export default {
         }
       }
 
-      const { medium_type: dataDiskMedium } = this.selectedItem.disks_info[1] || {}
+      const dataDisks = this.selectedItem.disks_info.filter(item => item.disk_type === 'data')
+      const { medium_type: dataDiskMedium } = dataDisks[0] || {}
       this.$nextTick(() => {
         this.diskLoaded = true
         this.form.fc.setFieldsValue({ vcpu: this.form.fd.vcpu_count, vmem: this.form.fd.vmem })


### PR DESCRIPTION
Cherry pick of #4386 on release/3.10.

#4386: fix: vm adjust config data disk show empty when there is no sysdisk