### PR TITLE
fix(8873): vmware adjust config can't show data disk

### DIFF
--- a/containers/Compute/sections/DataDisk/index.vue
+++ b/containers/Compute/sections/DataDisk/index.vue
@@ -317,8 +317,9 @@ export default {
         }
       }
     },
-    defaultType () {
-      if (this.getHypervisor() === HYPERVISORS_MAP.esxi.key) {
+    defaultType (v, oldV) {
+      // vmware系统盘改变清空数据盘，忽略调整配置初始化的情况
+      if (this.getHypervisor() === HYPERVISORS_MAP.esxi.key && oldV) {
         this.dataDisks = []
       }
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

fix(8873): vmware adjust config can't show data disk

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
- release/3.9
