### PR TITLE
Automated cherry pick of #4494: fix(8945): 新建Proxmox云账号时端口默认值应该改为8006

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/create/form/components/Proxmox.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/Proxmox.vue
@@ -78,7 +78,7 @@ export default {
         port: [
           'port',
           {
-            initialValue: 443,
+            initialValue: 8006,
             rules: [
               { type: 'number', min: 0, max: 65535, message: this.$t('cloudenv.text_270'), trigger: 'blur', transform: (v) => parseFloat(v) },
             ],


### PR DESCRIPTION
Cherry pick of #4494 on release/3.10.

#4494: fix(8945): 新建Proxmox云账号时端口默认值应该改为8006