### PR TITLE
Automated cherry pick of #4564: fix(8968): 虚拟机转换失败状态应该为中文

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -168,7 +168,9 @@
       "live_migrating": "Migrating",
       "stopped": "Stopped",
       "on": "On",
-      "off": "Off"
+      "off": "Off",
+      "qga_exec_command_failed": "QGA execution failed",
+      "convert_failed": "Convert Failed"
     },
     "network": {
       "init": "Initialize",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -168,7 +168,9 @@
       "live_migrating": "迁移中",
       "stopped": "关机",
       "on": "运行中",
-      "off": "关机"
+      "off": "关机",
+      "qga_exec_command_failed": "QGA执行失败",
+      "convert_failed": "转换失败"
     },
     "network": {
       "init": "初始化",


### PR DESCRIPTION
Cherry pick of #4564 on release/3.10.

#4564: fix(8968): 虚拟机转换失败状态应该为中文