### PR TITLE
fix(8902): vminstance create log error "loadDefaultSelectOpts undefined"

### DIFF
--- a/src/sections/DomainProject/index.vue
+++ b/src/sections/DomainProject/index.vue
@@ -129,7 +129,7 @@ export default {
   },
   methods: {
     async initDefaultData () {
-      if (this.isAdminMode) { // 系统视图
+      if (this.isAdminMode && this.l3PermissionEnable) { // 系统视图
         let defaultDomain = { key: this.userInfo.projectDomainId, label: this.userInfo.projectDomain }
         const initialValue = _.get(this.decorators, 'domain[1].initialValue')
         if (R.is(Object, initialValue) && initialValue.key) {


### PR DESCRIPTION
**What this PR does / why we need it**:

三级权限未开启时，新建虚拟机报错：loadDefaultSelectOpts undefined

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
