### PR TITLE
fix(9013): 控制面板对应资源数据没有权限时右的跳转置灰

### DIFF
--- a/containers/Dashboard/extends/NumberCard/components/Server.vue
+++ b/containers/Dashboard/extends/NumberCard/components/Server.vue
@@ -9,7 +9,7 @@
         <div class="dashboard-card-header-right">
           <span v-if="showDebuggerInfo">{{ `${$t('dashboard.text_20')}: ${form.fd.usage_key}` }}</span>
           <slot name="actions" :handle-edit="handleEdit" />
-          <a class="ml-2" v-if="!edit && canShowEdit" @click="goPage">
+          <a class="ml-2" :style="{ color: isResDeny ? '#ccc' : '' }" v-if="!edit && canShowEdit" @click="goPage">
             <icon type="arrow-right" style="font-size:18px" />
           </a>
         </div>
@@ -45,11 +45,13 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import BaseDrawer from '@Dashboard/components/BaseDrawer'
 import QuotaConfig from '@Dashboard/sections/QuotaConfig'
 import { USAGE_CONFIG } from '@Dashboard/constants'
 import { load } from '@Dashboard/utils/cache'
 import { getRequestT } from '@/utils/utils'
+import { hasPermission } from '@/utils/auth'
 import mixin from './mixin'
 
 export default {
@@ -150,6 +152,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters(['permission']),
     usage () {
       const usage = (this.data && this.data[this.form.fd.usage_key]) || 0
       const ret = {
@@ -189,6 +192,15 @@ export default {
       const config = USAGE_CONFIG[this.currentUsageKey]
       if (config && config.canUseUserUnit) {
         return true
+      }
+      return false
+    },
+    isResDeny () {
+      const usage_key = this.params.usage_key
+      if (usage_key.endsWith('servers')) {
+        return !hasPermission({ key: 'servers_list', permissionData: this.permission })
+      } else if (usage_key.endsWith('hosts') || usage_key.endsWith('baremetals')) {
+        return !hasPermission({ key: 'hosts_list', permissionData: this.permission })
       }
       return false
     },

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -141,6 +141,8 @@ export function hasPermission ({
   key,
   // 资源数据
   resourceData,
+  // 权限数据
+  permissionData,
 }) {
   // 没有声明定义的权限key，默认认为有权限
   if (!key) return true
@@ -149,7 +151,8 @@ export function hasPermission ({
   const has = keys.every(item => {
     // 这里只判断无权限的情况
     // 获取当前的key对应的权限结果
-    const pArr = store.getters.permission && store.getters.permission[item]
+    const pData = permissionData || (store.getters.permission && store.getters.permission)
+    const pArr = pData[item]
     if (pArr && pArr.length > 0) {
       // 如果当前的权限的资源不包含此资源直接不显示
       if (!store.getters.currentScopeResource.includes(pArr[1])) return false


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix(9013): 控制面板对应资源数据没有权限时右的跳转置灰

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.9
