### PR TITLE
fix(9008): clear dashboard cache after logout

### DIFF
--- a/containers/Dashboard/utils/cache.js
+++ b/containers/Dashboard/utils/cache.js
@@ -36,6 +36,9 @@ export function load ({
     if (_queue[key]) {
       _queue[key].add(resolve, reject)
     } else {
+      // refresh 突破缓存限制
+      if (actionArgs.params) actionArgs.params.refresh = true
+      if (actionArgs.data) actionArgs.data.refresh = true
       _queue[key] = new Loader({ key, res, action, apiVersion, resolve, reject, actionArgs, resPath, useManager })
       setTimeout(() => {
         _queue[key] && _queue[key].load()

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -23,6 +23,7 @@ import {
 import { SCOPES_MAP } from '@/constants'
 import router from '@/router'
 import { removeKeyIgnoreCase, getKeyIgnoreCase } from '@/utils/utils'
+import { clear as clearDashboardCache } from '@Dashboard/utils/cache'
 
 const initialState = {
   scope: getScopeFromCookie() || 'project',
@@ -199,6 +200,9 @@ export default {
       setLoggedUsersInStorage({})
       state.loggedUsers = {}
     },
+    CLEAR_DASHBOARD_CACHE () {
+      clearDashboardCache()
+    },
   },
   getters: {
     // 是否切换到管理后台
@@ -327,6 +331,7 @@ export default {
         if (is_forget_login_user) {
           await commit('CLEAR_LOGGED_USERS')
         }
+        await commit('CLEAR_DASHBOARD_CACHE')
         return response.data
       } catch (error) {
         throw error


### PR DESCRIPTION
**What this PR does / why we need it**:

退出登录后，清空dashboard数据缓存

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
