### PR TITLE
Automated cherry pick of #4645: fix(9026): 新建用户时，如果管理员没有添加项目用户的权限，则不应该展示设置项目的下一页，否则会报错

### DIFF
--- a/containers/IAM/locales/en.json
+++ b/containers/IAM/locales/en.json
@@ -1004,5 +1004,6 @@
   "iam.notify.server_panicked": "Server Panicked",
   "iam.operation_object.alter_tips": "Please check the operation object carefully, you may not be able to log in to the console if you modify it incorrectly.",
   "iam.modify_sth": "Modify {0}",
-  "iam.domain_tag": "Domain tags"
+  "iam.domain_tag": "Domain tags",
+  "iam.disabled_join_project.tips": "Insufficient permissions, please click the skip button"
 }

--- a/containers/IAM/locales/zh-CN.json
+++ b/containers/IAM/locales/zh-CN.json
@@ -1007,5 +1007,6 @@
   "iam.notify.server_panicked": "虚拟机异常",
   "iam.operation_object.alter_tips": "请仔细核对操作对象，修改错误可能会无法登录控制台。",
   "iam.modify_sth": "修改{0}",
-  "iam.domain_tag": "域标签"
+  "iam.domain_tag": "域标签",
+  "iam.disabled_join_project.tips": "权限不足，请点击跳过按钮"
 }

--- a/containers/IAM/views/user/create/index.vue
+++ b/containers/IAM/views/user/create/index.vue
@@ -7,7 +7,13 @@
     </page-body>
     <page-footer>
       <template v-slot:right>
-        <a-button type="primary" size="large" :loading="loading" @click="handleSubmit">{{ createTxt }}</a-button>
+        <a-tooltip v-if="disabledJoinProject">
+          <template slot="title">
+            {{ this.$t('iam.disabled_join_project.tips') }}
+          </template>
+          <a-button type="primary" size="large" :loading="loading" :disabled="disabledJoinProject" @click="handleSubmit">{{ createTxt }}</a-button>
+        </a-tooltip>
+        <a-button v-else type="primary" size="large" :loading="loading" @click="handleSubmit">{{ createTxt }}</a-button>
         <a-button class="ml-2" size="large" @click="handleCancel">{{ cancelTxt }}</a-button>
       </template>
     </page-footer>
@@ -17,6 +23,7 @@
 <script>
 import { mapGetters } from 'vuex'
 import step from '@/mixins/step'
+import { hasPermission } from '@/utils/auth'
 import CreateUser from './form/CreateUser'
 import JoinProject from './form/JoinProject'
 
@@ -42,7 +49,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['isAdminMode', 'l3PermissionEnable', 'userInfo']),
+    ...mapGetters(['isAdminMode', 'l3PermissionEnable', 'userInfo', 'permission']),
     stepComponent () {
       return this.step.steps[this.step.currentStep].key
     },
@@ -55,6 +62,12 @@ export default {
     },
     createTxt () {
       return this.step.currentStep ? this.$t('system.text_498', []) : this.$t('common.create')
+    },
+    disabledJoinProject () {
+      if (this.step.currentStep === 1) {
+        return !hasPermission({ key: 'projects_perform_join', permissionData: this.permission })
+      }
+      return false
     },
   },
   created () {


### PR DESCRIPTION
Cherry pick of #4645 on release/3.10.

#4645: fix(9026): 新建用户时，如果管理员没有添加项目用户的权限，则不应该展示设置项目的下一页，否则会报错