### PR TITLE
fix(9035): tag filter value set default value ""

### DIFF
--- a/src/sections/TagSelect/index.vue
+++ b/src/sections/TagSelect/index.vue
@@ -99,7 +99,7 @@ import Clickoutside from '@/directives/clickoutside'
 import { getTagTitle, getTagValue } from '@/utils/common/tag'
 import i18n from '@/locales'
 
-const filterHandler = function (val, search) {
+const filterHandler = function (val = '', search) {
   if (val.includes(':')) {
     val = val.split(':')[1]
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

标签过滤 标签值增加默认值为空字符串，防止使用报错

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
