### PR TITLE
feat(4332): time duration show < 1s when start equals end

### DIFF
--- a/src/utils/common/tableColumn.js
+++ b/src/utils/common/tableColumn.js
@@ -665,7 +665,7 @@ export const getTimeDurationColumn = ({
       const end = row[end_field] ? moment(row[end_field]) : ''
       if (start && end) {
         const duration = parseInt(moment.duration(end.diff(start)) / 1000)
-        if (!duration) return '-'
+        if (!duration) return `< 1${i18n.t('common.second_unit')}`
         const h = parseInt(duration / (60 * 60))
         const m = parseInt((duration % (60 * 60)) / 60)
         const s = duration % 60


### PR DESCRIPTION
**What this PR does / why we need it**:

耗时当开始时间=结束时间时，展示为 < 1秒

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
