### PR TITLE
Automated cherry pick of #4663: fix(9032): name column extend formatter method for local export

### DIFF
--- a/src/utils/common/tableColumn.js
+++ b/src/utils/common/tableColumn.js
@@ -215,6 +215,7 @@ export const getNameDescriptionTableColumn = ({
   message,
   addEncrypt,
   label,
+  formatter,
 } = {}) => {
   return {
     field,
@@ -222,6 +223,7 @@ export const getNameDescriptionTableColumn = ({
     sortable,
     showOverflow: 'ellipsis',
     minWidth,
+    formatter,
     // fixed: 'left',
     slots: {
       default: ({ row }, h) => {


### PR DESCRIPTION
Cherry pick of #4663 on release/3.10.

#4663: fix(9032): name column extend formatter method for local export