### PR TITLE
Automated cherry pick of #4756: fix(9047): 认证源sql, ldap详情的认证类型locale缺失

### DIFF
--- a/containers/IAM/views/idp/sidepage/Detail.vue
+++ b/containers/IAM/views/idp/sidepage/Detail.vue
@@ -289,10 +289,12 @@ export default {
           title: this.$t('common_550'),
           hideField: true,
           message: (row) => {
-            return this.$t('idpTmplTitles.' + row.template) || row.template || '-'
+            const v = row.template || row.driver
+            return this.$t('idpTmplTitles')[v] ? this.$t(`idpTmplTitles.${v}`) : v || '-'
           },
           slotCallback: (row) => {
-            return this.$t('idpTmplTitles.' + row.template) || row.template || '-'
+            const v = row.template || row.driver
+            return this.$t('idpTmplTitles')[v] ? this.$t(`idpTmplTitles.${v}`) : v || '-'
           },
         }),
         {


### PR DESCRIPTION
Cherry pick of #4756 on release/3.10.

#4756: fix(9047): 认证源sql, ldap详情的认证类型locale缺失