### PR TITLE
Automated cherry pick of #4762: fix(9081): 兼容接口不存在total字段导致日志管理列表计数为0

### DIFF
--- a/src/components/PageList/index.vue
+++ b/src/components/PageList/index.vue
@@ -297,7 +297,7 @@ export default {
       return this.list.limit
     },
     total () {
-      return this.list.total
+      return this.list.total || Object.keys(this.data)?.length
     },
     offset () {
       return this.list.offset


### PR DESCRIPTION
Cherry pick of #4762 on release/3.10.

#4762: fix(9081): 兼容接口不存在total字段导致日志管理列表计数为0