### PR TITLE
fix: workflow attachment show info

### DIFF
--- a/src/views/workflow/components/ApplyInternalResource.vue
+++ b/src/views/workflow/components/ApplyInternalResource.vue
@@ -19,8 +19,9 @@
           <div class="detail-item-value">{{item.value}}</div>
         </div>
       </template>
-      <div class="detail-item mt-2" style="100%" v-if="attachmentList.length">
+      <div class="detail-item mt-2" style="100%">
         <div class="detail-item-title">{{$t('wz_workflow_form.labels.cloud_solution')}}</div>
+        <div class="detail-item-value" v-if="!attachmentList.length">-</div>
         <div class="detail-item-value">
           <div class="mb-2" v-for="item in attachmentList" :key="item.key">
             <a-button type="link" style="padding:0;height:16px" @click="handleDownload">{{item.name}}</a-button>


### PR DESCRIPTION
**What this PR does / why we need it**:

附件列表为空时仍展示字段

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
