### PR TITLE
fix: Login prompt timer setting upper limit time

### DIFF
--- a/src/mixins/logout.js
+++ b/src/mixins/logout.js
@@ -63,7 +63,7 @@ export default {
       const { exp } = tokenObj
       if (exp) {
         const time = new Date(exp).getTime() - new Date().getTime()
-        if (time > 0) {
+        if (time > 0 && time < 3 * 24 * 60 * 60 * 1000) {
           this.timeout = setTimeout(() => {
             this.createDialog('LoginDialog', {
               tokenExpTime: exp,


### PR DESCRIPTION
**What this PR does / why we need it**:

登录提示定时器设置上限时间，防止定时器失效

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
- release/3.9
