### PR TITLE
fix: openresource instance id empty

### DIFF
--- a/src/views/workflow/utils/columns.js
+++ b/src/views/workflow/utils/columns.js
@@ -123,7 +123,7 @@ const openResourceColumns = [
     field: 'instance_code',
     slots: {
       default: ({ row }, h) => {
-        return row.instance_code
+        return row.instance_code || row.instance_id
       },
     },
   },


### PR DESCRIPTION
**What this PR does / why we need it**:

openresource instance id empty

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
