### PR TITLE
Automated cherry pick of #4926: fix: openresource instance id empty

### DIFF
--- a/src/views/workflow/utils/columns.js
+++ b/src/views/workflow/utils/columns.js
@@ -123,7 +123,7 @@ const openResourceColumns = [
     field: 'instance_code',
     slots: {
       default: ({ row }, h) => {
-        return row.instance_code
+        return row.instance_code || row.instance_id
       },
     },
   },


### PR DESCRIPTION
Cherry pick of #4926 on release/3.10.

#4926: fix: openresource instance id empty