### PR TITLE
Automated cherry pick of #4930: feat(4434): 如果虚拟机所在宿主机为禁用且离线状态，则虚拟机迁移默认启用 rescue-mode 迁移

### DIFF
--- a/containers/Compute/views/vminstance/dialogs/Transfer.vue
+++ b/containers/Compute/views/vminstance/dialogs/Transfer.vue
@@ -286,6 +286,7 @@ export default {
   methods: {
     doSingleTransfer (ids, values) {
       let action = 'migrate'
+      const selectedItem = this.params.data[0]
       const data = {
         prefer_host: values.host,
       }
@@ -305,7 +306,7 @@ export default {
         }
         data.quickly_finish = true
       }
-      if (values.rescue_mode) {
+      if (selectedItem.host_enabled === false && selectedItem.host_status === 'offline') {
         action = 'migrate'
         data.rescue_mode = true
       }


### PR DESCRIPTION
Cherry pick of #4930 on release/3.10.

#4930: feat(4434): 如果虚拟机所在宿主机为禁用且离线状态，则虚拟机迁移默认启用 rescue-mode 迁移