### PR TITLE
Automated cherry pick of #4960: fix(8852): 新建虚拟机切换私有云账号时因为页面缓存导致磁盘价格报错

### DIFF
--- a/containers/Compute/views/vminstance/create/components/BottomBar.vue
+++ b/containers/Compute/views/vminstance/create/components/BottomBar.vue
@@ -109,7 +109,7 @@ export default {
     cloudaccountId: String,
   },
   data () {
-    this.getPriceList = _.debounce(this._getPriceList2, 500)
+    this.getPriceList = _.debounce(this._getPriceList2, 1500)
     return {
       origin_price: null,
       discount: 0,


### PR DESCRIPTION
Cherry pick of #4960 on release/3.10.

#4960: fix(8852): 新建虚拟机切换私有云账号时因为页面缓存导致磁盘价格报错