### PR TITLE
fix(9120): 公有云虚拟机创建相同配置时，镜像列表不应该显示为空

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -280,6 +280,9 @@ export default {
     this.instanceSnapshots = new Manager('instance_snapshots', 'v2')
     this.fetchData()
     this.fetchCacheimages = _.debounce(this._fetchCacheimages, 500)
+    if (this.isPublicImage || this.isPrivateImage || this.isVMware) {
+      this.fetchCacheimages()
+    }
   },
   methods: {
     fetchData () {


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix(9120): 公有云虚拟机创建相同配置时，镜像列表不应该显示为空

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.10
