### PR TITLE
Automated cherry pick of #5050: fix(9120): 公有云虚拟机创建相同配置时，镜像列表不应该显示为空

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -280,6 +280,9 @@ export default {
     this.instanceSnapshots = new Manager('instance_snapshots', 'v2')
     this.fetchData()
     this.fetchCacheimages = _.debounce(this._fetchCacheimages, 500)
+    if (this.isPublicImage || this.isPrivateImage || this.isVMware) {
+      this.fetchCacheimages()
+    }
   },
   methods: {
     fetchData () {


### PR DESCRIPTION
Cherry pick of #5050 on release/3.10.

#5050: fix(9120): 公有云虚拟机创建相同配置时，镜像列表不应该显示为空