### PR TITLE
Automated cherry pick of #5056: fix: 去掉单条数据的迁移预检，保持与多条数据的逻辑统一

### DIFF
--- a/containers/Compute/views/vminstance/dialogs/Transfer.vue
+++ b/containers/Compute/views/vminstance/dialogs/Transfer.vue
@@ -176,6 +176,9 @@ export default {
         if (item.manager_id && !managerIds.includes(item.manager_id)) {
           managerIds.push(item.manager_id)
         }
+        if (item.host_id) {
+          hostIds.push(item.host_id)
+        }
       })
 
       if (!this.isKvm) {
@@ -280,7 +283,7 @@ export default {
     },
   },
   created () {
-    this.isSingle && !this.isExistManager && this.queryForcastData()
+    // this.isSingle && !this.isExistManager && this.queryForcastData()
     this.queryHosts()
   },
   methods: {


### PR DESCRIPTION
Cherry pick of #5056 on release/3.10.

#5056: fix: 去掉单条数据的迁移预检，保持与多条数据的逻辑统一