### PR TITLE
fix(9264): baseselect default select includes extraopts

### DIFF
--- a/src/components/BaseSelect/index.vue
+++ b/src/components/BaseSelect/index.vue
@@ -526,7 +526,7 @@ export default {
               await this.loadDefaultSelectedOpts()
             }
           }
-          this.defaultSelect(this.sourceList)
+          this.defaultSelect([...this.extraOpts, ...this.sourceList])
           return list
         } catch (error) {
           throw error


### PR DESCRIPTION
**What this PR does / why we need it**:

选择组件 默认选择项优化

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
