### PR TITLE
Automated cherry pick of #5073: fix(9264): baseselect default select includes extraopts

### DIFF
--- a/src/components/BaseSelect/index.vue
+++ b/src/components/BaseSelect/index.vue
@@ -528,7 +528,7 @@ export default {
               await this.loadDefaultSelectedOpts()
             }
           }
-          this.defaultSelect(this.sourceList)
+          this.defaultSelect([...this.extraOpts, ...this.sourceList])
           return list
         } catch (error) {
           throw error


### PR DESCRIPTION
Cherry pick of #5073 on release/3.10.

#5073: fix(9264): baseselect default select includes extraopts