### PR TITLE
fix: network change wire scope param

### DIFF
--- a/containers/Network/views/network/dialogs/SwitchWire.vue
+++ b/containers/Network/views/network/dialogs/SwitchWire.vue
@@ -62,7 +62,7 @@ export default {
     },
     wireParams () {
       const params = {
-        scope: this.scope,
+        scope: this.$store.getters.scope,
         brand: this.params.data[0].brand,
         vpcId: this.params.data[0].vpc_id,
       }


### PR DESCRIPTION
**What this PR does / why we need it**:

ip子网更换二层网络增加scope参数

**Does this PR need to be backport to the previous release branch?**:

NONE(3.10)
