### PR TITLE
Automated cherry pick of #5201: fix(9292): 系统镜像中按系统过滤应该加上nfs的选项支持查询方德的镜像

### DIFF
--- a/src/utils/common/tableFilter.js
+++ b/src/utils/common/tableFilter.js
@@ -466,6 +466,7 @@ export function getImageDistributionFilter () {
       { label: 'Kylin', key: 'Kylin' },
       { label: 'NeoKylin', key: 'NeoKylin' },
       { label: 'RedHat', key: 'RedHat' },
+      { label: 'NFS', key: 'nfs' },
     ],
   }
 }


### PR DESCRIPTION
Cherry pick of #5201 on release/3.10.

#5201: fix(9292): 系统镜像中按系统过滤应该加上nfs的选项支持查询方德的镜像