### PR TITLE
Automated cherry pick of #5227: fix: Cloudpods重装系统获取私有云镜像参数调整：去掉project_domain

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -41,6 +41,7 @@ import _ from 'lodash'
 import ImageSelectTemplate from './ImageSelectTemplate'
 import { SELECT_IMAGE_KEY_SUFFIX } from '@Compute/constants'
 import { Manager } from '@/utils/manager'
+import { HYPERVISORS_MAP } from '@/constants'
 import { IMAGES_TYPE_MAP, OS_TYPE_OPTION_MAP } from '@/constants/compute'
 import storage from '@/utils/storage'
 import { uuid } from '@/utils/utils'
@@ -102,6 +103,9 @@ export default {
     edit: {
       type: Boolean,
       default: false,
+    },
+    hypervisor: {
+      type: String,
     },
   },
   data () {
@@ -224,6 +228,9 @@ export default {
     },
     isShowErrorInfo () {
       return this.uefi && this.form.fd.os === OS_TYPE_OPTION_MAP.Windows.value
+    },
+    isCloudpods () {
+      return this.hypervisor === HYPERVISORS_MAP.cloudpods.key
     },
   },
   watch: {
@@ -425,7 +432,7 @@ export default {
       if (this.isVMware) {
         params.image_type = 'system'
       }
-      if (this.isPrivate || this.isVMware) {
+      if ((this.isPrivate && !this.isCloudpods) || this.isVMware) {
         params.project_domain = this.form.fd.domain?.key || this.$store.getters.userInfo.projectDomainId
       }
       this.loading = true

--- a/containers/Compute/sections/OsSelect/index.vue
+++ b/containers/Compute/sections/OsSelect/index.vue
@@ -23,7 +23,8 @@
       :imageCloudproviderDisabled="imageCloudproviderDisabled"
       :sys-disk-size="sysDiskSize"
       :form="form"
-      :edit="edit" />
+      :edit="edit"
+      :hypervisor="hypervisor" />
   </div>
 </template>
 
@@ -183,7 +184,6 @@ export default {
   },
   methods: {
     imageInput (image) {
-      console.log(image)
       this.$emit('change', image)
     },
     change (e) {


### PR DESCRIPTION
Cherry pick of #5227 on release/3.10.

#5227: fix: Cloudpods重装系统获取私有云镜像参数调整：去掉project_domain