### PR TITLE
Automated cherry pick of #5231: fix: Cloudpods新建虚拟机获取私有云镜像参数调整：去掉project_domain

### DIFF
--- a/containers/Compute/views/vminstance/create/form/Private.vue
+++ b/containers/Compute/views/vminstance/create/form/Private.vue
@@ -235,7 +235,9 @@ export default {
     cacheImageParams () {
       const params = {
         manager_id: this.form.fd.cloudprovider,
-        project_domain: this.project_domain,
+      }
+      if (this.form.fd.hypervisor !== HYPERVISORS_MAP.cloudpods.hypervisor) {
+        params.project_domain = this.project_domain
       }
       if (R.is(Object, this.form.fd.sku)) {
         if (this.cloudregionZoneParams.cloudregion) {


### PR DESCRIPTION
Cherry pick of #5231 on release/3.10.

#5231: fix: Cloudpods新建虚拟机获取私有云镜像参数调整：去掉project_domain