### PR TITLE
feat: onecloud dns zone do not support associate vpc

### DIFF
--- a/containers/Network/views/dns-zone/create/index.vue
+++ b/containers/Network/views/dns-zone/create/index.vue
@@ -357,6 +357,14 @@ export default {
       }
       return <div>{ item.name }</div>
     },
+    cancel () {
+      this.$router.push({
+        name: 'DnsZone',
+        params: {
+          cloudEnv: this.cloudEnv,
+        },
+      })
+    },
   },
 }
 </script>

--- a/containers/Network/views/dns-zone/dialogs/AssociateVpcDialog.vue
+++ b/containers/Network/views/dns-zone/dialogs/AssociateVpcDialog.vue
@@ -13,7 +13,6 @@
           :wrapperCol="formItemLayout.wrapperCol"
           :labelCol="formItemLayout.labelCol"
           :names="areaselectsName"
-          :providerParams="providerParams"
           :cloudregionParams="cloudregionParams"
           :isRequired="true"
           filterBrandResource="network_manage"
@@ -70,8 +69,7 @@ export default {
           },
         ],
       },
-      areaselectsName: ['provider', 'cloudregion'],
-      regionProvider: '',
+      areaselectsName: ['cloudregion'],
       regionId: '',
       associateVpcIds: [],
       formItemLayout: {
@@ -96,7 +94,6 @@ export default {
         usable_vpc: true,
         scope: this.scope,
         cloudregion_id: this.regionId,
-        filter: 'provider.in(Aws, Aliyun, OneCloud)',
       }
       if (this.params.data[0].manager_id) {
         params.manager_id = this.params.data[0].manager_id
@@ -108,19 +105,13 @@ export default {
       if (!this.regionId) return {}
       return params
     },
-    providerParams () {
-      return {
-        filter: 'provider.in(Aws, Aliyun, OneCloud)',
-        scope: this.scope,
-        cloud_env: 'public',
-      }
-    },
     cloudregionParams () {
       return {
         scope: this.scope,
         limit: 0,
         usable_vpc: true,
         show_emulated: true,
+        provider: this.params.data[0].provider,
       }
     },
   },
@@ -148,8 +139,6 @@ export default {
     handleRegionChange (data) {
       const { cloudregion } = data
       if (cloudregion) {
-        const { provider } = cloudregion.value
-        this.regionProvider = provider
         this.regionId = cloudregion.id
       }
     },

--- a/containers/Network/views/dns-zone/index.vue
+++ b/containers/Network/views/dns-zone/index.vue
@@ -18,7 +18,7 @@ export default {
     List,
   },
   data () {
-    const cloudEnvOptions = getCloudEnvOptions('compute_engine_brands').filter(val => ['onpremise', 'public'].includes(val.key))
+    const cloudEnvOptions = getCloudEnvOptions('compute_engine_brands').filter(val => !['private'].includes(val.key))
     const cloudEnv = this.$route.params?.cloudEnv
     return {
       listId: 'DnsZoneList',

--- a/containers/Network/views/dns-zone/mixins/singleActions.js
+++ b/containers/Network/views/dns-zone/mixins/singleActions.js
@@ -30,6 +30,10 @@ export default {
             ret.tooltip = i18n.t('network.text_730')
             return ret
           }
+          if (obj.cloud_env === 'onpremise') {
+            ret.validate = false
+            ret.tooltip = i18n.t('network.text_652')
+          }
           return ret
         },
       },

--- a/containers/Network/views/dns-zone/sidepage/index.vue
+++ b/containers/Network/views/dns-zone/sidepage/index.vue
@@ -61,7 +61,7 @@ export default {
         // { label: this.$t('network.text_316'), key: 'dns-zonecache-list-for-dns-zone-sidepage' },
         { label: this.$t('network.text_150'), key: 'event-drawer' },
       ]
-      if (data.zone_type === 'PrivateZone') {
+      if (data.cloud_env === 'public' && data.zone_type === 'PrivateZone') {
         detailTabs.splice(1, 0, { label: this.$t('network.text_719'), key: 'dns-associate-vpc-list' })
       }
       return detailTabs


### PR DESCRIPTION
**What this PR does / why we need it**:

本地idc dns不支持绑定vpc

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
