### PR TITLE
fix(9252): bill tasks default select current month

### DIFF
--- a/containers/Cloudenv/views/billtasks/dialogs/Create.vue
+++ b/containers/Cloudenv/views/billtasks/dialogs/Create.vue
@@ -76,8 +76,8 @@ export default {
       form: {
         account_id: this.params.account_id,
         task_type: initTaskType,
-        start_day: this.$moment().subtract(1, 'month'),
-        end_day: this.$moment().subtract(1, 'month'),
+        start_day: this.$moment(),
+        end_day: this.$moment(),
       },
       rules: {
         account_id: [{ required: true, message: this.$t('common.tips.select', [this.$t('dictionary.cloudaccount')]) }],


### PR DESCRIPTION
**What this PR does / why we need it**:

账单任务默认选择本月

**Does this PR need to be backport to the previous release branch?**:

- release/3.10
