### PR TITLE
fix(9355): idc dns-zone do not support attach vpc

### DIFF
--- a/containers/Network/views/dns-zone/sidepage/Detail.vue
+++ b/containers/Network/views/dns-zone/sidepage/Detail.vue
@@ -40,7 +40,7 @@ export default {
           field: 'vpc_count',
           title: this.$t('network.text_719'),
           formatter: ({ row }) => {
-            if (row.zone_type === 'PublicZone') return row.vpc_count
+            if (row.zone_type === 'PublicZone' || row.cloud_env === 'onpremise') return row.vpc_count
             return <a onClick={ () => this.$emit('tab-change', 'dns-associate-vpc-list') }>{row.vpc_count}</a>
           },
         },


### PR DESCRIPTION
**What this PR does / why we need it**:

本地idc dns不支持绑定vpc

**Does this PR need to be backport to the previous release branch?**:

- release/3.11
- release/3.10
