### PR TITLE
Automated cherry pick of #5375: fix(9355): idc dns-zone do not support attach vpc

### DIFF
--- a/containers/Network/views/dns-zone/sidepage/Detail.vue
+++ b/containers/Network/views/dns-zone/sidepage/Detail.vue
@@ -40,7 +40,7 @@ export default {
           field: 'vpc_count',
           title: this.$t('network.text_719'),
           formatter: ({ row }) => {
-            if (row.zone_type === 'PublicZone') return row.vpc_count
+            if (row.zone_type === 'PublicZone' || row.cloud_env === 'onpremise') return row.vpc_count
             return <a onClick={ () => this.$emit('tab-change', 'dns-associate-vpc-list') }>{row.vpc_count}</a>
           },
         },


### PR DESCRIPTION
Cherry pick of #5375 on release/3.10.

#5375: fix(9355): idc dns-zone do not support attach vpc