### PR TITLE
Automated cherry pick of #5378: fix(9329): 数字显示需优化，如果是0，应该显示0%即可，如果值很小，但是比0大，才显示<1%

### DIFF
--- a/containers/Dashboard/extends/Ring/components/Server.vue
+++ b/containers/Dashboard/extends/Ring/components/Server.vue
@@ -322,6 +322,7 @@ export default {
       return numerify(data * 100, 0.0)
     },
     percentTips () {
+      if (this.percent === 0) return '0%'
       if (this.percent < 1) {
         return '< 1%'
       }


### PR DESCRIPTION
Cherry pick of #5378 on release/3.11.

#5378: fix(9329): 数字显示需优化，如果是0，应该显示0%即可，如果值很小，但是比0大，才显示<1%