### PR TITLE
fix: disk and instance backup add ui hidden check

### DIFF
--- a/containers/Compute/router/index.js
+++ b/containers/Compute/router/index.js
@@ -389,6 +389,9 @@ export default {
             label: i18n.t('compute.disk_backup'),
             permission: 'diskbackups_list',
             hidden: () => {
+              if (isScopedPolicyMenuHidden('sub_hidden_menus.disk_backup')) {
+                return true
+              }
               return !hasSetupKey(['onestack'])
             },
           },
@@ -407,6 +410,9 @@ export default {
             label: i18n.t('compute.instance_backup'),
             permission: 'instancebackups_list',
             hidden: () => {
+              if (isScopedPolicyMenuHidden('sub_hidden_menus.instance_backup')) {
+                return true
+              }
               return !hasSetupKey(['onestack'])
             },
           },


### PR DESCRIPTION
**What this PR does / why we need it**:

硬盘备份和主机备份增加ui隐藏策略检查

**Does this PR need to be backport to the previous release branch?**:

- release/3.11
- release/3.10
