### PR TITLE
fix(9397): fix v-charts error

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,8 @@ import './plugins'
 import './permission'
 import './filters'
 
+Vue._watchers = Vue.prototype._watchers = []
+
 Vue.use(Antd)
 Vue.use(VXETable, {
   i18n: key => i18n.t(key),


### PR DESCRIPTION
**What this PR does / why we need it**:

修复 v-echarts 组件，在控制台的报错

**Does this PR need to be backport to the previous release branch?**:

- release/3.11
- release/3.10
