### PR TITLE
fix: host sidepage hidden vminstance create action

### DIFF
--- a/containers/Compute/views/vminstance/components/List.vue
+++ b/containers/Compute/views/vminstance/components/List.vue
@@ -75,6 +75,10 @@ export default {
     tableOverviewIndexs: {
       type: Array,
     },
+    hiddenActions: {
+      type: Array,
+      default: () => ([]),
+    },
   },
   data () {
     const filter = {}
@@ -200,7 +204,7 @@ export default {
               tooltip: this.cloudEnvEmpty ? this.$t('common.no_platform_available') : '',
             }
           },
-          hidden: () => this.$isScopedPolicyMenuHidden('vminstance_hidden_menus.server_create'),
+          hidden: () => this.$isScopedPolicyMenuHidden('vminstance_hidden_menus.server_create') || this.hiddenActions.includes('create'),
         },
         // 开机
         {


### PR DESCRIPTION
**What this PR does / why we need it**:

宿主机详情的虚拟机不允许新建

**Does this PR need to be backport to the previous release branch?**:

- release/3.11
- release/3.10
