### PR TITLE
fix: host network throw error when there is no nick_info

### DIFF
--- a/containers/Compute/views/physicalmachine/sidepage/Network.vue
+++ b/containers/Compute/views/physicalmachine/sidepage/Network.vue
@@ -111,12 +111,12 @@ export default {
   },
   computed: {
     nicList () {
-      return this.hostInfo.nic_info.filter((o) => {
+      return (this.hostInfo.nic_info || []).filter((o) => {
         return o.nic_type !== 'ipmi'
       })
     },
     ipmiList () {
-      return this.hostInfo.nic_info.filter((o) => {
+      return (this.hostInfo.nic_info || []).filter((o) => {
         return o.nic_type === 'ipmi'
       })
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

宿主机网络报错

**Does this PR need to be backport to the previous release branch?**:

- release/3.11
- release/3.10
