### PR TITLE
Automated cherry pick of #5612: fix: host network throw error when there is no nick_info

### DIFF
--- a/containers/Compute/views/physicalmachine/sidepage/Network.vue
+++ b/containers/Compute/views/physicalmachine/sidepage/Network.vue
@@ -111,12 +111,12 @@ export default {
   },
   computed: {
     nicList () {
-      return this.hostInfo.nic_info.filter((o) => {
+      return (this.hostInfo.nic_info || []).filter((o) => {
         return o.nic_type !== 'ipmi'
       })
     },
     ipmiList () {
-      return this.hostInfo.nic_info.filter((o) => {
+      return (this.hostInfo.nic_info || []).filter((o) => {
         return o.nic_type === 'ipmi'
       })
     },


### PR DESCRIPTION
Cherry pick of #5612 on release/3.11.

#5612: fix: host network throw error when there is no nick_info