### PR TITLE
fix(9421): volcengine added status check for ssh operation

### DIFF
--- a/containers/Compute/views/vminstance/utils.js
+++ b/containers/Compute/views/vminstance/utils.js
@@ -313,7 +313,7 @@ const actionEableMap = {
       proxmox: false,
       bingocloud: false,
       remotefile: false,
-      volcengine: true,
+      volcengine: ['running'],
     },
   },
   'IP SSH': {


### PR DESCRIPTION
**What this PR does / why we need it**:

火山引擎增加ssh操作的状态检查

**Does this PR need to be backport to the previous release branch?**:

- release/3.11
