### PR TITLE
fix: cloudaccount disable sync action when syncing

### DIFF
--- a/containers/Cloudenv/locales/en.json
+++ b/containers/Cloudenv/locales/en.json
@@ -870,5 +870,6 @@
   "cloudenv.cycle_type.month": "month",
   "cloudenv.cycle_once": "sync once",
   "cloudenv.input_cycle_num": "Please input frequency",
-  "cloudenv.each": "Each"
+  "cloudenv.each": "Each",
+  "cloudenv.syncing_account_disable_action": "The cloud account in synchronization does not support this operation"
 }

--- a/containers/Cloudenv/locales/ja-JP.json
+++ b/containers/Cloudenv/locales/ja-JP.json
@@ -871,5 +871,6 @@
   "cloudenv.cycle_type.month": "月",
   "cloudenv.cycle_once": "一度同期する",
   "cloudenv.input_cycle_num": "周波数を入力してください",
-  "cloudenv.each": "毎"
+  "cloudenv.each": "毎",
+  "cloudenv.syncing_account_disable_action": "同期中のクラウドアカウントではサポートされていません"
 }

--- a/containers/Cloudenv/locales/zh-CN.json
+++ b/containers/Cloudenv/locales/zh-CN.json
@@ -872,5 +872,6 @@
   "cloudenv.cycle_type.month": "月",
   "cloudenv.cycle_once": "同步一次",
   "cloudenv.input_cycle_num": "请输入频率",
-  "cloudenv.each": "每"
+  "cloudenv.each": "每",
+  "cloudenv.syncing_account_disable_action": "同步中的云账号不支持此操作"
 }

--- a/containers/Cloudenv/views/cloudaccount/mixins/singleActions.js
+++ b/containers/Cloudenv/views/cloudaccount/mixins/singleActions.js
@@ -42,7 +42,15 @@ export default {
             },
           })
         },
-        meta: (obj) => this.syncPolicy(obj),
+        meta: (obj) => {
+          if (obj.sync_status !== 'idle') {
+            return {
+              validate: false,
+              tooltip: this.$t('cloudenv.syncing_account_disable_action'),
+            }
+          }
+          return this.syncPolicy(obj)
+        },
 
       },
       {


### PR DESCRIPTION
**What this PR does / why we need it**:

云账号同步时，禁用同步状态操作

**Does this PR need to be backport to the previous release branch?**:

- release/3.11
- release/3.10
