### PR TITLE
Automated cherry pick of #5877: fix: 调整配置时只有vmware支持设置插槽，根据平台来过滤，不要根据cpu_sockets

### DIFF
--- a/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
+++ b/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
@@ -753,9 +753,11 @@ export default {
 
       const dataDisks = this.selectedItem.disks_info.filter(item => item.disk_type === 'data')
       const { medium_type: dataDiskMedium } = dataDisks[0] || {}
-      if (this.selectedItem.cpu_sockets) {
-        this.form.fi.showCpuSockets = true
-        this.form.fi.cpuSockets = this.selectedItem.cpu_sockets
+      if ([HYPERVISORS_MAP.esxi.key].includes(this.hypervisor)) {
+        if (this.selectedItem.cpu_sockets) {
+          this.form.fi.showCpuSockets = true
+          this.form.fi.cpuSockets = this.selectedItem.cpu_sockets
+        }
       }
       this.$nextTick(() => {
         this.diskLoaded = true


### PR DESCRIPTION
Cherry pick of #5877 on release/3.11.

#5877: fix: 调整配置时只有vmware支持设置插槽，根据平台来过滤，不要根据cpu_sockets