### PR TITLE
fix: modify the effective timing of ip-select component

### DIFF
--- a/containers/Compute/sections/ServerNetwork/IpSelect.vue
+++ b/containers/Compute/sections/ServerNetwork/IpSelect.vue
@@ -34,10 +34,10 @@ export default {
   },
   watch: {
     'network.id': {
-      handler (val) {
+      handler (val, oldVal) {
         if (val) {
           this.fetchIps(val)
-        } else {
+        } else if (oldVal && !val) {
           this.options = []
           this.$emit('change', null)
         }
@@ -71,7 +71,6 @@ export default {
             name: ip,
           }
         })
-        console.log('initial value ', this.value, addresses)
         if (!addresses.includes(this.value)) {
           this.options.unshift({
             ip: this.value,

--- a/containers/Compute/views/vminstance/dialogs/ChangeIp.vue
+++ b/containers/Compute/views/vminstance/dialogs/ChangeIp.vue
@@ -82,7 +82,6 @@ export default {
       }
       return callback()
     }
-    console.log('params', this.params.data[0])
     return {
       loading: false,
       form: {


### PR DESCRIPTION
**What this PR does / why we need it**:

修改ip-select watch函数生效时机， 防止初始化时默认值被清空

**Does this PR need to be backport to the previous release branch?**:

- release/3.11
