### PR TITLE
Automated cherry pick of #5917: fix(9562): 公有云新建虚拟机指定云订阅时，创建接口要传prefer_manager_id

### DIFF
--- a/containers/Compute/utils/createServer.js
+++ b/containers/Compute/utils/createServer.js
@@ -1356,6 +1356,14 @@ export class GenCreateData {
     return ret
   }
 
+  getPreferManagerId () {
+    let prefer_manager_id = ''
+    if (this.isPublic) {
+      prefer_manager_id = this.fd.cloudprovider
+    }
+    return prefer_manager_id
+  }
+
   /**
    * 组装所有的创建数据
    *
@@ -1442,6 +1450,10 @@ export class GenCreateData {
     const zoneId = this.getPreferZone()
     if (zoneId) {
       data.prefer_zone = zoneId
+    }
+    const prefer_manager_id = this.getPreferManagerId()
+    if (prefer_manager_id) {
+      data.prefer_manager_id = prefer_manager_id
     }
     // 只有kvm支持启动方式, VDI, VGA, Machine
     if (this.fd.hypervisor === HYPERVISORS_MAP.kvm.key) {

--- a/src/constants/compute.js
+++ b/src/constants/compute.js
@@ -11,7 +11,7 @@ export const IMAGES_TYPE_MAP = {
   snapshot: { key: 'snapshot', label: i18n.t('dictionary.instance_snapshot'), t: 'dictionary.instance_snapshot', tooltip: i18n.t('common.instance_snapshot.tooltip') },
   backup: { key: 'backup', label: i18n.t('dictionary.instancebackup'), t: 'dictionary.instancebackup', tooltip: i18n.t('dictionary.instancebackup') },
   public: { key: 'public', label: i18n.t('common.text00025'), tooltip: i18n.t('common.text00026') },
-  public_customize: { key: 'public_customize', label: i18n.t('common.public_cloud_customized_image'), tooltip: i18n.t('common.text00028'), enable_cloudaccount: true },
+  public_customize: { key: 'public_customize', label: i18n.t('common.public_cloud_customized_image'), tooltip: i18n.t('common.text00028'), enable_cloudaccount: false },
   private: { key: 'private', label: i18n.t('common.text00029'), tooltip: i18n.t('common.text00030'), enable_cloudaccount: true },
   vmware: { key: 'vmware', label: i18n.t('common.text00031'), tooltip: i18n.t('common.text00032'), enable_cloudaccount: true },
   private_iso: { key: 'private_iso', label: i18n.t('common.private_iso'), tooltip: i18n.t('common.private_iso_tip'), enable_cloudaccount: true },


### PR DESCRIPTION
Cherry pick of #5917 on release/3.11.

#5917: fix(9562): 公有云新建虚拟机指定云订阅时，创建接口要传prefer_manager_id