### PR TITLE
Automated cherry pick of #5975: fix(9608): 硬盘快照列表，状态字段，后端返回的是ready，前端确实loading的状态，不符合预期

### DIFF
--- a/src/constants/expectStatus.js
+++ b/src/constants/expectStatus.js
@@ -144,7 +144,7 @@ export default {
     info: ['unknown', 'stopped'],
   },
   snapshot: {
-    success: ['available'],
+    success: ['available', 'ready'],
     danger: ['delete_failed', 'apply_failed', 'cancel_failed'],
     info: ['unknown'],
   },


### PR DESCRIPTION
Cherry pick of #5975 on release/3.11.

#5975: fix(9608): 硬盘快照列表，状态字段，后端返回的是ready，前端确实loading的状态，不符合预期