### PR TITLE
Automated cherry pick of #6006: fix(9625): 使用镜像仓库新建deployment或其他资源时，镜像tag是用英文冒号拼接，不应该是反斜杠

### DIFF
--- a/containers/K8S/sections/MirrorRegistry/index.vue
+++ b/containers/K8S/sections/MirrorRegistry/index.vue
@@ -196,7 +196,7 @@ export default {
       const curRegistry = this.registrys.find(o => o.value === registry)
       const url = curRegistry?.url
       if (url && image && tag) {
-        this.$emit('change', `${url}/${image}/${tag}`)
+        this.$emit('change', `${url}/${image}:${tag}`)
       } else {
         this.$emit('change', '')
       }

--- a/containers/K8S/views/repos/sidepage/ContainerRegistry.vue
+++ b/containers/K8S/views/repos/sidepage/ContainerRegistry.vue
@@ -7,9 +7,6 @@
 </template>
 
 <script>
-import {
-  getNameFilter,
-} from '@/utils/common/tableFilter'
 import { uuid } from '@/utils/utils'
 
 export default {
@@ -29,7 +26,9 @@ export default {
         resource: () => this.fetchData(),
         getParams: this.getParams,
         filterOptions: {
-          name: getNameFilter(),
+          name: {
+            label: this.$t('k8s.repo.image.name'),
+          },
         },
       }),
       columns: [


### PR DESCRIPTION
Cherry pick of #6006 on release/3.10.

#6006: fix(9625): 使用镜像仓库新建deployment或其他资源时，镜像tag是用英文冒号拼接，不应该是反斜杠