### PR TITLE
fix(9610): 第三方登陆图片hover信息应该加下认证源的name

### DIFF
--- a/src/sections/Auth/Login/components/LoginChallenge.vue
+++ b/src/sections/Auth/Login/components/LoginChallenge.vue
@@ -126,7 +126,7 @@
           <div class="d-flex justify-content-center flex-wrap p-1">
             <div class="fast-login-items" :key="idx" v-for="(item, idx) of idps">
               <a class="fast-login-item d-flex align-items-center justify-content-center ml-2 mr-2" @click="handleClickIdp(item)">
-                <a-tooltip placement="top" :title="$t(`idpTmplTitles.${item.template || item.driver}`)">
+                <a-tooltip placement="top" :title="$t(`idpTmplTitles.${item.template || item.driver}`) + '/' + item.name">
                   <template slot="title">
                     <span>{{ item.tooltip }}</span>
                   </template>


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix(9610): 第三方登陆图片hover信息应该加下认证源的name

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.11
- release/3.10
