### PR TITLE
Automated cherry pick of #6022: fix(9154): 定时任务详情和列表策略时间不一致

### DIFF
--- a/containers/Cloudenv/views/scheduledtask/components/List.vue
+++ b/containers/Cloudenv/views/scheduledtask/components/List.vue
@@ -185,7 +185,10 @@ export default {
         id: row.id,
         apiVersion: 'v1',
         resource: 'scheduledtasks',
-        getParams: { details: true },
+        getParams: { 
+          details: true, 
+          utc_offset: this.$moment().utcOffset() / 60 
+        },
       }, {
         list: this.list,
       })


### PR DESCRIPTION
Cherry pick of #6022 on release/3.10.

#6022: fix(9154): 定时任务详情和列表策略时间不一致