### PR TITLE
fix(19462): 云账号改为只读模式后新建公有云虚拟机依然可以选中

### DIFF
--- a/containers/Compute/views/vminstance/create/form/Public.vue
+++ b/containers/Compute/views/vminstance/create/form/Public.vue
@@ -482,6 +482,7 @@ export default {
         brand: this.form.fd.provider,
         cloudregion: this.form.fd.cloudregion,
         enabled: true,
+        read_only: false,
         filter: 'status.equals(\'connected\')',
         ...this.scopeParams,
       }


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix(19462): 云账号改为只读模式后新建公有云虚拟机依然可以选中

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.11
- release/3.10