### PR TITLE
Automated cherry pick of #6065: fix(19462): 云账号改为只读模式后新建公有云虚拟机依然可以选中

### DIFF
--- a/containers/Compute/views/vminstance/create/form/Public.vue
+++ b/containers/Compute/views/vminstance/create/form/Public.vue
@@ -474,6 +474,7 @@ export default {
         brand: this.form.fd.provider,
         cloudregion: this.form.fd.cloudregion,
         enabled: true,
+        read_only: false,
         filter: 'status.equals(\'connected\')',
         ...this.scopeParams,
       }


### PR DESCRIPTION
Cherry pick of #6065 on release/3.10.

#6065: fix(19462): 云账号改为只读模式后新建公有云虚拟机依然可以选中