### PR TITLE
fix: disable force detach network when vm poweron

### DIFF
--- a/containers/Compute/views/networks/mixins/singleActions.js
+++ b/containers/Compute/views/networks/mixins/singleActions.js
@@ -90,6 +90,7 @@ export default {
                   data: [obj],
                   columns: this.columns,
                   refresh: this.refresh,
+                  server: this.data,
                 })
               },
               meta: (obj) => {

--- a/containers/Compute/views/vminstance/dialogs/DetachNetwork.vue
+++ b/containers/Compute/views/vminstance/dialogs/DetachNetwork.vue
@@ -5,12 +5,12 @@
       <dialog-selected-tips :name="$t('compute.nic')" :count="params.data.length" :action="action" />
       <dialog-table :data="params.data" :columns="columns" />
       <a-form-item>
-        <a-checkbox v-model="syncConfigImmediately">
+        <a-checkbox v-model="syncConfigImmediately" :disabled="!isVmPoweroff">
           {{ $t('compute.nics.sync_config_immediately') }}
         </a-checkbox>
       </a-form-item>
       <a-form-item>
-        <a-checkbox v-model="forceRemove">
+        <a-checkbox v-model="forceRemove" :disabled="!isVmPoweroff">
           {{ $t('compute.nics.force_remove') }}
         </a-checkbox>
       </a-form-item>
@@ -42,6 +42,9 @@ export default {
     columns () {
       const showFields = ['ifname', 'ip_addr', 'mac_addr']
       return this.params.columns.filter((item) => { return showFields.includes(item.field) })
+    },
+    isVmPoweroff () {
+      return this.params.server.power_states === 'off'
     },
   },
   methods: {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: disable force detach network when vm poweron

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @easy-mj @GuoLiBin6 