### PR TITLE
Automated cherry pick of #6126: fix(9636): 域管理后台新建用户，请求项目接口去掉project_domain_id=default

### DIFF
--- a/containers/IAM/views/user/components/DomainProjectSelect.vue
+++ b/containers/IAM/views/user/components/DomainProjectSelect.vue
@@ -106,6 +106,9 @@ export default {
       } else {
         params.project_domain_id = this.projectDomainId
       }
+      if (this.isDomainMode) {
+        delete params.project_domain_id
+      }
       return params
     },
   },


### PR DESCRIPTION
Cherry pick of #6126 on release/3.11.

#6126: fix(9636): 域管理后台新建用户，请求项目接口去掉project_domain_id=default