### PR TITLE
Automated cherry pick of #6140: fix(9617): 域管理后台不能新建k8s集群

### DIFF
--- a/containers/K8S/views/cluster/create/index.vue
+++ b/containers/K8S/views/cluster/create/index.vue
@@ -432,7 +432,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['userInfo', 'scope', 'isAdminMode']),
+    ...mapGetters(['userInfo', 'scope', 'isAdminMode', 'isDomainMode']),
     cloudregionParams () {
       const provider = this.provider
       /* const type = findPlatform(provider, 'hypervisor') */
@@ -470,6 +470,7 @@ export default {
     this.clustersM = new this.$Manager('kubeclusters', 'v1')
     this.form.fc.getFieldDecorator('cloudregion', { preserve: true })
     /* this.form.fc.getFieldDecorator('zone', { preserve: true }) */
+    this.isDomainMode && this.fetchCapability(this.userInfo.projectDomainId)
   },
   methods: {
     /*


### PR DESCRIPTION
Cherry pick of #6140 on release/3.10.

#6140: fix(9617): 域管理后台不能新建k8s集群