### PR TITLE
Automated cherry pick of #6210: fix(v3.9/9731): 兼容多块系统盘创建的虚拟机详情磁盘信息展示不对问题

### DIFF
--- a/containers/Compute/views/vminstance/sidepage/Detail.vue
+++ b/containers/Compute/views/vminstance/sidepage/Detail.vue
@@ -145,8 +145,8 @@ export default {
       const sysDisk = {}
       let image = '-'
       let imageId
-      const sysDisks = disksInfo.filter(v => v.disk_type === 'sys' && v.index === 0)
-      const dataDisks = disksInfo.filter(v => v.index !== 0 || v.disk_type !== 'sys')
+      const sysDisks = disksInfo.filter(v => v.disk_type === 'sys')
+      const dataDisks = disksInfo.filter(v => v.disk_type === 'data')
       if (sysDisks && sysDisks.length > 0) {
         const sysKey = sysDisks[0].storage_type
         image = sysDisks[0].image || '-'


### PR DESCRIPTION
Cherry pick of #6210 on release/3.10.

#6210: fix(v3.9/9731): 兼容多块系统盘创建的虚拟机详情磁盘信息展示不对问题