### PR TITLE
Automated cherry pick of #6214: fix(v3.9/9731): 兼容ISO启动无系统盘时调整配置磁盘下标index不对问题

### DIFF
--- a/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
+++ b/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
@@ -967,7 +967,7 @@ export default {
     },
     genDiskData (values) {
       const dataDisk = []
-      const len = this.form.fd.sysdisks?.length || 0
+      const len = this.form.fd.sysdisks?.length || -1
       let index = len >= 1 ? len - 1 : len
       const dataDisks = this.$refs.dataDiskRef.dataDisks
       R.forEachObjIndexed((value, key) => {


### PR DESCRIPTION
Cherry pick of #6214 on release/3.11.

#6214: fix(v3.9/9731): 兼容ISO启动无系统盘时调整配置磁盘下标index不对问题