### PR TITLE
Automated cherry pick of #6288: fix(v3.11/4815): vmware云账号和云可用区关联联动

### DIFF
--- a/containers/Compute/sections/OsSelect/ImageSelect.vue
+++ b/containers/Compute/sections/OsSelect/ImageSelect.vue
@@ -185,6 +185,9 @@ export default {
       if (!params.scope && !params.project_domain) {
         params.scope = this.$store.getters.scope
       }
+      if (this.isVMware && this.form.fd.zone) {
+        params.zone_id = this.form.fd.zone.key
+      }
       return params
     },
     storageImage () {


### PR DESCRIPTION
Cherry pick of #6288 on release/3.11.

#6288: fix(v3.11/4815): vmware云账号和云可用区关联联动