### PR TITLE
fix(v3.10/9741): 关闭镜像回收站后发现菜单没有隐藏

### DIFF
--- a/containers/Compute/router/index.js
+++ b/containers/Compute/router/index.js
@@ -918,6 +918,9 @@ export default {
               if (isScopedPolicyMenuHidden('sub_hidden_menus.imagerecovery')) {
                 return true
               }
+              if (!store.state.common.imageGlobalConfig.enable_pending_delete) {
+                return true
+              }
               return !hasSetupKey(['onestack', 'public', 'private', 'vmware'])
             },
           },

--- a/src/store/modules/common.js
+++ b/src/store/modules/common.js
@@ -29,6 +29,7 @@ export default {
     openCloudShell: false,
     globalServices: [],
     computeV2GlobalConfig: {},
+    imageGlobalConfig: {},
   },
   mutations: {
     UPDATE_OBJECT (state, { name, data }) {
@@ -106,6 +107,9 @@ export default {
     SET_COMPUTEV2_GLOBAL_CONFIG (state, payload) {
       state.computeV2GlobalConfig = payload
     },
+    SET_IMAGE_GLOBAL_CONFIG (state, payload) {
+      state.imageGlobalConfig = payload
+    },
   },
   actions: {
     updateObject ({ commit }, payload) {
@@ -166,7 +170,7 @@ export default {
       try {
         const response = await manager.list({
           params: {
-            type: ['common', 'yunionapi', 'meter', 'identity', 'compute_v2'],
+            type: ['common', 'yunionapi', 'meter', 'identity', 'compute_v2', 'image'],
           },
         })
         const resData = response?.data?.data
@@ -214,6 +218,15 @@ export default {
           })
           const config = (configResponse.data.config && configResponse.data.config.default) || {}
           commit('SET_COMPUTEV2_GLOBAL_CONFIG', config)
+        }
+        const imageId = resData.find(v => v.type === 'image')?.id || ''
+        if (imageId) {
+          const configResponse = await manager.getSpecific({
+            id: imageId,
+            spec: 'config',
+          })
+          const config = (configResponse.data.config && configResponse.data.config.default) || {}
+          commit('SET_IMAGE_GLOBAL_CONFIG', config)
         }
       } catch (error) {
         throw error


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

- fix(v3.10/9741): 关闭镜像回收站后发现菜单没有隐藏

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->

- release/3.12
- release/3.11
- release/3.10