### PR TITLE
Automated cherry pick of #6458: fix(v3.11/9852): 监控面板导出的列表内容，数据不全，只有第1列有数据

### DIFF
--- a/containers/Monitor/components/MonitorCard/sections/chart/line.vue
+++ b/containers/Monitor/components/MonitorCard/sections/chart/line.vue
@@ -53,10 +53,10 @@ export default {
         const data = [titles]
         resourceNames.map(name => {
           const row = [name]
-          times.map((time, idx) => {
+          times.map((time) => {
             const targets = rows.filter(item => item.time === time)
-            if (targets[idx]) {
-              row.push(targets[idx][name])
+            if (targets[0]) {
+              row.push(targets[0][name])
             } else {
               row.push('')
             }


### PR DESCRIPTION
Cherry pick of #6458 on release/3.11.

#6458: fix(v3.11/9852): 监控面板导出的列表内容，数据不全，只有第1列有数据