### PR TITLE
Automated cherry pick of #6539: fix(v3.11/9866): 费用预测关闭时 ，费用-云账号-账单任务-新建，前端增加限制

### DIFF
--- a/containers/Cloudenv/views/billtasks/dialogs/Create.vue
+++ b/containers/Cloudenv/views/billtasks/dialogs/Create.vue
@@ -45,7 +45,9 @@ export default {
   mixins: [DialogMixin, WindowsMixin],
   data () {
     const TaskTypeList = ['pull_bill', 'prepaid_amortizing', 'project_sharing', 'recalculate', 'predict', 'delete_bill'].filter(key => {
-      if (key === 'recalculate' && !this.$store.state.common.bill.globalConfig.cost_conversion_available) return false
+      const { cost_conversion_available, enable_prediction } = this.$store.state.common.bill?.globalConfig || {}
+      if (key === 'recalculate' && !cost_conversion_available) return false
+      if (key === 'predict' && !enable_prediction) return false
       return true
     })
     const { accountData = {} } = this.params


### PR DESCRIPTION
Cherry pick of #6539 on release/3.11.

#6539: fix(v3.11/9866): 费用预测关闭时 ，费用-云账号-账单任务-新建，前端增加限制