### PR TITLE
Automated cherry pick of #6682: feat(3.11/4928): 转换宿主机时候添加磁盘的挂载路径只能是 /opt/cloud/workspace 开头的目录

### DIFF
--- a/containers/Compute/locales/en.json
+++ b/containers/Compute/locales/en.json
@@ -1351,7 +1351,7 @@
   "compute.text_1358": "VMware does not currently support creating disk @:dictionary.snapshot",
   "compute.text_1359": "Line type",
   "compute.text_1360": "Billing type",
-  "compute.text_1361": "The default is the storage pool mount point {0}, which can be modified according to the actual use",
+  "compute.text_1361": "The default is the storage pool mount point {0}, which can be modified according to the actual purpose. The mount path of the disk can only be the directory starting with {0}",
   "compute.public_ip_tooltip": "Servers that have been assigned a public IP do not support binding/unbinding an elastic public IP",
   "compute.rule": "rule",
   "compute.norule": "No Rules",

--- a/containers/Compute/locales/zh-CN.json
+++ b/containers/Compute/locales/zh-CN.json
@@ -1351,7 +1351,7 @@
   "compute.text_1358": "VMware暂不支持创建硬盘@:dictionary.snapshot",
   "compute.text_1359": "线路类型",
   "compute.text_1360": "网络计费方式",
-  "compute.text_1361": "默认为存储池挂载点{0}，可根据实际用途修改",
+  "compute.text_1361": "默认为存储池挂载点{0}，可根据实际用途修改，磁盘的挂载路径只能是 {0} 开头的目录",
   "compute.public_ip_tooltip": "已分配公有IP的虚拟机不支持绑定/解绑弹性公网IP",
   "compute.rule": "规则",
   "compute.norule": "暂无规则",

--- a/containers/Compute/views/physicalmachine/dialogs/Convert.vue
+++ b/containers/Compute/views/physicalmachine/dialogs/Convert.vue
@@ -53,7 +53,7 @@
                   </template>
                   <a href="javascript:;" slot="extra" @click="handleDiskItemRemove(idx)" v-show="idx === diskOptionsDate.length - 1">{{$t('compute.perform_delete')}}</a>
                   <div class="d-flex align-items-center">
-                    <ve-pie :data="item.chartData" :settings="chartSettings" :events="chartFun(idx)" width="200px" height="200px" :legend-visible="false" />
+                    <ve-pie :data="item.chartData" :settings="chartSettings" :events="chartFun(idx)" width="200px" height="200px" :legend-visible="false" :tooltip="tooltip" />
                     <div class="flex-fill ml-2">
                       <template v-for="k in item.diskInfo">
                         <div :key="k">
@@ -274,6 +274,19 @@ export default {
         offsetY: 100,
         dataType: function (v) {
           return v + ' G'
+        },
+      },
+      tooltip: {
+        trigger: 'item',
+        axisPointer: {
+          type: 'line',
+          shadowStyle: {
+            color: 'rgb(77, 161, 255)',
+            opacity: 0.1,
+          },
+        },
+        position: (point, params, dom, rect, size) => {
+          return { left: point[0] - 30, top: point[1] - 20 }
         },
       },
       diskData: this.params.data[0].spec.disk, // 规格中的硬盘数据


### PR DESCRIPTION
Cherry pick of #6682 on release/3.10.

#6682: feat(3.11/4928): 转换宿主机时候添加磁盘的挂载路径只能是 /opt/cloud/workspace 开头的目录