### PR TITLE
Automated cherry pick of #6693: fix(v3.11/9938): Creating a bucket object list and using an ID to create resources

### DIFF
--- a/containers/Storage/views/bucket/sidepage/Objects.vue
+++ b/containers/Storage/views/bucket/sidepage/Objects.vue
@@ -183,7 +183,7 @@ export default {
                 },
               },
               callback: async (data) => {
-                const manager = new this.$Manager(`buckets/${this.resName}/makedir`, 'v2')
+                const manager = new this.$Manager(`buckets/${this.resId}/makedir`, 'v2')
                 data.key = `${this.prefix}${data.key}/`
                 await manager.create({ data })
                 this.list.fetchData()


### PR DESCRIPTION
Cherry pick of #6693 on release/3.11.

#6693: fix(v3.11/9938): Creating a bucket object list and using an ID to create resources