### PR TITLE
Automated cherry pick of #6706: fix(3.11/9949): 物理机转宿主机时，磁盘分区挂载点可以有多个/opt/cloud/workspace

### DIFF
--- a/containers/Compute/views/baremetal/dialogs/DiskOptionsUpdate.vue
+++ b/containers/Compute/views/baremetal/dialogs/DiskOptionsUpdate.vue
@@ -158,15 +158,16 @@ export default {
     },
     checkMountpoint (rule, value, callback) {
       const pathReg = new RegExp('^(/[^/ ]*)+')
+      const checkName = this.params.nameArr.filter(item => item.name === `${this.prefix}${value}`)
+      if (this.params.title === this.$t('compute.text_317') && checkName.length > 0) {
+        callback(new Error(this.$t('compute.text_337')))
+      }
       if (value) {
         if (!pathReg.test(value)) {
           callback(new Error(this.$t('compute.text_335')))
         }
         const checkName = this.params.nameArr.filter(item => item.name === `${this.prefix}${value}`)
         if (this.params.title === this.$t('compute.text_318') && checkName.length > 1) {
-          callback(new Error(this.$t('compute.text_337')))
-        }
-        if (this.params.title === this.$t('compute.text_317') && checkName.length > 0) {
           callback(new Error(this.$t('compute.text_337')))
         }
       }


### PR DESCRIPTION
Cherry pick of #6706 on release/3.11.

#6706: fix(3.11/9949): 物理机转宿主机时，磁盘分区挂载点可以有多个/opt/cloud/workspace