### PR TITLE
fix(v3.9): Operation logs display resource type from _i18n

### DIFF
--- a/src/sections/EventList/index.vue
+++ b/src/sections/EventList/index.vue
@@ -244,8 +244,14 @@ export default {
           title: this.$t('scope.text_653'),
           field: 'obj_type',
           hideField: true,
-          message: row => this.$te(`dictionary.${row.obj_type}`) ? this.$t(`dictionary.${row.obj_type}`) : row.obj_type,
-          slotCallback: row => this.$te(`dictionary.${row.obj_type}`) ? this.$t(`dictionary.${row.obj_type}`) : row.obj_type,
+          message: row => {
+            const { _i18n = {} } = row
+            return _i18n.obj_type || (this.$te(`dictionary.${row.obj_type}`) ? this.$t(`dictionary.${row.obj_type}`) : row.obj_type)
+          },
+          slotCallback: row => {
+            const { _i18n = {} } = row
+            return _i18n.obj_type || (this.$te(`dictionary.${row.obj_type}`) ? this.$t(`dictionary.${row.obj_type}`) : row.obj_type)
+          },
         }),
         {
           title: this.$t('common.operation_type'),


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

- release/3.12
- release/3.11
- release/3.10
- release/3.9
