### PR TITLE
Automated cherry pick of #6763: fix(v3.11/9952): onecloud 平台创建ssh代理节点请求cloudregions参数错误

### DIFF
--- a/containers/Network/views/ssh-proxy/form/index.vue
+++ b/containers/Network/views/ssh-proxy/form/index.vue
@@ -34,6 +34,7 @@
             :names="areaselectsName"
             :cloudregionParams="renderOrders.region.params"
             :providerParams="renderOrders.brand.params"
+            :cloudregionParamsMapper="cloudregionParamsMapper"
             filterBrandResource="compute_engine" />
           <a-form-item :label="$t('cloudenv.text_7')">
             <a-row :gutter="9">
@@ -398,6 +399,13 @@ export default {
           this.sshableStatus = newStatus
         }
       }
+    },
+    cloudregionParamsMapper (params) {
+      const ret = { ...params }
+      if (ret.provider === 'OneCloud') {
+        delete ret.capability
+      }
+      return ret
     },
     handleCancel () {
       this.$router.push('/ssh-proxy')


### PR DESCRIPTION
Cherry pick of #6763 on release/3.11.

#6763: fix(v3.11/9952): onecloud 平台创建ssh代理节点请求cloudregions参数错误