### PR TITLE
fix: adjust host details storage columes widths

### DIFF
--- a/containers/Compute/views/host/sidepage/Detail.vue
+++ b/containers/Compute/views/host/sidepage/Detail.vue
@@ -202,17 +202,18 @@ export default {
         {
           field: 'adapter',
           title: this.$t('compute.text_579'),
+          width: 70,
         },
         {
           field: 'driver',
           title: this.$t('compute.text_378'),
-          width: 80,
+          width: 140,
         },
         {
           field: 'model',
           title: this.$t('compute.text_580'),
           showOverflow: 'ellipsis',
-          minWidth: 100,
+          minWidth: 200,
         },
         {
           field: 'rotate',
@@ -239,7 +240,7 @@ export default {
         {
           field: 'ip_addr',
           title: 'IP',
-          width: 150,
+          width: 160,
         },
         {
           field: 'mac',

--- a/containers/Compute/views/physicalmachine/sidepage/Detail.vue
+++ b/containers/Compute/views/physicalmachine/sidepage/Detail.vue
@@ -50,17 +50,18 @@ export default {
         {
           field: 'adapter',
           title: this.$t('compute.text_579'),
+          width: 70,
         },
         {
           field: 'driver',
           title: this.$t('compute.text_378'),
-          width: 80,
+          width: 140,
         },
         {
           field: 'model',
           title: this.$t('compute.text_580'),
           showOverflow: 'ellipsis',
-          minWidth: 100,
+          minWidth: 200,
         },
         {
           field: 'rotate',


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: adjust host details storage columes widths

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.12
- release/3.11
- release/3.10

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @GuoLiBin6 