### PR TITLE
Automated cherry pick of #6880: fix(v3.11/4769): 公有云安全组规则入方向和出方向来源限制不允许为空

### DIFF
--- a/containers/Compute/views/secgroup-rule/components/List.vue
+++ b/containers/Compute/views/secgroup-rule/components/List.vue
@@ -165,6 +165,7 @@ export default {
               type: this.type,
               secgroup: this.id,
               brand: this.data.brand,
+              cloud_env: this.data.cloud_env,
             })
           },
           meta: () => {

--- a/containers/Compute/views/secgroup-rule/mixins/singleActions.js
+++ b/containers/Compute/views/secgroup-rule/mixins/singleActions.js
@@ -13,6 +13,7 @@ export default {
             refresh: this.refresh,
             type: this.type,
             brand: this.data.brand,
+            cloud_env: this.data.cloud_env,
           })
         },
         meta: (obj) => {


### PR DESCRIPTION
Cherry pick of #6880 on release/3.11.

#6880: fix(v3.11/4769): 公有云安全组规则入方向和出方向来源限制不允许为空