### PR TITLE
fix: vmware account init zone not need to be usable

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/create/form/components/VMware.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/VMware.vue
@@ -171,15 +171,15 @@ export default {
     cloudregionParams () {
       return {
         cloud_env: 'onpremise',
-        usable: true,
-        show_emulated: true,
+        // usable: true,
+        show_emulated: false,
         scope: this.$store.getters.scope,
       }
     },
     zoneParams () {
       return {
-        usable: true,
-        show_emulated: true,
+        // usable: true,
+        show_emulated: false,
         order_by: 'created_at',
         order: 'asc',
         scope: this.$store.getters.scope,

--- a/src/sections/CloudregionZone/index.vue
+++ b/src/sections/CloudregionZone/index.vue
@@ -120,7 +120,11 @@ export default {
         })
     },
     fetchZones (cloudregionId) {
-      const params = Object.assign({}, this.zoneParams, { cloudregion_id: cloudregionId, usable: true, order_by: 'created_at', order: 'asc' })
+      let zoneUsable = false
+      if (this.cloudregionParams && this.cloudregionParams.usable) {
+        zoneUsable = true
+      }
+      const params = Object.assign({}, this.zoneParams, { cloudregion_id: cloudregionId, usable: zoneUsable, order_by: 'created_at', order: 'asc' })
       // 清空可用区
       this.zoneOpts = []
       this.emit({}, 'zone')


### PR DESCRIPTION
**What this PR does / why we need it**:
vmware 账号的初始zone不需要加usable=true的过滤条件

添加esxi的时候区域和可用区为空咋回事
![image](https://github.com/yunionio/dashboard/assets/1121362/1cf10289-d4d1-45f3-91e5-fe92a7711e59)

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.12
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @GuoLiBin6 @zexi 