### PR TITLE
Automated cherry pick of #6901: fix: vmware account init zone not need to be usable

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/create/form/components/VMware.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/VMware.vue
@@ -171,15 +171,15 @@ export default {
     cloudregionParams () {
       return {
         cloud_env: 'onpremise',
-        usable: true,
-        show_emulated: true,
+        // usable: true,
+        show_emulated: false,
         scope: this.$store.getters.scope,
       }
     },
     zoneParams () {
       return {
-        usable: true,
-        show_emulated: true,
+        // usable: true,
+        show_emulated: false,
         order_by: 'created_at',
         order: 'asc',
         scope: this.$store.getters.scope,

--- a/src/sections/CloudregionZone/index.vue
+++ b/src/sections/CloudregionZone/index.vue
@@ -120,7 +120,11 @@ export default {
         })
     },
     fetchZones (cloudregionId) {
-      const params = Object.assign({}, this.zoneParams, { cloudregion_id: cloudregionId, usable: true, order_by: 'created_at', order: 'asc' })
+      let zoneUsable = false
+      if (this.cloudregionParams && this.cloudregionParams.usable) {
+        zoneUsable = true
+      }
+      const params = Object.assign({}, this.zoneParams, { cloudregion_id: cloudregionId, usable: zoneUsable, order_by: 'created_at', order: 'asc' })
       // 清空可用区
       this.zoneOpts = []
       this.emit({}, 'zone')


### PR DESCRIPTION
Cherry pick of #6901 on release/3.12.

#6901: fix: vmware account init zone not need to be usable