### PR TITLE
feat(compute): add netio pps metrics

### DIFF
--- a/containers/Compute/locales/en.json
+++ b/containers/Compute/locales/en.json
@@ -526,6 +526,8 @@
   "compute.text_523": "CPU Usage",
   "compute.text_524": "Network Inbound Traffic",
   "compute.text_525": "Network Outbound Traffic",
+  "compute.netio.pps_sent": "Packet Sent Per Second",
+  "compute.netio.pps_recv": "Packet Received Per Second",
   "compute.text_526": "Disk Read Rate",
   "compute.text_527": "Disk Write Rate",
   "compute.text_528": "CPU usage rate, CPU idle rate, user space occupied by CPU, kernel space occupied by CPU, proportion of CPU time waiting for input and output",

--- a/containers/Compute/locales/ja-JP.json
+++ b/containers/Compute/locales/ja-JP.json
@@ -526,6 +526,8 @@
   "compute.text_523": "CPU 使用率",
   "compute.text_524": "ネットワーク受信トラフィック",
   "compute.text_525": "ネットワーク エグレス トラフィック",
+  "compute.netio.pps_sent": "1 秒あたりの送信パケット数",
+  "compute.netio.pps_recv": "1 秒あたりの受信パケット数",
   "compute.text_526": "ディスク読み取り速度",
   "compute.text_527": "ディスク書き込み速度",
   "compute.text_528": "CPU 使用率、CPU アイドル率、ユーザー領域が CPU を占有、カーネル領域が CPU を占有、入出力を待機する CPU 時間",

--- a/containers/Compute/locales/zh-CN.json
+++ b/containers/Compute/locales/zh-CN.json
@@ -526,6 +526,8 @@
   "compute.text_523": "CPU使用率",
   "compute.text_524": "网络入流量",
   "compute.text_525": "网络出流量",
+  "compute.netio.pps_sent": "网络发包数/秒",
+  "compute.netio.pps_recv": "网络收包数/秒",
   "compute.text_526": "磁盘读速率",
   "compute.text_527": "磁盘写速率",
   "compute.text_528": "CPU使用率,CPU空闲率,用户空间占用CPU,内核空间占用CPU,等待输入输出的CPU时间占比",

--- a/containers/Compute/views/node-alert/constants.js
+++ b/containers/Compute/views/node-alert/constants.js
@@ -26,6 +26,8 @@ export const metricItems = {
   'vm_mem.used': { key: 'vm_mem.used', label: i18n.t('monitor.text_127'), unit: 'G' },
   'vm_netio.bps_recv': { key: 'vm_netio.bps_recv', label: i18n.t('compute.text_756'), unit: 'bps' },
   'vm_netio.bps_sent': { key: 'vm_netio.bps_sent', label: i18n.t('compute.text_757'), unit: 'bps' },
+  'vm_netio.pps_recv': { key: 'vm_netio.pps_recv', label: i18n.t('compute.netio.pps_recv'), unit: 'pps' },
+  'vm_netio.pps_sent': { key: 'vm_netio.pps_sent', label: i18n.t('compute.netio.pps_sent'), unit: 'pps' },
   'vm_diskio.read_bps': { key: 'vm_diskio.read_bps', label: i18n.t('compute.text_758'), unit: 'bps' },
   'vm_diskio.write_bps': { key: 'vm_diskio.write_bps', label: i18n.t('compute.text_759'), unit: 'bps' },
   // KVM宿主机

--- a/containers/Compute/views/vminstance/constants.js
+++ b/containers/Compute/views/vminstance/constants.js
@@ -117,6 +117,26 @@ const NET_SENT_BPS = {
   transfer: 1024,
 }
 
+const NET_RECV_PPS = {
+  name: 'net',
+  label: i18n.t('compute.netio.pps_recv'),
+  seleteItem: 'pps_recv',
+  fromItem: 'agent_net',
+  groupBy: ['interface'],
+  unit: 'pps',
+  transfer: 1,
+}
+
+const NET_SENT_PPS = {
+  name: 'net',
+  label: i18n.t('compute.netio.pps_sent'),
+  seleteItem: 'pps_sent',
+  fromItem: 'agent_net',
+  groupBy: ['interface'],
+  unit: 'pps',
+  transfer: 1,
+}
+
 const COND_AND = 'AND'
 // const COND_OR = 'OR'
 // const COND_NULL = ''
@@ -138,6 +158,8 @@ export const AGENT_MONITOR = [
   DISK_IO_WRITE_RATES,
   NET_RECV_BPS,
   NET_SENT_BPS,
+  NET_RECV_PPS,
+  NET_SENT_PPS,
 ]
 
 const TEMPERATURE_CPU_INPUT = {
@@ -208,6 +230,8 @@ export const AGENT_TEMPERATURE_MONITOR = [
   TEMPERATURE_VIRTUAL_INPUT,
 ]
 
+const NETIO_GROUP_BY_TAG = ['interface', 'host_interface', 'ip', 'mac']
+
 // OneCloud 虚拟机监控数据
 export const ONECLOUD_MONITOR = [
   {
@@ -228,7 +252,7 @@ export const ONECLOUD_MONITOR = [
     transfer: 1,
     metric: metricItems['vm_mem.used_percent'].key,
   },
-  BASIC_DISK_USED_PERCENT,
+  // BASIC_DISK_USED_PERCENT,
   {
     name: 'netio',
     label: i18n.t('compute.text_524'),
@@ -237,6 +261,7 @@ export const ONECLOUD_MONITOR = [
     unit: 'bps',
     transfer: 1024,
     metric: metricItems['vm_netio.bps_recv'].key,
+    groupBy: NETIO_GROUP_BY_TAG,
   },
   {
     name: 'netio',
@@ -246,6 +271,27 @@ export const ONECLOUD_MONITOR = [
     unit: 'bps',
     transfer: 1024,
     metric: metricItems['vm_netio.bps_sent'].key,
+    groupBy: NETIO_GROUP_BY_TAG,
+  },
+  {
+    name: 'netio',
+    label: i18n.t('compute.netio.pps_sent'),
+    seleteItem: 'pps_sent',
+    fromItem: 'vm_netio',
+    transfer: 1,
+    unit: 'pps',
+    metric: metricItems['vm_netio.pps_sent'].key,
+    groupBy: NETIO_GROUP_BY_TAG,
+  },
+  {
+    name: 'netio',
+    label: i18n.t('compute.netio.pps_recv'),
+    seleteItem: 'pps_recv',
+    fromItem: 'vm_netio',
+    transfer: 1,
+    unit: 'pps',
+    metric: metricItems['vm_netio.pps_recv'].key,
+    groupBy: NETIO_GROUP_BY_TAG,
   },
   {
     name: 'diskio',


### PR DESCRIPTION
**What this PR does / why we need it**:

- 给虚拟机基础监控和agent监控添加网络 pps_sent/recv 监控
- 去掉虚拟机基础监控里面的 disk_usage 监控

效果如下：

<img width="1028" alt="image" src="https://github.com/user-attachments/assets/991fa307-d2fa-479e-9690-552df8591273">
<img width="1045" alt="image" src="https://github.com/user-attachments/assets/905b25d1-b059-4e69-b062-eaf4259c27d1">


<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

- 3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @swordqiu @GuoLiBin6 