### PR TITLE
feat(monitor): add p95 and p50 query of monitor

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5436,6 +5436,8 @@
   "common.min": "Min",
   "common.max": "Max",
   "common.mean": "Average",
+  "common.p95": "P95",
+  "common.p50": "P50",
   "common.eip": "Eip",
   "common.show_origin_1": "Only show {0} bills - original bills",
   "common.show_origin_2": "Show all bills in units of {0} - the original bill",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -5453,6 +5453,8 @@
   "common.min": "最低限",
   "common.max": "最大",
   "common.mean": "平均値",
+  "common.p95": "P95",
+  "common.p50": "P50",
   "common.eip": "エラスティック IP",
   "common.show_origin_1": "{0} つの請求書 (元の請求書) のみが表示されます",
   "common.show_origin_2": "{0}のすべての請求書 (元の請求書) を表示します。",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -5457,6 +5457,8 @@
   "common.min": "最小值",
   "common.max": "最大值",
   "common.mean": "平均值",
+  "common.p95": "P95",
+  "common.p50": "P50",
   "common.eip": "弹性IP",
   "common.show_origin_1": "仅显示{0}账单-原账单",
   "common.show_origin_2": "以{0}为单位显示所有账单-原账单",

--- a/src/sections/Monitor/Header.vue
+++ b/src/sections/Monitor/Header.vue
@@ -142,6 +142,8 @@ export default {
         { key: 'min', label: this.$t('common.min') },
         { key: 'max', label: this.$t('common.max') },
         { key: 'mean', label: this.$t('common.mean') },
+        { key: 'p95', label: this.$t('common.p95') },
+        { key: 'p50', label: this.$t('common.p50') },
       ],
     }
   },

--- a/src/utils/monitor.js
+++ b/src/utils/monitor.js
@@ -2,6 +2,22 @@ import { UNITS, autoComputeUnit, getRequestT } from '@/utils/utils'
 import { getSignature } from '@/utils/crypto'
 
 function genServerQueryData (vmId, val, scope, from, interval, idKey, customTime, skip_check_series) {
+  // 对应 mean(val.seleteItem)
+  const aggregateParams = {
+    type: val.groupFunc || val.selectFunction || 'mean',
+    params: [],
+  }
+  const PERCENTILE = 'percentile'
+  const aggrFunc = val.groupFunc
+  if (aggrFunc === 'p95') {
+    aggregateParams.type = PERCENTILE
+    aggregateParams.params = [95]
+  }
+  if (aggrFunc === 'p50') {
+    aggregateParams.type = PERCENTILE
+    aggregateParams.params = [50]
+  }
+
   const model = {
     measurement: val.fromItem,
     select: [
@@ -10,10 +26,7 @@ function genServerQueryData (vmId, val, scope, from, interval, idKey, customTime
           type: 'field',
           params: [val.seleteItem],
         },
-        { // 对应 mean(val.seleteItem)
-          type: val.groupFunc || val.selectFunction || 'mean',
-          params: [],
-        },
+        aggregateParams,
         { // 确保后端返回columns有 val.label 的别名
           type: 'alias',
           params: [val.label],


### PR DESCRIPTION
**What this PR does / why we need it**:

Related issue: https://github.com/yunionio/cloudpods/issues/20832

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/46976c68-9153-44c9-8f22-1b1dec8e2eb0">


<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 3.11.6
/cc @swordqiu @GuoLiBin6 