### PR TITLE
Automated cherry pick of #7031: fix: 新建wmware云账号,去除cloudregion对compute_engine_brands参数的检查

### DIFF
--- a/containers/Cloudenv/views/cloudaccount/create/form/components/VMware.vue
+++ b/containers/Cloudenv/views/cloudaccount/create/form/components/VMware.vue
@@ -14,8 +14,7 @@
         <cloudregion-zone
           :zone-params="zoneParams"
           :cloudregion-params="cloudregionParams"
-          :decorator="decorators.cloudregionZone"
-          filterBrandResource="compute_engine" />
+          :decorator="decorators.cloudregionZone" />
       </a-form-item>
       <a-form-item :label="$t('cloudenv.text_264')" :extra="this.$t('common_572')">
         <a-input v-decorator="decorators.host" />


### PR DESCRIPTION
Cherry pick of #7031 on release/3.11.6.

#7031: fix: 新建wmware云账号,去除cloudregion对compute_engine_brands参数的检查