### PR TITLE
Automated cherry pick of #7035: fix: copy web-console files by dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-# web-base:v3.6.1 是 能够兼容 arm64 的版本
-FROM registry.cn-beijing.aliyuncs.com/yunionio/web-base:v3.10.3-20230619.1
+FROM registry.cn-beijing.aliyuncs.com/yunionio/web-console-fe:v3.11-20240808.1 AS web-console
+FROM registry.cn-beijing.aliyuncs.com/yunionio/web-base:v3.10.3-20240808.2
 
 COPY ./dist /usr/share/nginx/html/web
 COPY ./conf/nginx.conf /etc/nginx/nginx.conf
+COPY --from=web-console /usr/share/nginx/html/web-console /usr/share/nginx/html/web-console


### PR DESCRIPTION
Cherry pick of #7035 on release/3.11.

#7035: fix: copy web-console files by dockerfile