### PR TITLE
Automated cherry pick of #7080: fix: dns解析设置共享去除三级权限是否开启的检查

### DIFF
--- a/containers/Network/views/dns-zone/mixins/singleActions.js
+++ b/containers/Network/views/dns-zone/mixins/singleActions.js
@@ -98,6 +98,7 @@ export default {
               name: this.$t('dictionary.dns_zone'),
               scope: 'domain',
               resource: 'dns_zones',
+              ignorel3PermissionEnable: true,
             }),
             {
               label: this.$t('network.text_131'),

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -69,4 +69,17 @@ i18n.setOriginDictionary = () => {
   }
 }
 
+i18n.getOriginDictionaryI18n = (key, defaultValue) => {
+  const l = getLanguage()
+  let f = {}
+  if (l === 'en') {
+    f = R.clone(en.dictionary)
+  } else if (l === 'zh-CN') {
+    f = R.clone(zhCN.dictionary)
+  } else if (l === 'ja-JP') {
+    f = R.clone(jaJP.dictionary)
+  }
+  return f[key] || defaultValue
+}
+
 export default i18n

--- a/src/utils/common/tableActions.js
+++ b/src/utils/common/tableActions.js
@@ -91,7 +91,7 @@ export function getSetPublicAction (vm, dialogParams = {}, params = {}) {
   if (!vm) {
     throw Error('not found vm instance')
   }
-  const { name = i18n.t('common_92'), scope, resource, apiVersion, noCandidateDomains, projectExtraParams = {} } = dialogParams
+  const { name = i18n.t('common_92'), scope, resource, apiVersion, noCandidateDomains, projectExtraParams = {}, ignorel3PermissionEnable = false } = dialogParams
   const options = {
     label: i18n.t('common_100'),
     action: row => {
@@ -110,7 +110,7 @@ export function getSetPublicAction (vm, dialogParams = {}, params = {}) {
       })
     },
     meta: row => {
-      if (!store.getters.l3PermissionEnable && (scope === 'domain' || (store.getters.scopeResource && store.getters.scopeResource.domain.includes(resource)))) {
+      if (!ignorel3PermissionEnable && !store.getters.l3PermissionEnable && (scope === 'domain' || (store.getters.scopeResource && store.getters.scopeResource.domain.includes(resource)))) {
         return {
           validate: false,
           tooltip: i18n.t('common_281'),


### PR DESCRIPTION
Cherry pick of #7080 on release/3.12.

#7080: fix: dns解析设置共享去除三级权限是否开启的检查