### PR TITLE
Automated cherry pick of #7112: fix: 域过滤由domain字段改为project_domain

### DIFF
--- a/containers/K8S/views/cluster/components/List.vue
+++ b/containers/K8S/views/cluster/components/List.vue
@@ -11,7 +11,7 @@
 
 <script>
 import * as R from 'ramda'
-import { getNameFilter, getCreatedAtFilter, getDomainFilter } from '@/utils/common/tableFilter'
+import { getNameFilter, getCreatedAtFilter, getProjectDomainFilter } from '@/utils/common/tableFilter'
 import expectStatus from '@/constants/expectStatus'
 import WindowsMixin from '@/mixins/windows'
 import GlobalSearchMixin from '@/mixins/globalSearch'
@@ -44,7 +44,7 @@ export default {
             label: this.$t('table.title.id'),
           },
           name: getNameFilter(),
-          domain: getDomainFilter(),
+          project_domain: getProjectDomainFilter(),
           created_at: getCreatedAtFilter(),
         },
         filter,

--- a/containers/K8S/views/nodes/components/List.vue
+++ b/containers/K8S/views/nodes/components/List.vue
@@ -12,7 +12,7 @@
 
 <script>
 import ClusterNamespace from '@K8S/sections/ClusterNamespace'
-import { getNameFilter, getStatusFilter, getDomainFilter } from '@/utils/common/tableFilter'
+import { getNameFilter, getStatusFilter, getProjectDomainFilter } from '@/utils/common/tableFilter'
 import WindowsMixin from '@/mixins/windows'
 import ListMixin from '@/mixins/list'
 import ColumnsMixin from '../mixins/columns'
@@ -48,7 +48,7 @@ export default {
         filterOptions: {
           name: getNameFilter(),
           status: getStatusFilter({ statusMoule: 'kubecluster' }),
-          domain: getDomainFilter(),
+          project_domain: getProjectDomainFilter(),
         },
         filter,
       }),

--- a/containers/Network/views/waf/components/List.vue
+++ b/containers/Network/views/waf/components/List.vue
@@ -13,7 +13,7 @@
 
 <script>
 import expectStatus from '@/constants/expectStatus'
-import { getNameFilter, getDescriptionFilter, getBrandFilter, getAccountFilter, getDomainFilter, getRegionFilter, getCloudProviderFilter } from '@/utils/common/tableFilter'
+import { getNameFilter, getDescriptionFilter, getBrandFilter, getAccountFilter, getProjectDomainFilter, getRegionFilter, getCloudProviderFilter } from '@/utils/common/tableFilter'
 import WindowsMixin from '@/mixins/windows'
 import ListMixin from '@/mixins/list'
 import SingleActionsMixin from '../mixins/singleActions'
@@ -53,7 +53,7 @@ export default {
           brand: getBrandFilter(),
           account: getAccountFilter(),
           manager: getCloudProviderFilter(),
-          domain: getDomainFilter(),
+          project_domain: getProjectDomainFilter(),
           region: getRegionFilter(),
         },
         hiddenColumns: [],


### PR DESCRIPTION
Cherry pick of #7112 on release/3.11.

#7112: fix: 域过滤由domain字段改为project_domain