### PR TITLE
Automated cherry pick of #7250: fix: ip子网创建,cloudpods免填ipv6

### DIFF
--- a/containers/Network/views/network/Create.vue
+++ b/containers/Network/views/network/Create.vue
@@ -738,6 +738,9 @@ export default {
       if (this.cloudEnv === 'private' && this.curVpc?.brand === 'Cloudpods' && this.curVpc?.external_id === 'default') {
         this.isShowWire = true
         this.isGroupGuestIpPrefix = true
+      } else {
+        this.isShowWire = false
+        this.isGroupGuestIpPrefix = false
       }
     },
     vpcLabelFormat (item) {


### PR DESCRIPTION
Cherry pick of #7250 on release/3.11.

#7250: fix: ip子网创建,cloudpods免填ipv6