### PR TITLE
Automated cherry pick of #7375: fix: 虚拟机调度失败时宿主机不应该再展示请求中的状态

### DIFF
--- a/containers/Compute/views/vminstance/mixins/columns.js
+++ b/containers/Compute/views/vminstance/mixins/columns.js
@@ -483,7 +483,7 @@ export default {
         minWidth: 100,
         slots: {
           default: ({ row }) => {
-            if (!row.host) return [<data-loading />]
+            if (this.isPreLoad && !row.host) return [<data-loading />]
             if (findPlatform(row.hypervisor, 'hypervisor') === SERVER_TYPE.public || row.hypervisor === HYPERVISORS_MAP.hcso.hypervisor || row.hypervisor === HYPERVISORS_MAP.hcs.hypervisor) {
               return '-'
             }


### PR DESCRIPTION
Cherry pick of #7375 on release/3.11.9.

#7375: fix: 虚拟机调度失败时宿主机不应该再展示请求中的状态