### PR TITLE
Automated cherry pick of #7437: fix: 主机组翻译改为反亲和组

### DIFF
--- a/containers/Compute/locales/en.json
+++ b/containers/Compute/locales/en.json
@@ -88,7 +88,7 @@
   "compute.text_90": "Compute",
   "compute.text_91": "VM instance",
   "compute.text_92": "Baremetals",
-  "compute.text_93": "Server Groups",
+  "compute.text_93": "@:dictionary.instancegroup",
   "compute.text_94": "Templates",
   "compute.text_95": "Scaling Groups",
   "compute.text_96": "Images",

--- a/containers/Compute/locales/ja-JP.json
+++ b/containers/Compute/locales/ja-JP.json
@@ -88,7 +88,7 @@
   "compute.text_90": "ホスト",
   "compute.text_91": "仮想マシン",
   "compute.text_92": "ベアメタル",
-  "compute.text_93": "ホストグループ",
+  "compute.text_93": "@:dictionary.instancegroup",
   "compute.text_94": "テンプレート",
   "compute.text_95": "自動スケーリンググループ",
   "compute.text_96": "鏡像",

--- a/containers/Compute/locales/zh-CN.json
+++ b/containers/Compute/locales/zh-CN.json
@@ -88,7 +88,7 @@
   "compute.text_90": "主机",
   "compute.text_91": "虚拟机",
   "compute.text_92": "裸金属",
-  "compute.text_93": "主机组",
+  "compute.text_93": "@:dictionary.instancegroup",
   "compute.text_94": "主机模板",
   "compute.text_95": "弹性伸缩组",
   "compute.text_96": "镜像",


### PR DESCRIPTION
Cherry pick of #7437 on release/3.11.

#7437: fix: 主机组翻译改为反亲和组