### PR TITLE
fix: add icon to hide monitor metric table grid

### DIFF
--- a/containers/Compute/locales/en.json
+++ b/containers/Compute/locales/en.json
@@ -1866,5 +1866,6 @@
   "compute.uis.fs": "Shared disk",
   "compute.virtual_total": "Virtual Total",
   "compute.actual_total": "Physical Total",
+  "compute.actual_used": "Acutual Used",
   "compute.force_shutdown": "Forced shutdown"
 }

--- a/containers/Compute/locales/ja-JP.json
+++ b/containers/Compute/locales/ja-JP.json
@@ -1868,5 +1868,6 @@
   "compute.uis.fs": "共有ディスク",
   "compute.virtual_total": "仮想総量",
   "compute.actual_total": "物理総量",
+  "compute.actual_used": "実際の使用",
   "compute.force_shutdown": "強制シャットダウン"
 }

--- a/containers/Compute/locales/zh-CN.json
+++ b/containers/Compute/locales/zh-CN.json
@@ -1868,5 +1868,6 @@
   "compute.uis.fs": "共享盘",
   "compute.virtual_total": "虚拟总量",
   "compute.actual_total": "物理总量",
+  "compute.actual_used": "实际使用",
   "compute.force_shutdown": "强制关机"
 }

--- a/containers/Compute/views/host/mixins/columns.js
+++ b/containers/Compute/views/host/mixins/columns.js
@@ -193,7 +193,7 @@ export default {
           default: ({ row }) => {
             const { cpu_count, cpu_count_virtual, cpu_commit } = getHostSpecInfo(row)
             const title = `${this.$t('common_233')}: ${cpu_commit}\n${this.$t('compute.actual_total')}: ${cpu_count}\n${this.$t('compute.virtual_total')}: ${cpu_count_virtual}`
-            return [<MultipleProgress title={title} progress1Value={cpu_commit} progress2Value={cpu_count} progress3Value={cpu_count_virtual} text={`${cpu_commit}/${cpu_count}/${cpu_count_virtual}`} />]
+            return [<MultipleProgress title={title} progress1Value={Math.max(1, cpu_commit)} progress2Value={Math.max(1, cpu_count)} progress3Value={Math.max(1, cpu_count_virtual)} text={`${cpu_commit}/${cpu_count}/${cpu_count_virtual}`} />]
           },
         },
         formatter: ({ row }) => {
@@ -212,7 +212,7 @@ export default {
           default: ({ row }) => {
             const { mem_size, mem_size_virtual, mem_commit } = getHostSpecInfo(row)
             const title = `${this.$t('common_233')}: ${sizestr(mem_commit, 'M', 1024)}\n${this.$t('compute.actual_total')}: ${sizestr(mem_size, 'M', 1024)}\n${this.$t('compute.virtual_total')}: ${sizestr(mem_size_virtual, 'M', 1024)}`
-            return [<MultipleProgress title={title} progress1Value={mem_commit} progress2Value={mem_size} progress3Value={mem_size_virtual} text={`${sizestr(mem_commit, 'M', 1024)}/${sizestr(mem_size, 'M', 1024)}/${sizestr(mem_size_virtual, 'M', 1024)}`} />]
+            return [<MultipleProgress title={title} progress1Value={Math.max(1, mem_commit)} progress2Value={Math.max(1, mem_size)} progress3Value={Math.max(1, mem_size_virtual)} text={`${sizestr(mem_commit, 'M', 1024)}/${sizestr(mem_size, 'M', 1024)}/${sizestr(mem_size_virtual, 'M', 1024)}`} />]
           },
         },
         formatter: ({ row }) => {
@@ -229,14 +229,14 @@ export default {
         sortBy: 'order_by_storage_used',
         slots: {
           default: ({ row }) => {
-            const { storage_size, storage_size_virtual, storage_commit } = getHostSpecInfo(row)
-            const title = `${this.$t('common_233')}: ${sizestr(storage_commit, 'M', 1024)}\n${this.$t('compute.actual_total')}: ${sizestr(storage_size, 'M', 1024)}\n${this.$t('compute.virtual_total')}: ${sizestr(storage_size_virtual, 'M', 1024)}`
-            return [<MultipleProgress title={title} progress1Value={storage_commit} progress2Value={storage_size} progress3Value={storage_size_virtual} text={`${sizestr(storage_commit, 'M', 1024)}/${sizestr(storage_size, 'M', 1024)}/${sizestr(storage_size_virtual, 'M', 1024)}`} />]
+            const { storage_size, storage_size_virtual, storage_commit, actual_storage_used } = getHostSpecInfo(row)
+            const title = `${this.$t('compute.actual_used')}: ${sizestr(actual_storage_used, 'M', 1024)}\n${this.$t('common_233')}: ${sizestr(storage_commit, 'M', 1024)}\n${this.$t('compute.actual_total')}: ${sizestr(storage_size, 'M', 1024)}\n${this.$t('compute.virtual_total')}: ${sizestr(storage_size_virtual, 'M', 1024)}`
+            return [<MultipleProgress title={title} progress0Value={Math.max(1, actual_storage_used)} progress1Value={Math.max(1, storage_commit)} progress2Value={Math.max(1, storage_size)} progress3Value={Math.max(1, storage_size_virtual)} text={`${sizestr(actual_storage_used, 'M', 1024)}/${sizestr(storage_commit, 'M', 1024)}/${sizestr(storage_size, 'M', 1024)}/${sizestr(storage_size_virtual, 'M', 1024)}`} />]
           },
         },
         formatter: ({ row }) => {
-          const { storage_size, storage_size_virtual, storage_commit } = getHostSpecInfo(row)
-          const title = `${this.$t('common_233')}: ${sizestr(storage_commit, 'M', 1024)}, ${this.$t('compute.actual_total')}: ${sizestr(storage_size, 'M', 1024)}, ${this.$t('compute.virtual_total')}: ${sizestr(storage_size_virtual, 'M', 1024)}`
+          const { storage_size, storage_size_virtual, storage_commit, actual_storage_used } = getHostSpecInfo(row)
+          const title = `${this.$t('compute.actual_used')}: ${sizestr(actual_storage_used, 'M', 1024)}, ${this.$t('common_233')}: ${sizestr(storage_commit, 'M', 1024)}, ${this.$t('compute.actual_total')}: ${sizestr(storage_size, 'M', 1024)}, ${this.$t('compute.virtual_total')}: ${sizestr(storage_size_virtual, 'M', 1024)}`
           return title
         },
       },

--- a/containers/Compute/views/host/utils/index.js
+++ b/containers/Compute/views/host/utils/index.js
@@ -13,6 +13,7 @@ export const getHostSpecInfo = (obj) => {
     mem_commit_rate,
     storage_size,
     storage_used,
+    actual_storage_used,
     storage_commit_rate,
     storage_virtual,
   } = obj
@@ -36,6 +37,7 @@ export const getHostSpecInfo = (obj) => {
     storage_size_virtual: storage_virtual,
     storage_commit: storage_used,
     storage_commit_rate,
+    actual_storage_used,
   }
   return ret
 }

--- a/containers/Monitor/sections/MonitorLine/index.vue
+++ b/containers/Monitor/sections/MonitorLine/index.vue
@@ -1,5 +1,18 @@
 <template>
-  <a-card :title="title" size="small" class="explorer-monitor-line" :style="monitorLineCardStyle">
+  <a-card size="small" class="explorer-monitor-line" :style="monitorLineCardStyle">
+    <div slot="title" v-if="title">
+      <a-row type="flex">
+        <a-col>
+          <a class="font-weight-bold h-100 d-block" style="margin-right: 6px;" @click="toggleShowTableLegend">
+            <a-icon type="line-chart" style="font-size: 14px;" v-if="showTableLegend" />
+            <a-icon type="credit-card" style="font-size: 14px;" v-if="!showTableLegend" />
+          </a>
+        </a-col>
+        <a-col :span="21">
+          {{ title }}
+        </a-col>
+      </a-row>
+    </div>
     <div slot="extra" v-if="showTableExport">
       <a-button v-if="showTableExport && curPager.total" type="link" :title="$t('monitor.full_export')" @click="exportTable">
         {{ $t('table.action.export') }}
@@ -754,6 +767,9 @@ export default {
       const ws = XLSX.utils.aoa_to_sheet(list)
       XLSX.utils.book_append_sheet(wb, ws, ws_name)
       XLSX.writeFile(wb, filename)
+    },
+    toggleShowTableLegend () {
+      this.showTableLegend = !this.showTableLegend
     },
   },
 }

--- a/src/components/MultipleProgress/index.vue
+++ b/src/components/MultipleProgress/index.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="progress-wrapper" :title="title">
     <div class="title">{{ text }}</div>
+    <div class="progress0" v-if="progressConfig.progress0.show" :style="progressConfig.progress0.style" />
     <div class="progress1" v-if="progressConfig.progress1.show" :style="progressConfig.progress1.style" />
     <div class="progress2" v-if="progressConfig.progress2.show" :style="progressConfig.progress2.style" />
     <div class="progress3" v-if="progressConfig.progress3.show" :style="progressConfig.progress3.style" />
@@ -13,32 +14,56 @@ export default {
   props: {
     text: String,
     title: String,
-    progress1Value: Number,
-    progress2Value: Number,
-    progress3Value: Number,
+    progress0Value: {
+      type: Number,
+      default: 0.0,
+      required: false,
+    },
+    progress1Value: {
+      type: Number,
+      default: 0.0,
+      required: false,
+    },
+    progress2Value: {
+      type: Number,
+      default: 0.0,
+      required: false,
+    },
+    progress3Value: {
+      type: Number,
+      default: 0.0,
+      required: false,
+    },
   },
   computed: {
     progressConfig () {
-      const max = Math.max(this.progress1Value, this.progress2Value, this.progress3Value)
+      const max = Math.max(this.progress0Value, this.progress1Value, this.progress2Value, this.progress3Value)
       return {
-        progress1: {
-          show: true,
+        progress0: {
+          show: this.progress0Value > 0,
           style: {
-            width: this.progress1Value / max * 100 + '%',
+            width: Math.max(0.01, this.progress0Value / max) * 100 + '%',
+            background: this.color || 'var(--antd-wave-shadow-color)',
+          },
+        },
+        progress1: {
+          show: this.progress1Value > 0,
+          style: {
+            width: Math.max(0.01, this.progress1Value / max) * 100 + '%',
             background: this.color || 'var(--antd-wave-shadow-color)',
           },
         },
         progress2: {
-          show: true,
+          show: this.progress2Value > 0,
           style: {
-            width: this.progress2Value / max * 100 + '%',
+            width: Math.max(0.01, this.progress2Value / max) * 100 + '%',
             border: `solid 1px ${this.color || 'var(--antd-wave-shadow-color)'}`,
           },
         },
         progress3: {
-          show: true,
+          show: this.progress3Value > 0,
           style: {
-            width: this.progress3Value / max * 100 + '%',
+            width: Math.max(0.01, this.progress3Value / max) * 100 + '%',
             border: `dashed 1px ${this.color || 'var(--antd-wave-shadow-color)'}`,
           },
         },
@@ -58,7 +83,7 @@ export default {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .progress1, .progress2, .progress3 {
+  .progress0, .progress1, .progress2, .progress3 {
     height: 5px;
     max-width: 100px;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
1. add icon to hide monitor table grid
2. host show actual_storage_used

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
- release/3.11

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
/cc @GuoLiBin6 @zexi 