### PR TITLE
Automated cherry pick of #7659: fix: kvm机器选择windows镜像同时选择GPU-VGA增加限制需支持uefi

### DIFF
--- a/containers/Compute/views/vminstance/create/form/IDC.vue
+++ b/containers/Compute/views/vminstance/create/form/IDC.vue
@@ -464,7 +464,7 @@ export default {
     uefi () {
       const { pciEnable, pciDevType, pciModel } = this.form.fd
       if (this.isKvm && pciEnable && pciModel) {
-        if (this.isWindows || Object.values(pciDevType).includes(GPU_DEV_TYPE_OPTIONS[0].value)) {
+        if (this.isWindows && Object.values(pciDevType).includes(GPU_DEV_TYPE_OPTIONS[0].value)) {
           return true
         }
       }


### PR DESCRIPTION
Cherry pick of #7659 on release/3.11.10.

#7659: fix: kvm机器选择windows镜像同时选择GPU-VGA增加限制需支持uefi