### PR TITLE
Automated cherry pick of #7732: feat: aws磁盘增加最大最小值限制

### DIFF
--- a/containers/Compute/constants/index.js
+++ b/containers/Compute/constants/index.js
@@ -533,7 +533,7 @@ export const STORAGE_TYPES = {
       value: 'io1',
       min: 4,
       max: 16384,
-      sysMin: 1,
+      sysMin: 4,
       sysMax: 16384,
     },
     io2: {
@@ -541,7 +541,7 @@ export const STORAGE_TYPES = {
       value: 'io1',
       min: 4,
       max: 16384,
-      sysMin: 1,
+      sysMin: 4,
       sysMax: 16384,
     },
     st1: {
@@ -564,7 +564,7 @@ export const STORAGE_TYPES = {
       min: 1,
       max: 1024,
       sysMin: 1,
-      sysMax: 16384,
+      sysMax: 1024,
     },
     gp3: {
       label: i18n.t('compute.storage_gp3'),

--- a/src/constants/compute.js
+++ b/src/constants/compute.js
@@ -130,7 +130,7 @@ export const STORAGE_TYPES = {
       key: 'io1',
       min: 4,
       max: 16384,
-      sysMin: 1,
+      sysMin: 4,
       sysMax: 16384,
     },
     io2: {
@@ -138,7 +138,7 @@ export const STORAGE_TYPES = {
       key: 'io1',
       min: 4,
       max: 16384,
-      sysMin: 1,
+      sysMin: 4,
       sysMax: 16384,
     },
     st1: {
@@ -160,6 +160,14 @@ export const STORAGE_TYPES = {
       key: 'standard',
       min: 1,
       max: 1024,
+      sysMin: 1,
+      sysMax: 1024,
+    },
+    gp3: {
+      label: i18n.t('compute.storage_gp3'),
+      value: 'gp3',
+      min: 1,
+      max: 16384,
       sysMin: 1,
       sysMax: 16384,
     },


### PR DESCRIPTION
Cherry pick of #7732 on release/3.11.

#7732: feat: aws磁盘增加最大最小值限制