### PR TITLE
Automated cherry pick of #7852: fix: 修复列表检查状态对参数值为空的参数的判断

### DIFF
--- a/src/utils/list.js
+++ b/src/utils/list.js
@@ -76,8 +76,12 @@ class WaitStatusJob {
     if (!R.isEmpty(this.data.list.itemGetParams)) {
       for (const key in this.data.list.itemGetParams) {
         const val = this.data.list.itemGetParams[key]
-        if (val) {
-          params[key] = val
+        if (this.data.list.itemGetParams.hasOwnProperty(key)) {
+          if (val) {
+            params[key] = val
+          } else {
+            delete params[key]
+          }
         } else {
           params[key] = this.data.data[key]
         }


### PR DESCRIPTION
Cherry pick of #7852 on master.

#7852: fix: 修复列表检查状态对参数值为空的参数的判断