### PR TITLE
fix: 修复虚拟机和gpu作为二级页面仍然初始化router中的过滤参数问题

### DIFF
--- a/containers/Compute/views/gpu/components/List.vue
+++ b/containers/Compute/views/gpu/components/List.vue
@@ -31,11 +31,13 @@ export default {
   },
   data () {
     const filter = {}
-    if (this.$route.query.id) {
-      filter.id = [this.$route.query.id]
-    }
-    if (this.$route.query.hasOwnProperty('is_associated')) {
-      filter.is_associated = [this.$route.query.is_associated]
+    if (!this.inBaseSidePage) {
+      if (this.$route.query.id) {
+        filter.id = [this.$route.query.id]
+      }
+      if (this.$route.query.hasOwnProperty('is_associated')) {
+        filter.is_associated = [this.$route.query.is_associated]
+      }
     }
     return {
       list: this.$list.createList(this, {

--- a/containers/Compute/views/vminstance/components/List.vue
+++ b/containers/Compute/views/vminstance/components/List.vue
@@ -85,11 +85,13 @@ export default {
   },
   data () {
     const filter = {}
-    if (this.$route.query.id) {
-      filter.id = [this.$route.query.id]
-    }
-    if (this.$route.query.status) {
-      filter.status = this.$route.query.status
+    if (!this.inBaseSidePage) {
+      if (this.$route.query.id) {
+        filter.id = [this.$route.query.id]
+      }
+      if (this.$route.query.status) {
+        filter.status = this.$route.query.status
+      }
     }
 
     const pci_model_types = this.$store.getters.capability?.pci_model_types || []


### PR DESCRIPTION
**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

- release/4.0
