### PR TITLE
Automated cherry pick of #7959: feat: 修复列表组件因keepAlive导致组件销毁事件无法触发,列表状态轮询未被清除

### DIFF
--- a/src/components/PageList/index.vue
+++ b/src/components/PageList/index.vue
@@ -465,6 +465,13 @@ export default {
   },
   beforeDestroy () {
     this.list.clearWaitJob()
+    this.list.clearBatchCheckStatusTimer()
+  },
+  activated () {
+    this.list.restartBatchCheckStatusTimer()
+  },
+  deactivated () {
+    this.list.stopBatchCheckStatusTimer()
   },
   async created () {
     if (this.beforeShowMenu) {

--- a/src/utils/list.js
+++ b/src/utils/list.js
@@ -369,6 +369,17 @@ class CreateList {
     }, 10 * 1000)
   }
 
+  stopBatchCheckStatusTimer () {
+    if (this.batchCheckStatusTimer) {
+      clearTimeout(this.batchCheckStatusTimer)
+      this.batchCheckStatusTimer = null
+    }
+  }
+
+  restartBatchCheckStatusTimer () {
+    this.startBatchCheckStatusTimer()
+  }
+
   /**
    * @description 获取列表中不符合steadyStatus的数据列表
    * @memberof CreateList
@@ -392,6 +403,7 @@ class CreateList {
    */
   async batchCheckStatus () {
     if (!this.manager) return
+    this.batchCheckStatusList = this.getAbnormalStatusList().filter(id => id)
     const params = this.params
     if (!R.isEmpty(this.itemGetParams)) {
       for (const key in this.itemGetParams) {


### PR DESCRIPTION
Cherry pick of #7959 on release/4.0.

#7959: feat: 修复列表组件因keepAlive导致组件销毁事件无法触发,列表状态轮询未被清除