### PR TITLE
Automated cherry pick of #8389: fix: status引入参数报错改为i18n取值方式

### DIFF
--- a/src/components/Status/index.vue
+++ b/src/components/Status/index.vue
@@ -26,7 +26,6 @@
 import * as R from 'ramda'
 import expectStatusMap from '@/constants/expectStatus'
 import { status as statusMap } from '@/locales/zh-CN'
-import { scopeStatus as scopeStatusMap } from '@scope/locales/zh-CN'
 
 export default {
   name: 'Status',
@@ -61,6 +60,11 @@ export default {
       default: false,
     },
   },
+  data () {
+    return {
+      scopeStatusMap: this.$te('scopeStatus') ? this.$t('scopeStatus') : {},
+    }
+  },
   computed: {
     isBooleanValue () {
       return R.is(Boolean, this.status)
@@ -93,7 +97,7 @@ export default {
     },
     statusText () {
       if (this.specifyStatus.text) return this.specifyStatus.text
-      const moduleStatusMap = scopeStatusMap[this.statusModule] || statusMap[this.statusModule]
+      const moduleStatusMap = this.scopeStatusMap[this.statusModule] || statusMap[this.statusModule]
       if (moduleStatusMap) {
         if (moduleStatusMap[this.changedStatus || this.status]) {
           return this.$te(`scopeStatus.${this.statusModule}.${this.changedStatus || this.status}`) ? this.$t(`scopeStatus.${this.statusModule}.${this.changedStatus || this.status}`) : this.$t(`status.${this.statusModule}.${this.changedStatus || this.status}`)


### PR DESCRIPTION
Cherry pick of #8389 on release/4.0.1.

#8389: fix: status引入参数报错改为i18n取值方式