### PR TITLE
feat: add cloudaccount health status - pending

### DIFF
--- a/src/constants/expectStatus.js
+++ b/src/constants/expectStatus.js
@@ -83,7 +83,7 @@ export default {
   cloudaccountHealthStatus: {
     success: ['normal'],
     danger: ['insufficient', 'suspended', 'arrears'],
-    info: ['unknown', 'no permission'],
+    info: ['unknown', 'no permission', 'pending'],
   },
   cloudaccountSyncStatus: {
     success: ['idle'],

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -289,7 +289,8 @@
       "suspended": "Freeze",
       "arrears": "Arrears",
       "unknown": "Unknown status",
-      "no permission": "No Permission"
+      "no permission": "No Permission",
+      "pending": "Pending"
     },
     "cloudaccountSyncStatus": {
       "idle": "Sync completed",
@@ -1957,8 +1958,7 @@
     "Proxmox": "Proxmox",
     "H3C": "H3C",
     "ZettaKit": "ZettaKit",
-    "UIS": "UIS",
-    "CNware": "CNware Winstack"
+    "UIS": "UIS"
   },
   "shareScope": {
     "system": "System",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -289,7 +289,8 @@
       "suspended": "凍る",
       "arrears": "溜まり",
       "unknown": "不明な状態",
-      "no permission": "権限なし"
+      "no permission": "権限なし",
+      "pending": "待機中"
     },
     "cloudaccountSyncStatus": {
       "idle": "同期が完了しました",
@@ -1971,8 +1972,7 @@
     "H3C": "H3C",
     "Ksyun": "キングソフトクラウド",
     "ZettaKit": "ゼータ雲",
-    "UIS": "UIS",
-    "CNware": "CNware Winstack"
+    "UIS": "UIS"
   },
   "shareScope": {
     "system": "システム",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -296,7 +296,8 @@
       "suspended": "冻结",
       "arrears": "欠费",
       "unknown": "未知状态",
-      "no permission": "无权限"
+      "no permission": "无权限",
+      "pending": "待激活"
     },
     "cloudaccountSyncStatus": {
       "idle": "同步完成",


### PR DESCRIPTION
**What this PR does / why we need it**:

功能改进： 云账号健康状态增加 pending（待激活）状态

**Does this PR need to be backport to the previous release branch?**:

- release/4.0
- release/3.11