### PR TITLE
fix: image export tooltip message error

### DIFF
--- a/containers/Compute/views/image/mixins/singleActions.js
+++ b/containers/Compute/views/image/mixins/singleActions.js
@@ -331,7 +331,7 @@ export default {
                   ret.tooltip = this.$t('cloudenv.text_368', [this.$t('status.image')[obj.status]])
                   return ret
                 }
-                if (obj.is_standard) {
+                if (obj.is_standard === true || obj.is_standard === 'true') {
                   ret.tooltip = this.$t('compute.standard_not_export')
                   return ret
                 }


### PR DESCRIPTION
**What this PR does / why we need it**:

问题修复：修复镜像导出时，因 is_standard 参数判断错误导致的提示信息错误问题

**Does this PR need to be backport to the previous release branch?**:

- release/4.0
- release/4.0.0
- release/4.0.1
- release/3.11
- release/3.11.12
