### PR TITLE
fix: disk status statistic module

### DIFF
--- a/containers/Compute/views/disk/index.vue
+++ b/containers/Compute/views/disk/index.vue
@@ -40,6 +40,7 @@ export default {
       },
       cloudEnvOptions: getCloudEnvOptions('compute_engine_brands'),
       cloudEnv: '',
+      statusModule: 'disk',
       statusNormalList: ['ready'],
     }
   },


### PR DESCRIPTION
**What this PR does / why we need it**:

问题修复：修复硬盘列表右上角状态统计展示的状态翻译错误问题

**Does this PR need to be backport to the previous release branch?**:

- release/4.0
- release/4.0.0
