### PR TITLE
fix: delete document default tite

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="google" content="notranslate">
     <link rel="icon" href="./favicon.ico">
-    <title>云联壹云</title>
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: 删除文档标题默认展示的标题，防止后续切换时有明显的切换动作

**Does this PR need to be backport to the previous release branch?**:

- release/4.0
- release/3.11
