### PR TITLE
Automated cherry pick of #8573: fix: delete vminstance workflow exec two times

### DIFF
--- a/containers/Compute/views/vminstance/dialogs/DeleteVm.vue
+++ b/containers/Compute/views/vminstance/dialogs/DeleteVm.vue
@@ -314,7 +314,6 @@ export default {
       } else {
         await this.createWorkflow(variables)
       }
-      await this.createWorkflow(variables)
       this.$message.success(this.$t('compute.text_1214'))
       this.$router.push('/workflow')
     },


### PR DESCRIPTION
Cherry pick of #8573 on release/4.0.

#8573: fix: delete vminstance workflow exec two times