### PR TITLE
Automated cherry pick of #8733: feat: Alarm strategy notification channel cancels the check of alarm recipients

### DIFF
--- a/containers/Monitor/views/commonalert/components/new-alert/form/index.vue
+++ b/containers/Monitor/views/commonalert/components/new-alert/form/index.vue
@@ -104,7 +104,7 @@
         :select-props="{ mode: 'multiple', placeholder: $t('common.tips.select', [$t('monitor.recipient')]) }"
         :params="contactParams" />
     </a-form-item>
-    <a-form-item v-if="notifyTypes.includes('recipient') && contactArrAllOpts && contactArrAllOpts.length > 0" :label="$t('monitor.channel')">
+    <a-form-item v-if="contactArrAllOpts && contactArrAllOpts.length > 0" :label="$t('monitor.channel')">
       <a-checkbox-group
         v-decorator="decorators.channel">
         <a-checkbox


### PR DESCRIPTION
Cherry pick of #8733 on release/4.0.

#8733: feat: Alarm strategy notification channel cancels the check of alarm recipients