### PR TITLE
Automated cherry pick of #8747: fix: Add resource ID filtering to GPU operation logs

### DIFF
--- a/containers/Compute/views/gpu/sidepage/index.vue
+++ b/containers/Compute/views/gpu/sidepage/index.vue
@@ -15,7 +15,7 @@
     </template>
     <component
       :is="params.windowData.currentTab"
-      :res-id="data.resId"
+      :res-id="detailData.id"
       :id="listId"
       :data="detailData"
       :on-manager="onManager"


### PR DESCRIPTION
Cherry pick of #8747 on release/4.0.

#8747: fix: Add resource ID filtering to GPU operation logs