### PR TITLE
fix: The creation of a private clouserver hypervisor was incorrectly …

### DIFF
--- a/containers/Compute/views/vminstance/create/form/Private.vue
+++ b/containers/Compute/views/vminstance/create/form/Private.vue
@@ -443,7 +443,7 @@ export default {
           }
           this.form.fi.capability = {
             ...data,
-            hypervisors: data.hypervisors.filter(val => val !== 'baremetal'),
+            hypervisors: data.hypervisors.filter(val => val !== 'baremetal' && val !== 'pod'),
           }
           this.form.fc.getFieldDecorator('hypervisor', { preserve: true })
           this.form.fc.setFieldsValue({


### PR DESCRIPTION
…identified as a pod

**What this PR does / why we need it**:

修复：创建私有云虚拟机，hypervisor被错误识别为pod问题

**Does this PR need to be backport to the previous release branch?**:

- release/4.0
- release/4.0.2
