### PR TITLE
Automated cherry pick of #8976: fix: The creation of a private clouserver hypervisor was incorrectly identified as a pod

### DIFF
--- a/containers/Compute/views/vminstance/create/form/Private.vue
+++ b/containers/Compute/views/vminstance/create/form/Private.vue
@@ -443,7 +443,7 @@ export default {
           }
           this.form.fi.capability = {
             ...data,
-            hypervisors: data.hypervisors.filter(val => val !== 'baremetal'),
+            hypervisors: data.hypervisors.filter(val => val !== 'baremetal' && val !== 'pod'),
           }
           this.form.fc.getFieldDecorator('hypervisor', { preserve: true })
           this.form.fc.setFieldsValue({


### PR DESCRIPTION
Cherry pick of #8976 on release/4.0.

#8976: fix: The creation of a private clouserver hypervisor was incorrectly identified as a pod