### PR TITLE
feat(ai): scope-aware llm credentials and images

### DIFF
--- a/containers/Ai/views/container-secret/components/List.vue
+++ b/containers/Ai/views/container-secret/components/List.vue
@@ -92,6 +92,10 @@ export default {
         ...this.getParams,
         'filter.0': 'type.equals(container_secret)',
       }
+      if (this.$store.getters.scope === 'project') {
+        const uid = this.$store.getters.userInfo?.id
+        if (uid) ret['filter.1'] = `user_id.equals(${uid})`
+      }
       return ret
     },
     handleOpenSidepage (row) {

--- a/containers/Ai/views/container-secret/dialogs/Create.vue
+++ b/containers/Ai/views/container-secret/dialogs/Create.vue
@@ -116,13 +116,16 @@ export default {
       this.loading = true
       try {
         const manager = new this.$Manager('credentials', 'v1')
-        await manager.create({
-          data: {
-            type: 'container_secret',
-            name: values.name || '',
-            blob,
-          },
-        })
+        const createData = {
+          type: 'container_secret',
+          name: values.name || '',
+          blob,
+        }
+        if (this.$store.getters.scope === 'project') {
+          const uid = this.$store.getters.userInfo?.id
+          if (uid) createData.user_id = uid
+        }
+        await manager.create({ data: createData })
         this.$message.success(this.$t('common.success'))
         this.params.callback && this.params.callback()
         this.cancelDialog()

--- a/containers/Ai/views/llm-image/dialogs/create.vue
+++ b/containers/Ai/views/llm-image/dialogs/create.vue
@@ -6,14 +6,23 @@
         <a-form-model-item :label="$t('common.name')" prop="name">
           <a-input v-model="form.name" :placeholder="$t('common.tips.input', [$t('common.name')])" :disabled="type === 'edit'" />
         </a-form-model-item>
+        <a-form-model-item :label="$t('aice.llm_type')" prop="llm_type">
+          <a-radio-group
+            v-if="type !== 'edit'"
+            v-model="form.llm_type"
+            class="llm-type-picker"
+            button-style="solid">
+            <a-radio-button v-for="opt in llmTypeOptions" :key="opt.id" :value="opt.id">
+              {{ opt.name }}
+            </a-radio-button>
+          </a-radio-group>
+          <span v-else>{{ llmTypeName }}</span>
+        </a-form-model-item>
         <a-form-model-item :label="$t('aice.llm_image.name')" prop="image_name">
           <a-input v-model="form.image_name" :placeholder="$t('common.tips.input', [$t('aice.llm_image.name')])" />
         </a-form-model-item>
         <a-form-model-item :label="$t('aice.llm_image.label')" prop="image_label">
           <a-input v-model="form.image_label" :placeholder="$t('common.tips.input', [$t('aice.llm_image.label')])" />
-        </a-form-model-item>
-        <a-form-model-item :label="$t('aice.llm_image.progress')" prop="progress">
-          <a-input-number v-model="form.progress" :min="0" :max="100" :placeholder="$t('common.tips.input', [$t('aice.llm_image.progress')])" />
         </a-form-model-item>
       </a-form-model>
     </div>
@@ -28,6 +37,7 @@
 import DialogMixin from '@/mixins/dialog'
 import WindowsMixin from '@/mixins/windows'
 import { validateModelForm } from '@/utils/validate'
+import { LLM_TYPE_OPTIONS } from '../../llm-sku/llmTypeConfig'
 
 export default {
   name: 'DesktopImageCreateDialog',
@@ -36,20 +46,21 @@ export default {
   mixins: [DialogMixin, WindowsMixin],
   data () {
     const data = this.params.type === 'edit' ? this.params.data[0] : {}
+    const defaultLlmType = (LLM_TYPE_OPTIONS[0] && LLM_TYPE_OPTIONS[0].id) || 'openclaw'
     return {
       loading: false,
       type: this.params.type,
       form: {
         name: data.name || undefined,
+        llm_type: data.llm_type || defaultLlmType,
         image_name: data.image_name || undefined,
         image_label: data.image_label || undefined,
-        progress: data.progress || undefined,
       },
       rules: {
         name: [{ required: true, validator: this.$validate('imageName') }],
+        llm_type: [{ required: true, message: this.$t('common.tips.select', [this.$t('aice.llm_type')]) }],
         image_name: [{ required: true, message: this.$t('common.tips.input', [this.$t('aice.llm_image.name')]) }],
         image_label: [{ required: true, message: this.$t('common.tips.input', [this.$t('aice.llm_image.label')]) }],
-        progress: [{ required: true, message: this.$t('common.tips.input', [this.$t('aice.llm_image.progress')]) }],
       },
       formItemLayout: {
         wrapperCol: {
@@ -62,6 +73,13 @@ export default {
     }
   },
   computed: {
+    llmTypeOptions () {
+      return LLM_TYPE_OPTIONS.map(opt => ({ id: opt.id, name: this.$t(opt.name) }))
+    },
+    llmTypeName () {
+      const opt = LLM_TYPE_OPTIONS.find(o => o.id === this.form.llm_type)
+      return opt ? this.$t(opt.name) : this.form.llm_type || '-'
+    },
     desktopModelParams () {
       return {
         limit: 20,

--- a/containers/Ai/views/llm-image/mixins/columns.js
+++ b/containers/Ai/views/llm-image/mixins/columns.js
@@ -24,6 +24,15 @@ export default {
       getImageNameTableColumn(),
       getImageLabelTableColumn(),
       {
+        field: 'llm_type',
+        title: this.$t('aice.llm_type'),
+        width: 100,
+        formatter: ({ row }) => {
+          const key = row.llm_type ? `aice.llm_type.${row.llm_type}` : ''
+          return key ? this.$t(key) : (row.llm_type || '-')
+        },
+      },
+      {
         field: 'credential_id',
         title: this.$t('aice.llm_image.credential'),
         slots: {

--- a/containers/Ai/views/llm-sku/create/Form.vue
+++ b/containers/Ai/views/llm-sku/create/Form.vue
@@ -390,9 +390,14 @@ export default {
       }
     },
     credentialParams () {
+      const filter = ['type.equals(container_secret)']
+      if (this.$store.getters.scope === 'project') {
+        const uid = this.$store.getters.userInfo?.id
+        if (uid) filter.push(`user_id.equals(${uid})`)
+      }
       return {
         scope: this.$store.getters.scope,
-        filter: 'type.equals(container_secret)',
+        filter,
       }
     },
     specList () {
@@ -489,7 +494,11 @@ export default {
           disk_size: volumes[0].size_mb,
           app_type: 'steam',
         }
-        if (!this.isEditMode) data.llm_type = effectiveLlmType
+        if (!this.isEditMode) {
+          data.llm_type = effectiveLlmType
+          // 默认填入 llm_sku，空对象即可，如 openclaw => llm_sku: { openclaw: {} }
+          data.llm_sku = { [effectiveLlmType]: {} }
+        }
         typeFieldKeys.forEach(key => {
           const v = pickTypeValues[key]
           if (v === undefined) return

--- a/containers/Ai/views/llm/dialogs/UpdateSpec.vue
+++ b/containers/Ai/views/llm/dialogs/UpdateSpec.vue
@@ -469,10 +469,15 @@ export default {
       return normalize(`${base}-${u}-${k}`) || 'llm-credential'
     },
     credentialParamsForChannel (channelKey) {
+      const filter = ['type.equals(container_secret)']
+      if (this.$store.getters.scope === 'project') {
+        const uid = this.$store.getters.userInfo?.id
+        if (uid) filter.push(`user_id.equals(${uid})`)
+      }
       return {
         $t: 2,
         scope: this.$store.getters.scope,
-        filter: ['type.equals(container_secret)'],
+        filter,
         'tags.0.key': 'user:openclaw_usage',
         'tags.0.value': 'channel',
         'tags.1.key': 'user:openclaw_name',
@@ -513,11 +518,16 @@ export default {
       }
     },
     credentialParamsForProvider (providerKey) {
+      const filter = ['type.equals(container_secret)']
+      if (this.$store.getters.scope === 'project') {
+        const uid = this.$store.getters.userInfo?.id
+        if (uid) filter.push(`user_id.equals(${uid})`)
+      }
       const shortName = this.providerShortName(providerKey)
       return {
         $t: 1,
         scope: this.$store.getters.scope,
-        filter: 'type.equals(container_secret)',
+        filter,
         'tags.0.key': 'user:openclaw_usage',
         'tags.0.value': 'provider',
         'tags.1.key': 'user:openclaw_name',

--- a/containers/Ai/views/llm/dialogs/create.vue
+++ b/containers/Ai/views/llm/dialogs/create.vue
@@ -600,10 +600,12 @@ export default {
       return normalize(`${base}-${u}-${k}`) || 'llm-credential'
     },
     credentialParamsForChannel (channelKey) {
-      const base = {
-        scope: this.$store.getters.scope,
-        filter: ['type.equals(container_secret)'],
+      const filter = ['type.equals(container_secret)']
+      if (this.$store.getters.scope === 'project') {
+        const uid = this.$store.getters.userInfo?.id
+        if (uid) filter.push(`user_id.equals(${uid})`)
       }
+      const base = { scope: this.$store.getters.scope, filter }
       return {
         ...base,
         'tags.0.key': 'user:openclaw_usage',
@@ -646,10 +648,12 @@ export default {
       }
     },
     credentialParamsForProvider (providerKey) {
-      const base = {
-        scope: this.$store.getters.scope,
-        filter: 'type.equals(container_secret)',
+      const filter = ['type.equals(container_secret)']
+      if (this.$store.getters.scope === 'project') {
+        const uid = this.$store.getters.userInfo?.id
+        if (uid) filter.push(`user_id.equals(${uid})`)
       }
+      const base = { scope: this.$store.getters.scope, filter }
       const shortName = this.providerShortName(providerKey)
       return {
         ...base,


### PR DESCRIPTION
- LLM 实例 / 套餐 openclaw 容器密钥在项目视图下按 user_id 过滤
- 容器密钥创建在项目视图下自动带上 user_id 字段
- LLM 镜像新增 llm_type 字段（创建时选择、列表中展示），并清理 Image Progress

Made-with: Cursor

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0.2