### PR TITLE
feat(ai): add hermes-agent LLM type support

### DIFF
--- a/containers/Ai/locales/en.json
+++ b/containers/Ai/locales/en.json
@@ -345,6 +345,7 @@
   "aice.llm_type.dify": "Dify",
   "aice.llm_type.vllm": "vLLM",
   "aice.llm_type.openclaw": "OpenClaw",
+  "aice.llm_type.hermes_agent": "HermesAgent",
   "aice.llm_type.no_params_hint": "No additional parameters for this type",
   "aice.llm_network_type.guest_default": "Auto schedule - classic network",
   "aice.llm_network_type.hostlocal_default": "Auto schedule - host-local network",

--- a/containers/Ai/locales/ja-JP.json
+++ b/containers/Ai/locales/ja-JP.json
@@ -345,6 +345,7 @@
   "aice.llm_type.dify": "Dify",
   "aice.llm_type.vllm": "vLLM",
   "aice.llm_type.openclaw": "OpenClaw",
+  "aice.llm_type.hermes_agent": "HermesAgent",
   "aice.llm_type.no_params_hint": "このタイプには追加パラメータがありません",
   "aice.llm_network_type.guest_default": "自動スケジューリング-クラシックネットワーク",
   "aice.llm_network_type.hostlocal_default": "自動スケジューリング-ホストローカルネットワーク",

--- a/containers/Ai/locales/zh-CN.json
+++ b/containers/Ai/locales/zh-CN.json
@@ -13,6 +13,7 @@
   "aice.llm_type.dify": "Dify",
   "aice.llm_type.vllm": "vLLM",
   "aice.llm_type.openclaw": "OpenClaw",
+  "aice.llm_type.hermes_agent": "HermesAgent",
   "aice.llm_type.no_params_hint": "该类型暂无额外参数配置",
   "aice.cpu": "CPU",
   "aice.llm_image.name": "镜像名称",

--- a/containers/Ai/views/llm-image/import-community/index.vue
+++ b/containers/Ai/views/llm-image/import-community/index.vue
@@ -98,7 +98,7 @@ export default {
           width: 120,
           slots: {
             default: ({ row }, h) => {
-              return [h('span', this.$t(`aice.llm_type.${row.llm_type}`) || row.llm_type)]
+              return [h('span', this.$t(`aice.llm_type.${(row.llm_type || '').replace(/-/g, '_')}`) || row.llm_type)]
             },
           },
         },

--- a/containers/Ai/views/llm-image/mixins/columns.js
+++ b/containers/Ai/views/llm-image/mixins/columns.js
@@ -28,7 +28,7 @@ export default {
         title: this.$t('aice.llm_type.app'),
         width: 100,
         formatter: ({ row }) => {
-          const key = row.llm_type ? `aice.llm_type.${row.llm_type}` : ''
+          const key = row.llm_type ? `aice.llm_type.${row.llm_type.replace(/-/g, '_')}` : ''
           return key ? this.$t(key) : (row.llm_type || '-')
         },
       },

--- a/containers/Ai/views/llm-sku/llmTypeConfig.js
+++ b/containers/Ai/views/llm-sku/llmTypeConfig.js
@@ -10,6 +10,7 @@ export const LLM_TYPE_OPTIONS = [
   { id: 'ollama', name: 'aice.llm_type.ollama' },
   // { id: 'vllm', name: 'aice.llm_type.vllm' },
   { id: 'comfyui', name: 'aice.llm_type.comfyui' },
+  { id: 'hermes-agent', name: 'aice.llm_type.hermes_agent' },
 ]
 
 /**
@@ -99,4 +100,5 @@ export const LLM_TYPE_FORM_CONFIG = {
   openclaw: [
     // OpenClaw 的 credential 已改为 providers/channels 级别分别配置（见 create/Form.vue）
   ],
+  'hermes-agent': [],
 }

--- a/containers/Ai/views/llm/components/List.vue
+++ b/containers/Ai/views/llm/components/List.vue
@@ -354,7 +354,7 @@ export default {
     getParam () {
       const ret = {
         ...this.getParams,
-        llm_types: this.isApplyType ? ['dify', 'openclaw', 'comfyui'] : ['vllm', 'ollama'],
+        llm_types: this.isApplyType ? ['dify', 'openclaw', 'comfyui', 'hermes-agent'] : ['vllm', 'ollama'],
         details: true,
       }
       return ret

--- a/containers/Ai/views/llm/sidepage/Detail.vue
+++ b/containers/Ai/views/llm/sidepage/Detail.vue
@@ -217,7 +217,10 @@ export default {
         const loginUrl = info.login_url != null ? info.login_url : ''
         const username = info.username != null ? info.username : ''
         const password = info.password != null ? info.password : ''
-        const extra = info.extra && typeof info.extra === 'object' ? info.extra : {}
+        const extra = info.extra && typeof info.extra === 'object' ? { ...info.extra } : {}
+        if ((this.data.llm_type || '').toLowerCase() === 'hermes-agent') {
+          delete extra.OPENCLAW_GATEWAY_TOKEN
+        }
 
         loginSectionItems.push({
           field: 'login_url',


### PR DESCRIPTION
Add HermesAgent as a new LLM type option with i18n labels, type config, and application-type list filtering. Fix llm_type locale key lookup to handle hyphens by replacing them with underscores. Hide OPENCLAW_GATEWAY_TOKEN from hermes-agent detail page.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0