### PR TITLE
feat(ai): add OpenClaw manual config mode toggle in UI

### DIFF
--- a/containers/Ai/locales/en.json
+++ b/containers/Ai/locales/en.json
@@ -53,6 +53,8 @@
   "aice.openclaw.credential_mode.label": "Configuration",
   "aice.openclaw.new_credential_name": "Secret name",
   "aice.openclaw.new_credential_name_tip": "The new container secret will store the KEYs you enter below and be referenced by this plan.",
+  "aice.openclaw.manual_config": "Manual Config Mode",
+  "aice.openclaw.manual_config_tip": "When enabled, provider and channel env vars are not injected. Users configure them after entering the desktop.",
   "aice.openclaw.provider_filter": "Select providers",
   "aice.openclaw.provider_select_tip": "Select providers first; the corresponding KEYs will be shown below for you to fill. Multiple selection supported; at least one required.",
   "aice.openclaw.provider_select_first": "Select one or more providers above; the KEYs to fill will appear here.",

--- a/containers/Ai/locales/ja-JP.json
+++ b/containers/Ai/locales/ja-JP.json
@@ -53,6 +53,8 @@
   "aice.openclaw.credential_mode.label": "設定方法",
   "aice.openclaw.new_credential_name": "シークレット名",
   "aice.openclaw.new_credential_name_tip": "新規作成したコンテナシークレットに以下で入力した KEY を保存し、本プランで参照します。",
+  "aice.openclaw.manual_config": "手動設定モード",
+  "aice.openclaw.manual_config_tip": "有効にすると、プロバイダーとチャネルの環境変数は注入されません。ユーザーがデスクトップに入ってから自分で設定します。",
   "aice.openclaw.provider_filter": "プロバイダーを選択",
   "aice.openclaw.provider_select_tip": "先に設定するプロバイダーを選択すると、対応する KEY が下に表示されます。複数選択可。1つ以上必須。",
   "aice.openclaw.provider_select_first": "上で設定するプロバイダーを選択すると、入力する KEY がここに表示されます。",

--- a/containers/Ai/locales/zh-CN.json
+++ b/containers/Ai/locales/zh-CN.json
@@ -64,6 +64,8 @@
   "aice.openclaw.credential_mode.label": "配置方式",
   "aice.openclaw.new_credential_name": "密钥名称",
   "aice.openclaw.new_credential_name_tip": "新建的容器密钥将用于存储下方填写的 KEY，并自动引用到本套餐。",
+  "aice.openclaw.manual_config": "手动配置模式",
+  "aice.openclaw.manual_config_tip": "启用后，系统不注入供应商和渠道环境变量，由用户进入桌面后自行配置",
   "aice.openclaw.provider_filter": "选择供应商",
   "aice.openclaw.provider_select_tip": "先选择要配置的供应商，下方将展示对应的 KEY 供填写。可多选，至少选择一项。",
   "aice.openclaw.provider_select_first": "请先在上方选择要配置的供应商，此处将展示需要填写的 KEY。",

--- a/containers/Ai/views/llm-sku/utils/llmSpecDetail.js
+++ b/containers/Ai/views/llm-sku/utils/llmSpecDetail.js
@@ -129,6 +129,15 @@ export async function fetchLlmSpecCredentialNames (vm) {
  */
 function renderOpenclawSpec (spec, vm, h) {
   const nodes = []
+  if (spec.manual_config) {
+    nodes.push(h('div', { class: 'mb-2', style: INNER_DETAIL_BLOCK_STYLE }, [
+      h('div', { class: 'detail-item-title text-secondary mb-1' }, vm.$t('aice.openclaw.manual_config')),
+      h('div', { style: INNER_DETAIL_VALUE_STYLE }, [
+        h('a-tag', { props: { color: 'blue' } }, vm.$t('compute.text_115')),
+        h('span', { class: 'text-secondary ml-1', style: { fontSize: '12px' } }, vm.$t('aice.openclaw.manual_config_tip')),
+      ]),
+    ]))
+  }
   if (spec.providers && Array.isArray(spec.providers) && spec.providers.length > 0) {
     const sectionLabel = vm.$te('aice.openclaw.section.ai_providers_detail')
       ? vm.$t('aice.openclaw.section.ai_providers_detail')

--- a/containers/Ai/views/llm/create.vue
+++ b/containers/Ai/views/llm/create.vue
@@ -63,6 +63,11 @@
           </a-collapse-panel>
         </a-collapse>
         <template v-if="form.fd.llm_type === 'openclaw'">
+          <a-form-item :label="$t('aice.openclaw.manual_config')">
+            <a-switch v-decorator="decorators.openclaw_manual_config" :checkedChildren="$t('compute.text_115')" :unCheckedChildren="$t('compute.text_116')" />
+            <div class="text-color-secondary mt-1" style="font-size: 13px;">{{ $t('aice.openclaw.manual_config_tip') }}</div>
+          </a-form-item>
+          <template v-if="!form.fd.openclaw_manual_config">
           <a-divider orientation="left" class="openclaw-section-divider">{{ $t('aice.openclaw.section.ai_providers') }}</a-divider>
           <a-form-item :label="$t('aice.openclaw.provider_filter')" :extra="$t('aice.openclaw.provider_select_tip')">
             <a-select
@@ -430,6 +435,7 @@
               </a-tab-pane>
             </a-tabs>
           </template>
+          </template>
         </template>
         <a-form-item :label="$t('compute.text_494')" :extra="$t('compute.text_495')">
           <a-switch v-decorator="decorators.auto_start" :checkedChildren="$t('compute.text_115')" :unCheckedChildren="$t('compute.text_116')" />
@@ -618,6 +624,13 @@ export default {
           {
             valuePropName: 'checked',
             initialValue: true,
+          },
+        ],
+        openclaw_manual_config: [
+          'openclaw_manual_config',
+          {
+            valuePropName: 'checked',
+            initialValue: false,
           },
         ],
         openclaw_channels: [
@@ -1178,194 +1191,198 @@ export default {
           data.prefer_host = values.prefer_host
         }
         if (this.form.fd.llm_type === 'openclaw') {
-          const openclaw = {}
-          const channelsSelected = values.openclaw_channels || []
-          const channels = []
-          const credManager = new this.$Manager('credentials', 'v1')
-          for (let i = 0; i < channelsSelected.length; i++) {
-            const channelKey = channelsSelected[i]
-            this.ensureChannelState(channelKey)
-            const mode = this.openclawChannelCredentialMode[channelKey] || 'new'
-            let credentialId
-            let exportKeys
-            if (mode === 'existing') {
-              credentialId = this.openclawChannelCredentialId[channelKey]
-              if (!credentialId) {
-                this.$message.warning(this.$t('common.tips.select', [this.$t('aice.container_secret')]))
-                this.loading = false
-                return
-              }
-              exportKeys = this.openclawChannelExportKeys[channelKey] || []
-              if (channelKey === 'qqbot') {
-                const requiredKeys = ['QQBOT_APP_ID', 'QQBOT_CLIENT_SECRET']
-                const missing = requiredKeys.filter(k => !(exportKeys || []).includes(k))
-                if (missing.length) {
-                  const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
-                  this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
+          if (this.form.fd.openclaw_manual_config) {
+            data.llm_spec = { openclaw: { manual_config: true } }
+          } else {
+            const openclaw = {}
+            const channelsSelected = values.openclaw_channels || []
+            const channels = []
+            const credManager = new this.$Manager('credentials', 'v1')
+            for (let i = 0; i < channelsSelected.length; i++) {
+              const channelKey = channelsSelected[i]
+              this.ensureChannelState(channelKey)
+              const mode = this.openclawChannelCredentialMode[channelKey] || 'new'
+              let credentialId
+              let exportKeys
+              if (mode === 'existing') {
+                credentialId = this.openclawChannelCredentialId[channelKey]
+                if (!credentialId) {
+                  this.$message.warning(this.$t('common.tips.select', [this.$t('aice.container_secret')]))
                   this.loading = false
                   return
                 }
-              }
-              if (channelKey === 'feishu') {
-                const requiredKeys = ['FEISHU_APP_ID', 'FEISHU_APP_SECRET']
-                const missing = requiredKeys.filter(k => !(exportKeys || []).includes(k))
-                if (missing.length) {
-                  const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
-                  this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
+                exportKeys = this.openclawChannelExportKeys[channelKey] || []
+                if (channelKey === 'qqbot') {
+                  const requiredKeys = ['QQBOT_APP_ID', 'QQBOT_CLIENT_SECRET']
+                  const missing = requiredKeys.filter(k => !(exportKeys || []).includes(k))
+                  if (missing.length) {
+                    const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
+                    this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
+                    this.loading = false
+                    return
+                  }
+                }
+                if (channelKey === 'feishu') {
+                  const requiredKeys = ['FEISHU_APP_ID', 'FEISHU_APP_SECRET']
+                  const missing = requiredKeys.filter(k => !(exportKeys || []).includes(k))
+                  if (missing.length) {
+                    const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
+                    this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
+                    this.loading = false
+                    return
+                  }
+                }
+                if (channelKey === 'discord') {
+                  const requiredKeys = ['DISCORD_BOT_TOKEN']
+                  const missing = requiredKeys.filter(k => !(exportKeys || []).includes(k))
+                  if (missing.length) {
+                    const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
+                    this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
+                    this.loading = false
+                    return
+                  }
+                }
+                if (channelKey === 'telegram') {
+                  const requiredKeys = ['TELEGRAM_BOT_TOKEN']
+                  const missing = requiredKeys.filter(k => !(exportKeys || []).includes(k))
+                  if (missing.length) {
+                    const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
+                    this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
+                    this.loading = false
+                    return
+                  }
+                }
+              } else {
+                const credName = this.genCredentialName({ llmName: values.name, usage: 'channel', key: channelKey })
+                const raw = this.openclawChannelBlob[channelKey] || {}
+                const blob = this.pickTrimmedOpenclawBlob(raw, '')
+                if (channelKey === 'qqbot') {
+                  const missing = ['QQBOT_APP_ID', 'QQBOT_CLIENT_SECRET'].filter(k => !blob[k])
+                  if (missing.length) {
+                    const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
+                    this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
+                    this.loading = false
+                    return
+                  }
+                }
+                if (channelKey === 'feishu') {
+                  const missing = ['FEISHU_APP_ID', 'FEISHU_APP_SECRET'].filter(k => !blob[k])
+                  if (missing.length) {
+                    const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
+                    this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
+                    this.loading = false
+                    return
+                  }
+                  // 单选/勾选控件可能只显示 defaultValue，但不一定触发 @change 写入 blob
+                  // 这里兜底补齐默认值，确保这些字段会写入 credential blob 与 export_keys
+                  if (!blob.FEISHU_DOMAIN) blob.FEISHU_DOMAIN = 'feishu'
+                  if (!blob.FEISHU_DM_POLICY) blob.FEISHU_DM_POLICY = 'open'
+                  if (!blob.FEISHU_TYPING_INDICATOR) blob.FEISHU_TYPING_INDICATOR = 'true'
+                  if (!blob.FEISHU_RESOLVE_SENDER_NAMES) blob.FEISHU_RESOLVE_SENDER_NAMES = 'true'
+                }
+                if (channelKey === 'discord') {
+                  const missing = ['DISCORD_BOT_TOKEN'].filter(k => !blob[k])
+                  if (missing.length) {
+                    const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
+                    this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
+                    this.loading = false
+                    return
+                  }
+                  if (!blob.DISCORD_DM_POLICY) blob.DISCORD_DM_POLICY = 'open'
+                }
+                if (channelKey === 'telegram') {
+                  const missing = ['TELEGRAM_BOT_TOKEN'].filter(k => !blob[k])
+                  if (missing.length) {
+                    const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
+                    this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
+                    this.loading = false
+                    return
+                  }
+                  if (!blob.TELEGRAM_DM_POLICY) blob.TELEGRAM_DM_POLICY = 'open'
+                }
+                if (Object.keys(blob).length === 0) {
+                  this.$message.warning(this.$t('aice.openclaw.provider_filter_empty'))
                   this.loading = false
                   return
                 }
-              }
-              if (channelKey === 'discord') {
-                const requiredKeys = ['DISCORD_BOT_TOKEN']
-                const missing = requiredKeys.filter(k => !(exportKeys || []).includes(k))
-                if (missing.length) {
-                  const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
-                  this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
-                  this.loading = false
-                  return
-                }
-              }
-              if (channelKey === 'telegram') {
-                const requiredKeys = ['TELEGRAM_BOT_TOKEN']
-                const missing = requiredKeys.filter(k => !(exportKeys || []).includes(k))
-                if (missing.length) {
-                  const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
-                  this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
-                  this.loading = false
-                  return
-                }
-              }
-            } else {
-              const credName = this.genCredentialName({ llmName: values.name, usage: 'channel', key: channelKey })
-              const raw = this.openclawChannelBlob[channelKey] || {}
-              const blob = this.pickTrimmedOpenclawBlob(raw, '')
-              if (channelKey === 'qqbot') {
-                const missing = ['QQBOT_APP_ID', 'QQBOT_CLIENT_SECRET'].filter(k => !blob[k])
-                if (missing.length) {
-                  const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
-                  this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
-                  this.loading = false
-                  return
-                }
-              }
-              if (channelKey === 'feishu') {
-                const missing = ['FEISHU_APP_ID', 'FEISHU_APP_SECRET'].filter(k => !blob[k])
-                if (missing.length) {
-                  const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
-                  this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
-                  this.loading = false
-                  return
-                }
-                // 单选/勾选控件可能只显示 defaultValue，但不一定触发 @change 写入 blob
-                // 这里兜底补齐默认值，确保这些字段会写入 credential blob 与 export_keys
-                if (!blob.FEISHU_DOMAIN) blob.FEISHU_DOMAIN = 'feishu'
-                if (!blob.FEISHU_DM_POLICY) blob.FEISHU_DM_POLICY = 'open'
-                if (!blob.FEISHU_TYPING_INDICATOR) blob.FEISHU_TYPING_INDICATOR = 'true'
-                if (!blob.FEISHU_RESOLVE_SENDER_NAMES) blob.FEISHU_RESOLVE_SENDER_NAMES = 'true'
-              }
-              if (channelKey === 'discord') {
-                const missing = ['DISCORD_BOT_TOKEN'].filter(k => !blob[k])
-                if (missing.length) {
-                  const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
-                  this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
-                  this.loading = false
-                  return
-                }
-                if (!blob.DISCORD_DM_POLICY) blob.DISCORD_DM_POLICY = 'open'
-              }
-              if (channelKey === 'telegram') {
-                const missing = ['TELEGRAM_BOT_TOKEN'].filter(k => !blob[k])
-                if (missing.length) {
-                  const missingLabels = missing.map(k => this.$t(`aice.openclaw.channel.env.${k}`)).join(', ')
-                  this.$message.warning(this.$t('aice.openclaw.required_hint') + missingLabels)
-                  this.loading = false
-                  return
-                }
-                if (!blob.TELEGRAM_DM_POLICY) blob.TELEGRAM_DM_POLICY = 'open'
-              }
-              if (Object.keys(blob).length === 0) {
-                this.$message.warning(this.$t('aice.openclaw.provider_filter_empty'))
-                this.loading = false
-                return
-              }
-              const { data: credData } = await credManager.create({
-                data: {
-                  type: 'container_secret',
-                  name: credName,
-                  blob,
-                  __meta__: {
-                    'user:openclaw_usage': 'channel',
-                    'user:openclaw_name': channelKey,
+                const { data: credData } = await credManager.create({
+                  data: {
+                    type: 'container_secret',
+                    name: credName,
+                    blob,
+                    __meta__: {
+                      'user:openclaw_usage': 'channel',
+                      'user:openclaw_name': channelKey,
+                    },
                   },
-                },
+                })
+                credentialId = credData.id
+                exportKeys = Object.keys(blob)
+              }
+              channels.push({
+                name: channelKey,
+                credential: { id: credentialId, export_keys: exportKeys },
               })
-              credentialId = credData.id
-              exportKeys = Object.keys(blob)
             }
-            channels.push({
-              name: channelKey,
-              credential: { id: credentialId, export_keys: exportKeys },
-            })
-          }
-          if (channels.length) openclaw.channels = channels
+            if (channels.length) openclaw.channels = channels
 
-          const providersSelected = this.openclawSelectedProviders || []
-          if (!providersSelected.length) {
-            this.$message.warning(this.$t('aice.openclaw.provider_select_first'))
-            this.loading = false
-            return
-          }
-          const providers = []
-          for (let i = 0; i < providersSelected.length; i++) {
-            const providerKey = providersSelected[i]
-            this.ensureProviderState(providerKey)
-            if (!this.validateOpenclawProviderRequiredEnv(providerKey)) {
+            const providersSelected = this.openclawSelectedProviders || []
+            if (!providersSelected.length) {
+              this.$message.warning(this.$t('aice.openclaw.provider_select_first'))
               this.loading = false
               return
             }
-            const mode = this.openclawProviderCredentialMode[providerKey] || 'new'
-            let credentialId
-            let exportKeys
-            if (mode === 'existing') {
-              credentialId = this.openclawProviderCredentialId[providerKey]
-              if (!credentialId) {
-                this.$message.warning(this.$t('common.tips.select', [this.$t('aice.container_secret')]))
+            const providers = []
+            for (let i = 0; i < providersSelected.length; i++) {
+              const providerKey = providersSelected[i]
+              this.ensureProviderState(providerKey)
+              if (!this.validateOpenclawProviderRequiredEnv(providerKey)) {
                 this.loading = false
                 return
               }
-              exportKeys = this.openclawProviderExportKeys[providerKey] || []
-            } else {
-              const credName = this.genCredentialName({ llmName: values.name, usage: 'provider', key: this.providerShortName(providerKey) })
-              const raw = this.openclawProviderBlob[providerKey] || {}
-              const blob = this.pickTrimmedOpenclawBlob(raw, providerKey)
-              if (Object.keys(blob).length === 0) {
-                this.$message.warning(this.$t('aice.openclaw.ai_providers.at_least_one'))
-                this.loading = false
-                return
-              }
-              const { data: credData } = await credManager.create({
-                data: {
-                  type: 'container_secret',
-                  name: credName,
-                  blob,
-                  __meta__: {
-                    'user:openclaw_usage': 'provider',
-                    'user:openclaw_name': this.providerShortName(providerKey),
+              const mode = this.openclawProviderCredentialMode[providerKey] || 'new'
+              let credentialId
+              let exportKeys
+              if (mode === 'existing') {
+                credentialId = this.openclawProviderCredentialId[providerKey]
+                if (!credentialId) {
+                  this.$message.warning(this.$t('common.tips.select', [this.$t('aice.container_secret')]))
+                  this.loading = false
+                  return
+                }
+                exportKeys = this.openclawProviderExportKeys[providerKey] || []
+              } else {
+                const credName = this.genCredentialName({ llmName: values.name, usage: 'provider', key: this.providerShortName(providerKey) })
+                const raw = this.openclawProviderBlob[providerKey] || {}
+                const blob = this.pickTrimmedOpenclawBlob(raw, providerKey)
+                if (Object.keys(blob).length === 0) {
+                  this.$message.warning(this.$t('aice.openclaw.ai_providers.at_least_one'))
+                  this.loading = false
+                  return
+                }
+                const { data: credData } = await credManager.create({
+                  data: {
+                    type: 'container_secret',
+                    name: credName,
+                    blob,
+                    __meta__: {
+                      'user:openclaw_usage': 'provider',
+                      'user:openclaw_name': this.providerShortName(providerKey),
+                    },
                   },
-                },
+                })
+                credentialId = credData.id
+                exportKeys = Object.keys(blob)
+              }
+              providers.push({
+                name: this.providerShortName(providerKey),
+                credential: { id: credentialId, export_keys: exportKeys },
               })
-              credentialId = credData.id
-              exportKeys = Object.keys(blob)
             }
-            providers.push({
-              name: this.providerShortName(providerKey),
-              credential: { id: credentialId, export_keys: exportKeys },
-            })
-          }
-          if (providers.length) openclaw.providers = providers
+            if (providers.length) openclaw.providers = providers
 
-          if (Object.keys(openclaw).length) data.llm_spec = { openclaw }
+            if (Object.keys(openclaw).length) data.llm_spec = { openclaw }
+          }
         }
         await new this.$Manager('llms', 'v1').create({
           data,

--- a/containers/Ai/views/llm/dialogs/UpdateSpec.vue
+++ b/containers/Ai/views/llm/dialogs/UpdateSpec.vue
@@ -4,6 +4,11 @@
     <div slot="body">
       <a-form :form="form.fc" hideRequiredMark v-bind="formItemLayout">
         <template v-if="isOpenclaw">
+          <a-form-item :label="$t('aice.openclaw.manual_config')">
+            <a-switch v-decorator="decorators.openclaw_manual_config" :checkedChildren="$t('compute.text_115')" :unCheckedChildren="$t('compute.text_116')" />
+            <div class="text-color-secondary mt-1" style="font-size: 13px;">{{ $t('aice.openclaw.manual_config_tip') }}</div>
+          </a-form-item>
+          <template v-if="!form.fd.openclaw_manual_config">
           <a-divider orientation="left" class="openclaw-section-divider">{{ $t('aice.openclaw.section.ai_providers') }}</a-divider>
           <a-form-item :label="$t('aice.openclaw.provider_filter')" :extra="$t('aice.openclaw.provider_select_tip')">
             <a-select
@@ -379,6 +384,7 @@
               </a-tab-pane>
             </a-tabs>
           </template>
+          </template>
         </template>
         <template v-else>
           <a-alert type="warning" :message="$t('aice.llm_spec_update')" :description="$t('aice.llm_spec')" show-icon />
@@ -419,9 +425,17 @@ export default {
         }),
         fd: {
           openclaw_channels: [],
+          openclaw_manual_config: !!(row?.llm_spec?.openclaw?.manual_config),
         },
       },
       decorators: {
+        openclaw_manual_config: [
+          'openclaw_manual_config',
+          {
+            valuePropName: 'checked',
+            initialValue: !!(row?.llm_spec?.openclaw?.manual_config),
+          },
+        ],
         openclaw_channels: [
           'openclaw_channels',
           { initialValue: (row?.llm_spec?.openclaw?.channels || []).map(item => item.name), rules: [] },
@@ -995,6 +1009,20 @@ export default {
       this.loading = true
       try {
         const row = this.row
+        if (this.form.fd.openclaw_manual_config) {
+          await this.params.onManager('update', {
+            id: row.id,
+            managerArgs: {
+              data: {
+                llm_spec: { openclaw: { manual_config: true } },
+              },
+            },
+          })
+          this.$message.success(this.$t('common.success'))
+          this.cancelDialog()
+          this.params.refresh && this.params.refresh()
+          return
+        }
         const channelsSelected = this.form.fd.openclaw_channels || []
         const openclaw = {}
         const credManager = new this.$Manager('credentials', 'v1')


### PR DESCRIPTION
Add a switch to create/update forms to enable manual config mode, which hides provider/channel configuration and lets users configure them after entering the desktop. Also show the mode in detail page.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0