### PR TITLE
fix(monitor): improve alert status display, history params, and strategy name link

### DIFF
--- a/containers/Compute/views/host/mixins/columns.js
+++ b/containers/Compute/views/host/mixins/columns.js
@@ -513,10 +513,8 @@ export default {
             return [<span style="margin-right:5px">{this.$t('compute.alert_status')}</span>, <help-tooltip name="alertDataTimeRange" />]
           },
           default: ({ row }) => {
-            if (row.alert_data?.alert_state) {
-              return [<status status={row.alert_data?.alert_state} statusModule='monitorresources' />]
-            }
-            return '-'
+            const state = row.alert_data?.alert_state || 'init'
+            return [<status status={state} statusModule='monitorresources' />]
           },
         },
       },

--- a/containers/Compute/views/host/sidepage/AlertList.vue
+++ b/containers/Compute/views/host/sidepage/AlertList.vue
@@ -32,16 +32,14 @@ export default {
     mergedGetParams () {
       return () => {
         const base = typeof this.getParams === 'function' ? this.getParams() : this.getParams
-        const filter = [
-          'res_type.equals("host")',
-        ]
-        if (this.hostName) {
-          filter.push(`res_name.equals("${this.hostName}")`)
-        }
-        return {
+        const params = {
           ...(base || {}),
-          filter,
+          res_type: 'host',
         }
+        if (this.hostName) {
+          params.res_name = this.hostName
+        }
+        return params
       }
     },
     hiddenColumns () {

--- a/containers/Compute/views/host/sidepage/Detail.vue
+++ b/containers/Compute/views/host/sidepage/Detail.vue
@@ -106,11 +106,8 @@ export default {
         ],
         slots: {
           default: () => {
-            const state = this.alertData?.alert_state
-            if (state) {
-              return [<status status={state} statusModule="monitorresources" />]
-            }
-            return '-'
+            const state = this.alertData?.alert_state || 'init'
+            return [<status status={state} statusModule="monitorresources" />]
           },
         },
         hidden: () => this.$isScopedPolicyMenuHidden('host_hidden_columns.alert_data'),

--- a/containers/Compute/views/vminstance/mixins/columns.js
+++ b/containers/Compute/views/vminstance/mixins/columns.js
@@ -580,10 +580,8 @@ export default {
             return [<span style="margin-right:5px">{this.$t('compute.alert_status')}</span>, <help-tooltip name="alertDataTimeRange" />]
           },
           default: ({ row }) => {
-            if (row.alert_data?.alert_state) {
-              return [<status status={row.alert_data?.alert_state} statusModule='monitorresources' />]
-            }
-            return '-'
+            const state = row.alert_data?.alert_state || 'init'
+            return [<status status={state} statusModule='monitorresources' />]
           },
         },
       },

--- a/containers/Compute/views/vminstance/sidepage/AlertHistory.vue
+++ b/containers/Compute/views/vminstance/sidepage/AlertHistory.vue
@@ -32,16 +32,14 @@ export default {
     mergedGetParams () {
       return () => {
         const base = typeof this.getParams === 'function' ? this.getParams() : this.getParams
-        const filter = [
-          'res_type.equals("guest")',
-        ]
-        if (this.vmName) {
-          filter.push(`res_name.equals("${this.vmName}")`)
-        }
-        return {
+        const params = {
           ...(base || {}),
-          filter,
+          res_type: 'guest',
         }
+        if (this.vmName) {
+          params.res_name = this.vmName
+        }
+        return params
       }
     },
     hiddenColumns () {

--- a/containers/Compute/views/vminstance/sidepage/Detail.vue
+++ b/containers/Compute/views/vminstance/sidepage/Detail.vue
@@ -106,11 +106,8 @@ export default {
           ],
           slots: {
             default: () => {
-              const state = this.alertData?.alert_state
-              if (state) {
-                return [<status status={state} statusModule="monitorresources" />]
-              }
-              return '-'
+              const state = this.alertData?.alert_state || 'init'
+              return [<status status={state} statusModule="monitorresources" />]
             },
           },
           hidden: () => this.$isScopedPolicyMenuHidden('server_hidden_columns.alert_data'),

--- a/containers/Compute/views/vminstance/sidepage/index.vue
+++ b/containers/Compute/views/vminstance/sidepage/index.vue
@@ -52,7 +52,6 @@ import ColumnsMixin from '../mixins/columns'
 // import { cloudEnabled, cloudUnabledTip } from '../utils'
 import VmInstanceDetail from './Detail'
 import VmInstanceMonitorSidepage from './Monitor'
-import VmInstanceAlertSidepage from './Alert'
 import VmInstanceAlertHistory from './AlertHistory'
 import VmSnapshotSidepage from './Snapshot'
 import SecgroupList from './Secgroup'
@@ -73,7 +72,6 @@ export default {
     SecgroupList,
     // HostList,
     VmInstanceMonitorSidepage,
-    VmInstanceAlertSidepage,
     VmInstanceAlertHistory,
     VmSnapshotSidepage,
     GpuList,
@@ -94,7 +92,6 @@ export default {
       // { label: this.$t('compute.text_102'), key: 'instance-snapshot-list-for-vm-instance-sidepage' },
       { label: this.$t('compute.text_113'), key: 'gpu-list' },
       { label: this.$t('compute.text_608'), key: 'vm-instance-monitor-sidepage' },
-      { label: this.$t('compute.text_1301'), key: 'vm-instance-alert-sidepage' },
       { label: this.$t('dictionary.alertrecord'), key: 'vm-instance-alert-history' },
       { label: this.$t('table.title.task'), key: 'task-drawer' },
       { label: this.$t('cloudenv.text_431'), key: 'scheduledtasks-list' },
@@ -216,8 +213,6 @@ export default {
           return 'DiskLiskForVminstanceSidepage'
         case 'secgroup-list':
           return 'SecgroupLiskForVminstanceSidepage'
-        case 'vm-instance-alert-sidepage':
-          return 'AlertLiskForVminstanceSidepage'
         case 'event-drawer':
           return 'EventListForVminstanceSidepage'
         case 'gpu-list':

--- a/containers/Monitor/views/alertresource/components/List.vue
+++ b/containers/Monitor/views/alertresource/components/List.vue
@@ -250,7 +250,14 @@ export default {
         {
           field: 'alert_name',
           title: this.$t('monitor.text_99'),
-          formatter: ({ row }) => row.alert_name || '-',
+          slots: {
+            default: ({ row }) => {
+              if (!row.alert_name) return '-'
+              return [
+                <side-page-trigger onTrigger={() => this.handleOpenAlertSidepage(row)}>{ row.alert_name }</side-page-trigger>,
+              ]
+            },
+          },
         },
         {
           field: 'alert_count',
@@ -330,6 +337,13 @@ export default {
         ret.top = this.templateParams?.topN
       }
       return ret
+    },
+    handleOpenAlertSidepage (row) {
+      this.sidePageTriggerHandle(this, 'CommonalertsSidePage', {
+        id: row.alert_id,
+        resource: 'commonalerts',
+        apiVersion: 'v1',
+      })
     },
     handleOpenSidepage (row) {
       const { tags = {} } = row.data || {}


### PR DESCRIPTION
- Show '未发生告警' (init status) instead of '-' when alert data is empty for VM and host in both list and detail views
- Remove '报警' tab from VM and host sidepages, keep '报警记录' tab
- Use res_type/res_name direct params instead of filter format in alert history query for VM and host sidepages
- Make strategy name clickable in alert resource list to open policy detail

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0