### PR TITLE
Automated cherry pick of #9399: refactor(monitor): use GET for unifiedmonitors resource-metrics

### DIFF
--- a/containers/Compute/views/host/components/List.vue
+++ b/containers/Compute/views/host/components/List.vue
@@ -122,7 +122,7 @@ export default {
     this.hiddenFilterOptions.forEach(key => {
       delete filterOptions[key]
     })
-    const monitorManager = new this.$Manager('unifiedmonitors/resource-metrics', 'v1')
+    const monitorManager = new this.$Manager('unifiedmonitors', 'v1')
     return {
       monitorManager,
       list: this.$list.createList(this, {
@@ -141,8 +141,9 @@ export default {
             const list = response.data?.data || []
             const ids = list.map(item => item.id).filter(Boolean)
             if (ids.length) {
-              const res = await monitorManager.create({
-                data: {
+              const res = await monitorManager.get({
+                id: 'resource-metrics',
+                params: {
                   res_ids: ids,
                   res_type: 'host',
                 },

--- a/containers/Compute/views/host/sidepage/Detail.vue
+++ b/containers/Compute/views/host/sidepage/Detail.vue
@@ -670,9 +670,10 @@ export default {
       if (!id) return
       if (this.$isScopedPolicyMenuHidden('host_hidden_columns.alert_data')) return
       try {
-        const monitorManager = new this.$Manager('unifiedmonitors/resource-metrics', 'v1')
-        const res = await monitorManager.create({
-          data: {
+        const monitorManager = new this.$Manager('unifiedmonitors', 'v1')
+        const res = await monitorManager.get({
+          id: 'resource-metrics',
+          params: {
             res_ids: [id],
             res_type: 'host',
           },

--- a/containers/Compute/views/vminstance/components/List.vue
+++ b/containers/Compute/views/vminstance/components/List.vue
@@ -173,7 +173,7 @@ export default {
     if (bastionService && bastionService.status === true) {
       hasBastionService = true
     }
-    const monitorManager = new this.$Manager('unifiedmonitors/resource-metrics', 'v1')
+    const monitorManager = new this.$Manager('unifiedmonitors', 'v1')
     return {
       monitorManager,
       list: this.$list.createList(this, {
@@ -199,8 +199,9 @@ export default {
             const list = response.data?.data || []
             const ids = list.map(item => item.id).filter(Boolean)
             if (ids.length) {
-              const res = await monitorManager.create({
-                data: {
+              const res = await monitorManager.get({
+                id: 'resource-metrics',
+                params: {
                   res_ids: ids,
                   res_type: 'guest',
                 },

--- a/containers/Compute/views/vminstance/sidepage/Detail.vue
+++ b/containers/Compute/views/vminstance/sidepage/Detail.vue
@@ -709,9 +709,10 @@ export default {
       if (!id) return
       if (this.$isScopedPolicyMenuHidden('server_hidden_columns.alert_data')) return
       try {
-        const monitorManager = new this.$Manager('unifiedmonitors/resource-metrics', 'v1')
-        const res = await monitorManager.create({
-          data: {
+        const monitorManager = new this.$Manager('unifiedmonitors', 'v1')
+        const res = await monitorManager.get({
+          id: 'resource-metrics',
+          params: {
             res_ids: [id],
             res_type: 'guest',
           },


### PR DESCRIPTION
Cherry pick of #9399 on release/4.0.3.

#9399: refactor(monitor): use GET for unifiedmonitors resource-metrics