### PR TITLE
Automated cherry pick of #9415: fix(monitor): default alert silent_period to 5m

### DIFF
--- a/containers/Monitor/views/commonalert/components/alert/form/index.vue
+++ b/containers/Monitor/views/commonalert/components/alert/form/index.vue
@@ -165,7 +165,7 @@ export default {
       period: '5m',
       comparator: '>=',
       alert_duration: 2,
-      silent_period: '360m',
+      silent_period: '5m',
       reduce: 'avg',
       level: 'normal',
       scope: this.$store.getters.scope,

--- a/containers/Monitor/views/commonalert/components/new-alert/form/index.vue
+++ b/containers/Monitor/views/commonalert/components/new-alert/form/index.vue
@@ -222,7 +222,7 @@ export default {
       comparator: '>=',
       alert_duration: 2,
       from: '10m',
-      silent_period: '360m',
+      silent_period: '5m',
       reduce: 'avg',
       level: 'normal',
       scope: this.$store.getters.scope,


### PR DESCRIPTION
Cherry pick of #9415 on release/4.0.3.

#9415: fix(monitor): default alert silent_period to 5m