### PR TITLE
fix(monitor): 修正主机/虚拟机侧栏告警历史查询与全部时间

### DIFF
--- a/containers/Compute/views/host/sidepage/AlertList.vue
+++ b/containers/Compute/views/host/sidepage/AlertList.vue
@@ -3,14 +3,15 @@
     :id="id"
     :list-id="id"
     :get-params="mergedGetParams"
-    :hidden-columns="hiddenColumns" />
+    :hidden-columns="hiddenColumns"
+    default-time="" />
 </template>
 
 <script>
 import AlertResourceList from '@Monitor/views/alertresource/components/List'
 
 export default {
-  name: 'HostAlertList',
+  name: 'HostAlertHistory',
   components: {
     AlertResourceList,
   },
@@ -26,18 +27,19 @@ export default {
     },
   },
   computed: {
-    hostName () {
-      return this.data?.name || ''
+    hostId () {
+      return this.data?.id || ''
     },
     mergedGetParams () {
       return () => {
         const base = typeof this.getParams === 'function' ? this.getParams() : this.getParams
         const params = {
           ...(base || {}),
-          res_type: 'host',
+          all_state: true,
+          alerting: true,
         }
-        if (this.hostName) {
-          params.res_name = this.hostName
+        if (this.hostId) {
+          params.monitor_resource_id = this.hostId
         }
         return params
       }

--- a/containers/Compute/views/host/sidepage/index.vue
+++ b/containers/Compute/views/host/sidepage/index.vue
@@ -45,7 +45,7 @@ import StorageList from './Storage'
 import Monitor from './Monitor'
 import VminstanceList from './VminstanceList'
 import Dmesg from './Dmesg'
-import AlertList from './AlertList'
+import HostAlertHistory from './AlertList'
 
 export default {
   name: 'HostSidePage',
@@ -61,7 +61,8 @@ export default {
     Monitor,
     BmcLog,
     Dmesg,
-    AlertList,
+    HostAlertHistory,
+    'host-alert-history': HostAlertHistory,
   },
   mixins: [SidePageMixin, WindowsMixin, ColumnsMixin, SingleActionsMixin],
   computed: {
@@ -79,7 +80,7 @@ export default {
         { label: this.$t('compute.text_113'), key: 'gpu-list' },
         { label: this.$t('compute.text_114'), key: 'server-recovery' },
         { label: this.$t('compute.text_608'), key: 'monitor' },
-        { label: this.$t('dictionary.alertrecord'), key: 'alert-list' },
+        { label: this.$t('dictionary.alertrecord'), key: 'host-alert-history' },
         { label: this.$t('table.title.task'), key: 'task-drawer' },
         { label: this.$t('compute.text_240'), key: 'event-drawer' },
         { label: this.$t('compute.dmesg_log'), key: 'dmesg' },
@@ -123,10 +124,6 @@ export default {
         return {
           host_id: this.data.id,
         }
-      } else if (this.params.windowData.currentTab === 'alert-list') {
-        return {
-          res_name: this.detailData?.name,
-        }
       }
       return null
     },
@@ -134,7 +131,7 @@ export default {
       switch (this.params.windowData.currentTab) {
         case 'event-drawer':
           return 'EventListForHostSidePage'
-        case 'alert-list':
+        case 'host-alert-history':
           return 'AlertResourceListForHostSidePage'
         case 'vminstance-list':
           return 'VminstanceListForHostSidePage'

--- a/containers/Compute/views/vminstance/sidepage/AlertHistory.vue
+++ b/containers/Compute/views/vminstance/sidepage/AlertHistory.vue
@@ -3,7 +3,8 @@
     :id="id"
     :list-id="id"
     :get-params="mergedGetParams"
-    :hidden-columns="hiddenColumns" />
+    :hidden-columns="hiddenColumns"
+    default-time="" />
 </template>
 
 <script>
@@ -26,18 +27,19 @@ export default {
     },
   },
   computed: {
-    vmName () {
-      return this.data?.name || ''
+    vmId () {
+      return this.data?.id || ''
     },
     mergedGetParams () {
       return () => {
         const base = typeof this.getParams === 'function' ? this.getParams() : this.getParams
         const params = {
           ...(base || {}),
-          res_type: 'guest',
+          all_state: true,
+          alerting: true,
         }
-        if (this.vmName) {
-          params.res_name = this.vmName
+        if (this.vmId) {
+          params.monitor_resource_id = this.vmId
         }
         return params
       }

--- a/containers/Monitor/views/alertresource/components/List.vue
+++ b/containers/Monitor/views/alertresource/components/List.vue
@@ -3,6 +3,7 @@
     <monitor-header
       v-if="isTemplate && isTemplateEdit"
       :time.sync="time"
+      :allow-empty-time="allowEmptyTime"
       :showCustomTime="false"
       :showGroupFunc="false"
       :showTimegroup="false"
@@ -22,6 +23,7 @@
           class-name="ml-2"
           :time.sync="time"
           :customTime.sync="customTime"
+          :allow-empty-time="allowEmptyTime"
           :showGroupFunc="false"
           :showTimegroup="false"
           :show-sync="false"
@@ -73,6 +75,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    defaultTime: {
+      type: String,
+      default: '168h',
+    },
   },
   data () {
     let resource = 'monitorresourcealertees'
@@ -82,11 +88,14 @@ export default {
     return {
       list: this.$list.createList(this, this.listOptions(resource)),
       resTypeItems: [],
-      time: this.templateParams.time || '168h',
+      time: this.templateParams.time ?? (this.defaultTime === '' ? 'all' : this.defaultTime),
       customTime: null,
     }
   },
   computed: {
+    allowEmptyTime () {
+      return this.defaultTime === ''
+    },
     columns () {
       let columns = this.listColumns()
       if (this.hiddenColumns.length) {
@@ -113,6 +122,9 @@ export default {
   },
   watch: {
     time (val) {
+      if (val === 'all') {
+        this.customTime = null
+      }
       this.list.fetchData()
     },
     customTime (val) {
@@ -303,12 +315,13 @@ export default {
       ]
     },
     getParam () {
+      const base = R.is(Function, this.getParams) ? this.getParams() : (this.getParams || {})
       const ret = {
-        ...(R.is(Function, this.getParams) ? this.getParams() : this.getParams),
         details: true,
         alerting: true,
+        ...base,
       }
-      if (this.time) {
+      if (this.time && this.time !== 'all') {
         let timeFilter = ''
         if (this.time.includes('h')) {
           ret.start_time = this.$moment().utc().subtract(this.time.replace('h', ''), 'hours').format('YYYY-MM-DD HH:mm:ss')

--- a/src/sections/Monitor/Header.vue
+++ b/src/sections/Monitor/Header.vue
@@ -15,6 +15,7 @@
     </template>
     <refresh-button v-else-if="showSync" :loading="loading" @refresh="refresh" class="mr-2" />
     <a-radio-group class="mr-3" @change="timeChange" :value="time">
+      <a-radio-button v-if="allowEmptyTime" key="all" value="all">{{ $t('common_737') }}</a-radio-button>
       <a-radio-button v-for="item in timeOpts" v-show="!item.hidden" :key="item.key" :value="item.key">{{ item.label }}</a-radio-button>
       <slot name="radio-button-append" v-if="showCustomTime">
         <custom-date @update:time="(val) => timeChange({target: {value: val}})" :customTimeUseTimeStamp="customTimeUseTimeStamp" :customTime="customTime" @update:customTime="customTimeChange" :showCustomTimeText="isCustom" />
@@ -211,6 +212,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    allowEmptyTime: {
+      type: Boolean,
+      default: false,
+    },
   },
   data () {
     let timer
@@ -276,6 +281,10 @@ export default {
     timeChange (val) {
       const time = val.target.value
       console.log('time', time)
+      if (time === 'all') {
+        this.$emit('update:time', 'all')
+        return
+      }
       if (time === 'custom') {
         this.$emit('update:time', time, 'YYYY-MM-DD HH:mm')
       } else {


### PR DESCRIPTION
侧栏告警历史改用 monitor_resource_id 与 alerting 参数过滤，并支持默认展示全部时间范围。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0