### PR TITLE
feat(ai): 抽取 LLM 镜像/套餐选择组件并增强选项展示

### DIFF
--- a/containers/Ai/sections/LlmImageSelect.vue
+++ b/containers/Ai/sections/LlmImageSelect.vue
@@ -1,0 +1,126 @@
+<template>
+  <base-select
+    class="llm-image-select"
+    resource="llm_images"
+    dropdown-item-word-wrap
+    :value="value"
+    v-bind="attrsWithoutValue"
+    v-on="otherListeners"
+    :params="params"
+    :select-props="mergedSelectProps"
+    @input="onInput"
+    @change="onChange">
+    <template #optionLabelTemplate="{ item }">
+      <div class="llm-image-option">
+        <div class="oc-selected-display-none">
+          <div class="text-truncate" :title="item.name">{{ item.name }}</div>
+          <div
+            class="text-color-secondary mt-1 text-truncate"
+            style="font-size: 12px"
+            :title="formatLlmImageConfig(item)">
+            {{ formatLlmImageConfig(item) }}
+          </div>
+        </div>
+        <div
+          class="oc-dropdown-display-none llm-image-option__selected text-truncate"
+          :title="`${item.name} (${formatLlmImageConfig(item)})`">
+          <span>{{ item.name }}</span>
+          <span class="text-color-secondary"> ({{ formatLlmImageConfig(item) }})</span>
+        </div>
+      </div>
+    </template>
+  </base-select>
+</template>
+
+<script>
+export default {
+  name: 'LlmImageSelect',
+  inheritAttrs: false,
+  model: {
+    prop: 'value',
+    event: 'change',
+  },
+  props: {
+    value: {
+      default: undefined,
+    },
+    params: {
+      type: Object,
+      default: () => ({}),
+    },
+    selectProps: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    attrsWithoutValue () {
+      const attrs = { ...this.$attrs }
+      delete attrs.value
+      return attrs
+    },
+    otherListeners () {
+      const { input, change, ...rest } = this.$listeners
+      return rest
+    },
+    mergedSelectProps () {
+      const placeholder = this.selectProps.placeholder
+      return {
+        dropdownStyle: { minWidth: '520px' },
+        optionLabelProp: 'label',
+        ...this.selectProps,
+        ...(placeholder != null ? { placeholder } : {}),
+      }
+    },
+  },
+  methods: {
+    onInput (val) {
+      this.$emit('input', val)
+    },
+    onChange (val, isNative) {
+      this.$emit('input', val)
+      this.$emit('change', val, isNative)
+    },
+    formatLlmImageRef (item) {
+      if (!item.image_name) return ''
+      const label = item.image_label || 'latest'
+      return `${item.image_name}:${label}`
+    },
+    formatLlmImageConfig (item) {
+      const parts = []
+      const ref = this.formatLlmImageRef(item)
+      if (ref) {
+        parts.push(`${this.$t('aice.llm_image.url')}：${ref}`)
+      }
+      if (item.llm_type) {
+        const key = `aice.llm_type.${String(item.llm_type).replace(/-/g, '_')}`
+        const typeLabel = this.$te(key) ? this.$t(key) : item.llm_type
+        parts.push(`${this.$t('aice.llm_type')}：${typeLabel}`)
+      }
+      if (item.app_name) {
+        parts.push(`${this.$t('aice.llm_image.app_name')}：${item.app_name}`)
+      }
+      const desc = item.description
+      if (desc && desc !== '-') {
+        parts.push(desc)
+      }
+      return parts.join(' · ') || item.name || '-'
+    },
+  },
+}
+</script>
+
+<style lang="less" scoped>
+.llm-image-select {
+  ::v-deep .ant-select-selection__rendered {
+    overflow: hidden;
+  }
+  ::v-deep .ant-select-selection-selected-value {
+    float: none;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+</style>

--- a/containers/Ai/sections/LlmSkuSelect.vue
+++ b/containers/Ai/sections/LlmSkuSelect.vue
@@ -1,0 +1,140 @@
+<template>
+  <base-select
+    class="llm-sku-select"
+    resource="llm_skus"
+    dropdown-item-word-wrap
+    :value="value"
+    v-bind="attrsWithoutValue"
+    v-on="otherListeners"
+    :params="params"
+    :select-props="mergedSelectProps"
+    @input="onInput"
+    @change="onChange">
+    <template #optionLabelTemplate="{ item }">
+      <div class="llm-sku-option">
+        <div class="oc-selected-display-none">
+          <div class="text-truncate" :title="item.name">{{ item.name }}</div>
+          <div
+            class="text-color-secondary mt-1 text-truncate"
+            style="font-size: 12px"
+            :title="formatLlmSkuConfig(item)">
+            {{ formatLlmSkuConfig(item) }}
+          </div>
+        </div>
+        <div
+          class="oc-dropdown-display-none llm-sku-option__selected text-truncate"
+          :title="`${item.name} (${formatLlmSkuConfig(item)})`">
+          <span>{{ item.name }}</span>
+          <span class="text-color-secondary"> ({{ formatLlmSkuConfig(item) }})</span>
+        </div>
+      </div>
+    </template>
+  </base-select>
+</template>
+
+<script>
+import { sizestr } from '@/utils/utils'
+
+export default {
+  name: 'LlmSkuSelect',
+  inheritAttrs: false,
+  model: {
+    prop: 'value',
+    event: 'change',
+  },
+  props: {
+    value: {
+      default: undefined,
+    },
+    params: {
+      type: Object,
+      default: () => ({}),
+    },
+    selectProps: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    attrsWithoutValue () {
+      const attrs = { ...this.$attrs }
+      delete attrs.value
+      return attrs
+    },
+    otherListeners () {
+      const { input, change, ...rest } = this.$listeners
+      return rest
+    },
+    mergedSelectProps () {
+      const placeholder = this.selectProps.placeholder
+      return {
+        dropdownStyle: { minWidth: '520px' },
+        optionLabelProp: 'label',
+        ...this.selectProps,
+        ...(placeholder != null ? { placeholder } : {}),
+      }
+    },
+  },
+  methods: {
+    onInput (val) {
+      this.$emit('input', val)
+    },
+    onChange (val, isNative) {
+      this.$emit('input', val)
+      this.$emit('change', val, isNative)
+    },
+    formatLlmSkuMemory (memory) {
+      if (memory == null) return '-'
+      return sizestr(memory, 'M', 1024)
+    },
+    formatLlmSkuDisk (item) {
+      const volumes = item.volumes || []
+      if (!volumes.length) return '-'
+      let size = 0
+      volumes.forEach(v => { size += v.size_mb || 0 })
+      return sizestr(size, 'M', 1024)
+    },
+    formatLlmSkuBandwidth (bandwidth) {
+      if (bandwidth == null) return '-'
+      if (bandwidth === 0) return `0(${this.$t('common.not_limited')})`
+      return `${bandwidth}M`
+    },
+    formatLlmSkuConfig (item) {
+      const parts = []
+      if (item.app_name) {
+        parts.push(`${this.$t('aice.llm_image.app_name')}：${item.app_name}`)
+      }
+      parts.push(
+        `CPU ${item.cpu || '-'}`,
+        `${this.$t('aice.memory')} ${this.formatLlmSkuMemory(item.memory)}`,
+        `${this.$t('aice.disk')} ${this.formatLlmSkuDisk(item)}`,
+      )
+      if (item.bandwidth != null) {
+        parts.push(`${this.$t('aice.bandwidth')} ${this.formatLlmSkuBandwidth(item.bandwidth)}`)
+      }
+      if (item.image) {
+        parts.push(`${this.$t('aice.image')}：${item.image}`)
+      }
+      if (item.llm_type) {
+        parts.push(`${this.$t('aice.llm_type')}：${item.llm_type}`)
+      }
+      return parts.join(' · ')
+    },
+  },
+}
+</script>
+
+<style lang="less" scoped>
+.llm-sku-select {
+  ::v-deep .ant-select-selection__rendered {
+    overflow: hidden;
+  }
+  ::v-deep .ant-select-selection-selected-value {
+    float: none;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+</style>

--- a/containers/Ai/views/llm-deployment/create/index.vue
+++ b/containers/Ai/views/llm-deployment/create/index.vue
@@ -29,36 +29,12 @@
         <!-- Mode A: reuse existing SKU -->
         <template v-if="form.fd.mode === 'reuse'">
           <a-form-item :label="$t('aice.llm_sku')">
-            <base-select
-              class="llm-sku-select"
+            <llm-sku-select
               v-decorator="decorators.llm_sku_id"
-              resource="llm_skus"
               :params="skuParams"
-              dropdown-item-word-wrap
               :select-props="{
                 placeholder: $t('common.tips.select', [$t('aice.llm_sku')]),
-                dropdownStyle: { minWidth: '520px' },
-              }">
-              <template #optionLabelTemplate="{ item }">
-                <div class="llm-sku-option">
-                  <div class="oc-selected-display-none">
-                    <div class="text-truncate" :title="item.name">{{ item.name }}</div>
-                    <div
-                      class="text-color-secondary mt-1 text-truncate"
-                      style="font-size: 12px"
-                      :title="formatLlmSkuConfig(item)">
-                      {{ formatLlmSkuConfig(item) }}
-                    </div>
-                  </div>
-                  <div
-                    class="oc-dropdown-display-none llm-sku-option__selected text-truncate"
-                    :title="`${item.name} (${formatLlmSkuConfig(item)})`">
-                    <span>{{ item.name }}</span>
-                    <span class="text-color-secondary"> ({{ formatLlmSkuConfig(item) }})</span>
-                  </div>
-                </div>
-              </template>
-            </base-select>
+              }" />
           </a-form-item>
         </template>
 
@@ -73,9 +49,8 @@
           </a-form-item>
 
           <a-form-item :label="$t('aice.llm_image')">
-            <base-select
+            <llm-image-select
               v-decorator="decorators.llm_image_id"
-              resource="llm_images"
               :params="imageParams"
               :select-props="{ placeholder: $t('common.tips.select', [$t('aice.llm_image')]) }" />
           </a-form-item>
@@ -83,7 +58,7 @@
           <a-divider orientation="left">{{ $t('aice.llm_deployment.create.resources') }}</a-divider>
 
           <a-form-item label="CPU">
-            <a-input-number v-decorator="decorators.cpu" :min="1" :max="128" /> {{ $t('compute.text_357') }}
+            <a-input-number v-decorator="decorators.cpu" :min="1" :max="128" />
           </a-form-item>
           <a-form-item :label="$t('compute.text_300')">
             <a-input-number v-decorator="decorators.memory" :min="512" :step="512" /> MB
@@ -213,10 +188,12 @@
 <script>
 import * as R from 'ramda'
 import { Manager } from '@/utils/manager'
-import { uuid, sizestr } from '@/utils/utils'
+import { uuid } from '@/utils/utils'
 import validateForm from '@/utils/validate'
 import ServerNetwork from '@Compute/sections/ServerNetwork'
 import { NETWORK_OPTIONS_MAP } from '@Compute/constants'
+import LlmImageSelect from '@Ai/sections/LlmImageSelect'
+import LlmSkuSelect from '@Ai/sections/LlmSkuSelect'
 import { getDefaultPortMappingsForType } from '@Ai/views/llm-sku/constants/llmTypeConfig'
 
 const getInitVal = (list, key, property) => {
@@ -226,7 +203,7 @@ const getInitVal = (list, key, property) => {
 
 export default {
   name: 'LlmDeploymentCreate',
-  components: { ServerNetwork },
+  components: { LlmImageSelect, LlmSkuSelect, ServerNetwork },
   data () {
     const defaultLlmType = 'ollama'
     const portMappings = getDefaultPortMappingsForType(defaultLlmType).map(item => ({ ...item, key: uuid() }))
@@ -264,6 +241,7 @@ export default {
         }],
         llm_type: ['llm_type', { initialValue: defaultLlmType }],
         llm_image_id: ['llm_image_id', {
+          trigger: 'input',
           rules: [{ required: true, message: this.$t('common.tips.select', [this.$t('aice.llm_image')]) }],
         }],
         cpu: ['cpu', {
@@ -350,7 +328,12 @@ export default {
       return { scope: this.$store.getters.scope, details: true, limit: 20, filter: ['llm_type.in(vllm,ollama,sglang)'] }
     },
     imageParams () {
-      return { scope: this.$store.getters.scope, llm_type: this.form.fd.llm_type }
+      return {
+        limit: 20,
+        scope: this.$store.getters.scope,
+        details: true,
+        llm_type: this.form.fd.llm_type,
+      }
     },
     instantModelParams () {
       return { scope: this.$store.getters.scope, llm_type: this.form.fd.llm_type }
@@ -397,36 +380,6 @@ export default {
           llm_sku_id: skuId,
         })
       })
-    },
-    formatLlmSkuMemory (memory) {
-      if (memory == null) return '-'
-      return sizestr(memory, 'M', 1024)
-    },
-    formatLlmSkuDisk (item) {
-      const volumes = item.volumes || []
-      if (!volumes.length) return '-'
-      let size = 0
-      volumes.forEach(v => { size += v.size_mb || 0 })
-      return sizestr(size, 'M', 1024)
-    },
-    formatLlmSkuBandwidth (bandwidth) {
-      if (bandwidth == null) return '-'
-      if (bandwidth === 0) return `0(${this.$t('common.not_limited')})`
-      return `${bandwidth}M`
-    },
-    formatLlmSkuConfig (item) {
-      const parts = [
-        `CPU ${item.cpu || '-'}`,
-        `${this.$t('aice.memory')} ${this.formatLlmSkuMemory(item.memory)}`,
-        `${this.$t('aice.disk')} ${this.formatLlmSkuDisk(item)}`,
-      ]
-      if (item.bandwidth != null) {
-        parts.push(`${this.$t('aice.bandwidth')} ${this.formatLlmSkuBandwidth(item.bandwidth)}`)
-      }
-      if (item.image) {
-        parts.push(`${this.$t('aice.image')}：${item.image}`)
-      }
-      return parts.join(' · ')
     },
     async loadModelSpec (id) {
       try {
@@ -627,18 +580,3 @@ export default {
   },
 }
 </script>
-
-<style lang="less" scoped>
-.llm-sku-select {
-  ::v-deep .ant-select-selection__rendered {
-    overflow: hidden;
-  }
-  ::v-deep .ant-select-selection-selected-value {
-    float: none;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-}
-</style>

--- a/containers/Ai/views/llm-deployment/shared/CatalogDeployForm.vue
+++ b/containers/Ai/views/llm-deployment/shared/CatalogDeployForm.vue
@@ -14,9 +14,8 @@
         :placeholder="$t('common.tips.input', [$t('common.name')])" />
     </a-form-model-item>
     <a-form-model-item :label="$t('aice.llm_image')" prop="llm_image_id">
-      <base-select
+      <llm-image-select
         v-model="deployForm.llm_image_id"
-        resource="llm_images"
         :params="imageParams"
         :select-props="{ placeholder: $t('common.tips.select', [$t('aice.llm_image')]) }" />
     </a-form-model-item>
@@ -53,10 +52,14 @@
 </template>
 
 <script>
+import LlmImageSelect from '@Ai/sections/LlmImageSelect'
 import { getParamsForType } from '@Ai/views/llm-sku/constants/llmTypeConfig'
 
 export default {
   name: 'CatalogDeployForm',
+  components: {
+    LlmImageSelect,
+  },
   props: {
     deployForm: {
       type: Object,
@@ -90,6 +93,7 @@ export default {
       return {
         limit: 20,
         scope: this.$store.getters.scope,
+        details: true,
         $t: 1,
         ...getParamsForType(this.llmType),
       }

--- a/containers/Ai/views/llm-sku/components/LlmSkuGrid.vue
+++ b/containers/Ai/views/llm-sku/components/LlmSkuGrid.vue
@@ -9,7 +9,8 @@
           :key="item.id"
           hoverable
           class="catalog-card"
-          :class="{ 'catalog-card--selected': isSelected(item) }">
+          :class="{ 'catalog-card--selected': isSelected(item) }"
+          @click="handleCardClick(item, $event)">
           <div class="catalog-card-header">
             <img
               v-if="getCardIcon(item)"
@@ -23,7 +24,7 @@
               {{ getCardIconLabel(item) }}
             </div>
             <div class="catalog-card-title">
-              <div class="catalog-card-name" @click.stop>
+              <div class="catalog-card-name">
                 <list-body-cell-wrap
                   copy
                   hide-field
@@ -33,9 +34,7 @@
                   :on-manager="onManager"
                   :edit="true"
                   :steady-status="steadyStatus">
-                  <side-page-trigger @trigger="$emit('open-sidepage', item)">
-                    {{ item.name }}
-                  </side-page-trigger>
+                  <span class="catalog-card-name-text">{{ item.name }}</span>
                 </list-body-cell-wrap>
               </div>
               <div class="catalog-subtitle">
@@ -47,7 +46,7 @@
               </div>
             </div>
           </div>
-          <div class="catalog-meta" @click="$emit('open-sidepage', item)">
+          <div class="catalog-meta">
             <div class="meta-row meta-row--specs">
               <span>CPU {{ item.cpu || '-' }}</span>
               <span>{{ $t('aice.memory') }} {{ formatMemory(item.memory) }}</span>
@@ -256,6 +255,16 @@ export default {
       const trimmed = String(s).trim()
       return trimmed.length > 80 ? trimmed.slice(0, 77) + '…' : trimmed
     },
+    handleCardClick (item, e) {
+      const target = e && e.target
+      if (target && target.closest) {
+        const ignore = target.closest(
+          '.catalog-card-footer, .meta-row--copy, .meta-scope, .edit-icon, .copy-icon',
+        )
+        if (ignore) return
+      }
+      this.$emit('open-sidepage', item)
+    },
   },
 }
 </script>
@@ -305,6 +314,7 @@ export default {
   height: 100%;
   display: flex;
   flex-direction: column;
+  cursor: pointer;
 }
 .catalog-card--selected {
   border-color: @primary-color;
@@ -341,6 +351,9 @@ export default {
   font-weight: 600;
   min-width: 0;
 }
+.catalog-card-name-text {
+  cursor: pointer;
+}
 .catalog-card-name ::v-deep .list-body-cell-wrap {
   min-width: 0;
 }
@@ -375,7 +388,6 @@ export default {
 }
 .catalog-meta {
   flex: 1;
-  cursor: pointer;
 }
 .meta-row {
   font-size: 12px;

--- a/containers/Ai/views/llm-sku/create/Form.vue
+++ b/containers/Ai/views/llm-sku/create/Form.vue
@@ -31,75 +31,65 @@
       </a-form-item>
       <template v-if="form.fd.llm_type === 'dify'">
         <a-form-item :label="$t('aice.dify_api_image')">
-          <base-select
+          <llm-image-select
             v-decorator="decorators.dify_api_image_id"
-            resource="llm_images"
             :params="{ ...appImageParams, $t: 'dify_api_image' }"
-            :selectProps="{ placeholder: $t('common.tips.select', [$t('aice.dify_api_image')]) }" />
+            :select-props="{ placeholder: $t('common.tips.select', [$t('aice.dify_api_image')]) }" />
         </a-form-item>
         <a-form-item :label="$t('aice.dify_plugin_image')">
-          <base-select
+          <llm-image-select
             v-decorator="decorators.dify_plugin_image_id"
-            resource="llm_images"
             :params="{ ...appImageParams, $t: 'dify_plugin_image' }"
-            :selectProps="{ placeholder: $t('common.tips.select', [$t('aice.dify_plugin_image')]) }" />
+            :select-props="{ placeholder: $t('common.tips.select', [$t('aice.dify_plugin_image')]) }" />
         </a-form-item>
         <a-form-item :label="$t('aice.dify_sandbox_image')">
-          <base-select
+          <llm-image-select
             v-decorator="decorators.dify_sandbox_image_id"
-            resource="llm_images"
             :params="{ ...appImageParams, $t: 'dify_sandbox_image' }"
-            :selectProps="{ placeholder: $t('common.tips.select', [$t('aice.dify_sandbox_image')]) }" />
+            :select-props="{ placeholder: $t('common.tips.select', [$t('aice.dify_sandbox_image')]) }" />
         </a-form-item>
         <a-form-item :label="$t('aice.dify_ssrf_image')">
-          <base-select
+          <llm-image-select
             v-decorator="decorators.dify_ssrf_image_id"
-            resource="llm_images"
             :params="{ ...appImageParams, $t: 'dify_ssr_image' }"
-            :selectProps="{ placeholder: $t('common.tips.select', [$t('aice.dify_ssr_image')]) }" />
+            :select-props="{ placeholder: $t('common.tips.select', [$t('aice.dify_ssr_image')]) }" />
         </a-form-item>
         <a-form-item :label="$t('aice.dify_weaviate_image')">
-          <base-select
+          <llm-image-select
             v-decorator="decorators.dify_weaviate_image_id"
-            resource="llm_images"
             :params="{ ...appImageParams, $t: 'dify_weaviate_image' }"
-            :selectProps="{ placeholder: $t('common.tips.select', [$t('aice.dify_weaviate_image')]) }" />
+            :select-props="{ placeholder: $t('common.tips.select', [$t('aice.dify_weaviate_image')]) }" />
         </a-form-item>
         <a-form-item :label="$t('aice.dify_web_image')">
-          <base-select
+          <llm-image-select
             v-decorator="decorators.dify_web_image_id"
-            resource="llm_images"
             :params="{ ...appImageParams, $t: 'dify_web_image' }"
-            :selectProps="{ placeholder: $t('common.tips.select', [$t('aice.dify_web_image')]) }" />
+            :select-props="{ placeholder: $t('common.tips.select', [$t('aice.dify_web_image')]) }" />
         </a-form-item>
         <a-form-item :label="$t('aice.nginx_image')">
-          <base-select
+          <llm-image-select
             v-decorator="decorators.nginx_image_id"
-            resource="llm_images"
             :params="{ ...appImageParams, $t: 'nginx_image' }"
-            :selectProps="{ placeholder: $t('common.tips.select', [$t('aice.nginx_image')]) }" />
+            :select-props="{ placeholder: $t('common.tips.select', [$t('aice.nginx_image')]) }" />
         </a-form-item>
         <a-form-item :label="$t('aice.postgres_image')">
-          <base-select
+          <llm-image-select
             v-decorator="decorators.postgres_image_id"
-            resource="llm_images"
             :params="{ ...appImageParams, $t: 'postgres_image' }"
-            :selectProps="{ placeholder: $t('common.tips.select', [$t('aice.postgres_image')]) }" />
+            :select-props="{ placeholder: $t('common.tips.select', [$t('aice.postgres_image')]) }" />
         </a-form-item>
         <a-form-item :label="$t('aice.redis_image')">
-          <base-select
+          <llm-image-select
             v-decorator="decorators.redis_image_id"
-            resource="llm_images"
             :params="{ ...appImageParams, $t: 'redis_image' }"
-            :selectProps="{ placeholder: $t('common.tips.select', [$t('aice.redis_image')]) }" />
+            :select-props="{ placeholder: $t('common.tips.select', [$t('aice.redis_image')]) }" />
         </a-form-item>
       </template>
       <a-form-item v-else :label="$t('aice.llm_image')">
-        <base-select
+        <llm-image-select
           v-decorator="decorators.llm_image_id"
-          resource="llm_images"
           :params="appImageParams"
-          :selectProps="{ placeholder: $t('common.tips.select', [$t('aice.llm_image')]) }" />
+          :select-props="{ placeholder: $t('common.tips.select', [$t('aice.llm_image')]) }" />
       </a-form-item>
       <a-form-item :label="$t('aice.cpu')">
         <a-input-number
@@ -376,6 +366,7 @@ import { isRequired } from '@/utils/validate'
 import { uuid } from '@/utils/utils'
 import { dict } from '../constants/constant'
 import { LLM_TYPE_OPTIONS, LLM_TYPE_FORM_CONFIG, getParamsForType, getDefaultPortMappingsForType } from '../constants/llmTypeConfig'
+import LlmImageSelect from '@Ai/sections/LlmImageSelect'
 import { parseLlmRoute } from '@Ai/utils/llmRouteContext'
 import {
   backendToLlmType,
@@ -398,6 +389,7 @@ export default {
   name: 'LlmSkuCreateForm',
   components: {
     DomainProject,
+    LlmImageSelect,
     NameRepeated,
   },
   mixins: [WindowsMixin],
@@ -585,6 +577,7 @@ export default {
           'llm_image_id',
           {
             initialValue: llm_image_id,
+            trigger: 'input',
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('aice.llm_image')]) },
             ],
@@ -594,6 +587,7 @@ export default {
           'dify_api_image_id',
           {
             initialValue: dify_api_image_id,
+            trigger: 'input',
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('aice.dify_api_image')]) },
             ],
@@ -603,6 +597,7 @@ export default {
           'dify_plugin_image_id',
           {
             initialValue: dify_plugin_image_id,
+            trigger: 'input',
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('aice.dify_plugin_image')]) },
             ],
@@ -612,6 +607,7 @@ export default {
           'dify_sandbox_image_id',
           {
             initialValue: dify_sandbox_image_id,
+            trigger: 'input',
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('aice.dify_sandbox_image')]) },
             ],
@@ -621,6 +617,7 @@ export default {
           'dify_ssrf_image_id',
           {
             initialValue: dify_ssrf_image_id,
+            trigger: 'input',
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('aice.dify_ssr_image')]) },
             ],
@@ -639,6 +636,7 @@ export default {
           'dify_weaviate_image_id',
           {
             initialValue: dify_weaviate_image_id,
+            trigger: 'input',
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('aice.dify_weaviate_image')]) },
             ],
@@ -648,6 +646,7 @@ export default {
           'dify_web_image_id',
           {
             initialValue: dify_web_image_id,
+            trigger: 'input',
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('aice.dify_web_image')]) },
             ],
@@ -657,6 +656,7 @@ export default {
           'nginx_image_id',
           {
             initialValue: nginx_image_id,
+            trigger: 'input',
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('aice.nginx_image')]) },
             ],
@@ -666,6 +666,7 @@ export default {
           'postgres_image_id',
           {
             initialValue: postgres_image_id,
+            trigger: 'input',
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('aice.postgres_image')]) },
             ],
@@ -675,6 +676,7 @@ export default {
           'redis_image_id',
           {
             initialValue: redis_image_id,
+            trigger: 'input',
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('aice.redis_image')]) },
             ],
@@ -915,6 +917,7 @@ export default {
       return {
         limit: 20,
         scope: this.$store.getters.scope,
+        details: true,
         $t: 1,
         ...getParamsForType(llmType),
       }

--- a/containers/Ai/views/llm-sku/mixins/singleActions.js
+++ b/containers/Ai/views/llm-sku/mixins/singleActions.js
@@ -22,7 +22,7 @@ export default {
             query: { from_sku: obj.id },
           })
         },
-        hidden: () => this.isApplyType,
+        hidden: () => this.isApplyType || this.isDesktopType,
       },
       {
         label: this.$t('common.more'),

--- a/containers/Ai/views/llm/create.vue
+++ b/containers/Ai/views/llm/create.vue
@@ -20,13 +20,12 @@
           </a-radio-group>
         </a-form-item>
         <a-form-item :label="llmSkuLabel">
-          <base-select
+          <llm-sku-select
             v-decorator="decorators.llm_sku_id"
-            resource="llm_skus"
+            :params="llmSkuParams"
             :select-props="{
               placeholder: $t('common.tips.select', [llmSkuLabel]),
-            }"
-            :params="llmSkuParams" />
+            }" />
         </a-form-item>
         <a-form-item v-if="supportMountedModels" :label="$t('aice.model')" :extra="$t('aice.llm_override_sku_extra')">
           <base-select
@@ -569,6 +568,7 @@ import { uuid } from '@/utils/utils'
 import NameRepeated from '@/sections/NameRepeated'
 import { NETWORK_OPTIONS_MAP } from '@Compute/constants'
 import ServerNetwork from '@Compute/sections/ServerNetwork'
+import LlmSkuSelect from '@Ai/sections/LlmSkuSelect'
 import { LLM_TYPE_OPTIONS, getParamsForType } from '../llm-sku/constants/llmTypeConfig'
 import { parseLlmRoute } from '@Ai/utils/llmRouteContext'
 import { OPENCLAW_CHANNEL_SECTIONS, OPENCLAW_CHANNEL_OPTIONS } from '../llm-sku/constants/openclawChannelConfig'
@@ -581,6 +581,7 @@ export default {
     }
   },
   components: {
+    LlmSkuSelect,
     NameRepeated,
     ServerNetwork,
   },
@@ -884,6 +885,7 @@ export default {
       return {
         limit: 20,
         scope: this.$store.getters.scope,
+        details: true,
         ...getParamsForType(this.form.fd.llm_type),
       }
     },


### PR DESCRIPTION
新增 LlmImageSelect、LlmSkuSelect 共用组件，在部署、LLM 与套餐创建表单中复用； 修复镜像字段校验 trigger，并为下拉请求补充 details 参数；Desktop 类型隐藏套餐克隆操作。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0