### PR TITLE
fix(ai): 社区导入桌面镜像 generate_name 使用 app_name 前缀

### DIFF
--- a/containers/Ai/views/llm-image/import-community/index.vue
+++ b/containers/Ai/views/llm-image/import-community/index.vue
@@ -54,6 +54,15 @@ function parseImageField (imageStr) {
   return { image_name: imageStr, image_label: 'latest' }
 }
 
+/** 导入时 generate_name：桌面镜像以 app_name 开头，其它类型仍为 llm_type-image_label */
+function buildImportGenerateName (record) {
+  const label = record.image_label || 'latest'
+  if (record.llm_type === 'desktop' && record.app_name) {
+    return `${record.app_name}-${label}`
+  }
+  return `${record.llm_type}-${label}`
+}
+
 export default {
   name: 'LlmImageImportCommunityPage',
   mixins: [WindowsMixin, ListMixin],
@@ -257,7 +266,7 @@ export default {
       let imageId = ''
       try {
         const createData = {
-          generate_name: `${record.llm_type}-${record.image_label}`,
+          generate_name: buildImportGenerateName(record),
           llm_type: record.llm_type,
           image_name: record.image_name,
           image_label: record.image_label,
@@ -287,7 +296,7 @@ export default {
       if (!spec) return // dify 等无默认 SKU 模板的类型直接跳过
       const portMappings = getDefaultPortMappingsForType(record.llm_type)
       const data = {
-        generate_name: `${record.llm_type}-${record.image_label}`,
+        generate_name: buildImportGenerateName(record),
         llm_type: record.llm_type,
         llm_image_id: imageId,
         cpu: spec.cpu,


### PR DESCRIPTION
桌面类型导入时 generate_name 改为 app_name-image_label，其它类型仍为 llm_type-image_label。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0