### PR TITLE
fix(compute): 容器实例镜像仓库选择时传递 image_credential_id

### DIFF
--- a/containers/Compute/sections/MirrorRegistry/index.vue
+++ b/containers/Compute/sections/MirrorRegistry/index.vue
@@ -169,7 +169,9 @@ export default {
           }
         })
         if (this.isDefaultSelect && this.registrys?.length > 0) {
-          this.registry = this.registrys?.[0].value
+          const defaultRegistry = this.registrys[0]
+          this.registry = defaultRegistry.value
+          this.$emit('credential-change', defaultRegistry.credential_id || '')
           this.getImagesByRegistryId(this.registry)
         } else {
           this.image = ''

--- a/containers/Compute/views/vminstance-container/dialogs/Update.vue
+++ b/containers/Compute/views/vminstance-container/dialogs/Update.vue
@@ -24,7 +24,8 @@
               :placeholder="$t('common.tips.input', [$t('compute.repo.container_image')])" />
           </a-form-item>
           <a-form-item v-else :label="$t('compute.repo.container_image')">
-            <mirror-registry v-decorator="decorators.registryImage" />
+            <mirror-registry v-decorator="decorators.registryImage" @credential-change="handleCredentialChange" />
+            <a-input v-show="false" v-decorator="decorators.imageCredentialId" />
           </a-form-item>
           <a-form-item :label="$t('compute.repo.command')">
             <a-input v-decorator="decorators.command" :placeholder="$t('compute.repo.command.placeholder')" />
@@ -130,6 +131,12 @@ export default {
             rules: [
               { required: true, message: this.$t('common.tips.select', [this.$t('compute.eci.repo.image.registry')]) },
             ],
+          },
+        ],
+        imageCredentialId: [
+          'imageCredentialId',
+          {
+            initialValue: specData.image_credential_id,
           },
         ],
         image: [
@@ -252,6 +259,11 @@ export default {
     handleSourceChange (e) {
       this.source = e.target.value
     },
+    handleCredentialChange (credentialId) {
+      this.form.fc.setFieldsValue({
+        imageCredentialId: credentialId,
+      })
+    },
     async doSubmit (values) {
       const { id, spec } = this.params.data[0]
       const getEnvs = (names, values) => {
@@ -267,9 +279,17 @@ export default {
         ...spec,
       }
       if (this.editMode === 'custom') {
-        const { image, registryImage, command, arg, envNames, envValues, privileged, capAdd, capDrop } = values
-        if (image || registryImage) {
-          specData.image = image || registryImage
+        const { image, registryImage, imageCredentialId, command, arg, envNames, envValues, privileged, capAdd, capDrop } = values
+        if (this.source === 'registry' && registryImage) {
+          specData.image = registryImage
+          if (imageCredentialId) {
+            specData.image_credential_id = imageCredentialId
+          } else {
+            delete specData.image_credential_id
+          }
+        } else if (image) {
+          specData.image = image
+          delete specData.image_credential_id
         }
         if (command) {
           specData.command = command.split(' ')

--- a/containers/Compute/views/vminstance-container/utils/createServer.js
+++ b/containers/Compute/views/vminstance-container/utils/createServer.js
@@ -1385,7 +1385,7 @@ export class GenCreateData {
           }
         }
       }
-      if (credentialId) {
+      if (image && credentialId) {
         spec.image_credential_id = credentialId
       }
       return spec


### PR DESCRIPTION
默认选中镜像仓库时同步 credential_id；更新对话框与创建流程写入 spec.image_credential_id。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0