### PR TITLE
feat(ai): add LLM SKU community import and refactor community image UI

### DIFF
--- a/containers/Ai/router/index.js
+++ b/containers/Ai/router/index.js
@@ -8,11 +8,11 @@ const LlmSku = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: tr
 const LlmSkuCreate = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-sku/create/index')
 const LlmSkuImportFromModelSets = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-sku/import-from-model-sets')
 const LlmSkuImportFromHuggingFace = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-sku/import-from-huggingface')
+const LlmSkuImportFromCommunity = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-sku/import-from-community')
 const LlmInstantmodel = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-instantmodel')
 const LlmImage = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-image')
 const LlmInstantmodelImportFromCommunity = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-instantmodel/import-from-community')
 const LlmInstantmodelImportFromHuggingFace = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-instantmodel/import-from-huggingface')
-const LlmImageImportCommunity = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-image/import-community')
 const LlmCreate = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm/create')
 const LlmDeployment = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-deployment')
 const LlmDeploymentCreate = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-deployment/create')
@@ -82,6 +82,11 @@ export default {
               path: 'create',
               component: LlmSkuCreate,
             },
+            {
+              name: 'AppLlmSkuImportFromCommunity',
+              path: 'import-from-community',
+              component: LlmSkuImportFromCommunity,
+            },
           ],
         },
         {
@@ -102,11 +107,6 @@ export default {
               name: 'AgentLlmImageList',
               path: '',
               component: AgentLlmImage,
-            },
-            {
-              name: 'AgentLlmImageImportCommunity',
-              path: 'import-community',
-              component: LlmImageImportCommunity,
             },
           ],
         },
@@ -260,11 +260,6 @@ export default {
               name: 'LlmImageList',
               path: '',
               component: LlmImage,
-            },
-            {
-              name: 'LlmImageImportCommunity',
-              path: 'import-community',
-              component: LlmImageImportCommunity,
             },
           ],
         },

--- a/containers/Ai/sections/LlmGpuDeviceSelect.vue
+++ b/containers/Ai/sections/LlmGpuDeviceSelect.vue
@@ -1,0 +1,43 @@
+<!--
+  GPU 型号多选，与推理模板 / 模型目录导入 SKU 表单中的 device 字段一致。
+-->
+<template>
+  <base-select
+    :value="value"
+    :options="specList"
+    :select-props="mergedSelectProps"
+    v-bind="$attrs"
+    v-on="$listeners" />
+</template>
+
+<script>
+export default {
+  name: 'LlmGpuDeviceSelect',
+  inheritAttrs: false,
+  props: {
+    value: {
+      type: [Array, String],
+      default: () => [],
+    },
+    selectProps: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  computed: {
+    specList () {
+      const list = Object.values(this.$store.getters.capability?.pci_model_types || {})
+        .filter(item => item.hypervisor === 'pod')
+      return list.map(item => ({ key: item.model, label: item.model }))
+    },
+    mergedSelectProps () {
+      return {
+        mode: 'multiple',
+        placeholder: this.$t('common.tips.select', [this.$t('aice.devices')]),
+        allowClear: true,
+        ...this.selectProps,
+      }
+    },
+  },
+}
+</script>

--- a/containers/Ai/sections/community-images/components/CommunityImageGrid.vue
+++ b/containers/Ai/sections/community-images/components/CommunityImageGrid.vue
@@ -1,0 +1,355 @@
+<!--
+  社区容器镜像卡片列表（llmimages.yaml），供 Agent 模板导入等场景使用。
+-->
+<template>
+  <div class="community-image-grid">
+    <a-row :gutter="8" class="mb-3">
+      <a-col :span="10">
+        <a-input-search
+          v-model="filter.search"
+          :placeholder="$t('aice.llm_catalog.search.placeholder')"
+          allow-clear
+          @search="applyFilter"
+          @change="onFilterChange" />
+      </a-col>
+      <a-col :span="10">
+        <a-select
+          v-model="filter.llmType"
+          :placeholder="$t('aice.llm_image.filter_by_type')"
+          allow-clear
+          style="width: 100%"
+          :dropdown-match-select-width="false"
+          @change="applyFilter">
+          <a-select-option v-for="opt in llmTypeOptions" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </a-select-option>
+        </a-select>
+      </a-col>
+      <a-col :span="4" style="text-align: right;">
+        <a-button
+          shape="circle"
+          icon="reload"
+          :loading="refreshing"
+          :title="$t('common.refresh')"
+          @click="refresh" />
+      </a-col>
+    </a-row>
+
+    <a-spin :spinning="gridLoading">
+      <a-empty v-if="!gridLoading && filteredItems.length === 0" />
+      <div v-else class="catalog-grid">
+        <a-card
+          v-for="item in filteredItems"
+          :key="itemKey(item)"
+          hoverable
+          class="catalog-card"
+          :class="{ 'catalog-card--imported': isImported(item) }"
+          @click="$emit('select', item)">
+          <div class="catalog-card-header">
+            <img v-if="item.icon" :src="item.icon" class="catalog-icon" alt="" />
+            <div v-else class="catalog-icon catalog-icon-name" :title="displayTitle(item)">
+              {{ displayTitle(item).slice(0, 2) }}
+            </div>
+            <div class="catalog-card-title">
+              <div class="catalog-title-row">
+                <div class="catalog-name" :title="displayTitle(item)">{{ displayTitle(item) }}</div>
+                <a-tag
+                  v-if="isImported(item)"
+                  color="green"
+                  class="catalog-imported-tag">
+                  {{ $t('aice.llm_image.imported') }}
+                </a-tag>
+              </div>
+              <div v-if="hasCardMeta(item)" class="catalog-subtitle">
+                <a-tag v-if="isDesktopCommunityItem(item)" class="catalog-type-tag">
+                  {{ llmTypeLabel(item.llm_type) }}
+                </a-tag>
+                <span
+                  v-if="itemSubtitle(item)"
+                  class="catalog-app-name"
+                  :title="itemSubtitle(item)">
+                  {{ itemSubtitle(item) }}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div class="catalog-desc">{{ shortDesc(item.description) }}</div>
+        </a-card>
+      </div>
+    </a-spin>
+  </div>
+</template>
+
+<script>
+import {
+  fetchCommunityImageItems,
+  formatCommunityDisplayTitle,
+  getCommunityImageKey,
+  getCommunityItemSubtitle,
+  isCommunityImageImported,
+  isDesktopCommunityItem,
+} from '@Ai/utils/communityImages'
+
+export default {
+  name: 'CommunityImageGrid',
+  props: {
+    allowedTypes: {
+      type: Array,
+      default: () => [],
+    },
+    catalogItems: {
+      type: Array,
+      default: null,
+    },
+    existingImages: {
+      type: Object,
+      default: () => ({}),
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data () {
+    return {
+      localLoading: false,
+      refreshing: false,
+      localItems: [],
+      catalogManager: new this.$Manager('llm_images_catalogs', 'v1'),
+      filter: {
+        search: '',
+        llmType: undefined,
+      },
+      filterDebounce: null,
+    }
+  },
+  computed: {
+    useExternalItems () {
+      return Array.isArray(this.catalogItems)
+    },
+    gridLoading () {
+      return this.useExternalItems ? this.loading : this.localLoading
+    },
+    items () {
+      return this.useExternalItems ? this.catalogItems : this.localItems
+    },
+    llmTypeOptions () {
+      const allowed = new Set(this.allowedTypes)
+      const seen = {}
+      const opts = []
+      this.items.forEach(item => {
+        const t = item.llm_type
+        if (t && allowed.has(t) && !seen[t]) {
+          seen[t] = true
+          opts.push({ value: t, label: this.llmTypeLabel(t) })
+        }
+      })
+      return opts.sort((a, b) => a.label.localeCompare(b.label))
+    },
+    filteredItems () {
+      let list = this.items
+      if (this.filter.llmType) {
+        list = list.filter(item => item.llm_type === this.filter.llmType)
+      }
+      const kw = (this.filter.search || '').trim().toLowerCase()
+      if (!kw) return list
+      return list.filter(item => {
+        const haystack = [
+          item.image,
+          item.image_name,
+          item.image_label,
+          item.llm_type,
+          item.app_name,
+          item.name,
+          item.description,
+        ].join(' ').toLowerCase()
+        return haystack.includes(kw)
+      })
+    },
+  },
+  watch: {
+    allowedTypes: {
+      handler () {
+        if (!this.useExternalItems) {
+          this.fetchList()
+        }
+      },
+      deep: true,
+    },
+  },
+  created () {
+    if (!this.useExternalItems) {
+      this.fetchList()
+    }
+  },
+  methods: {
+    itemKey (item) {
+      return getCommunityImageKey(item) || item.id
+    },
+    isImported (item) {
+      return isCommunityImageImported(item, this.existingImages)
+    },
+    isDesktopCommunityItem,
+    displayTitle (item) {
+      return formatCommunityDisplayTitle(item, type => this.llmTypeLabel(type))
+    },
+    itemSubtitle (item) {
+      return getCommunityItemSubtitle(item)
+    },
+    hasCardMeta (item) {
+      return this.isDesktopCommunityItem(item) || !!this.itemSubtitle(item)
+    },
+    llmTypeLabel (type) {
+      if (!type) return '-'
+      const key = `aice.llm_type.${String(type).replace(/-/g, '_')}`
+      return this.$te(key) ? this.$t(key) : type
+    },
+    onFilterChange () {
+      if (this.filterDebounce) clearTimeout(this.filterDebounce)
+      this.filterDebounce = setTimeout(() => this.applyFilter(), 300)
+    },
+    applyFilter () {},
+    async fetchList () {
+      if (this.useExternalItems) return
+      this.localLoading = true
+      try {
+        this.localItems = await fetchCommunityImageItems(this.allowedTypes, this.catalogManager)
+      } catch (e) {
+        if (e && !e.__CANCEL__) {
+          this.$message.error(this.$t('aice.llm_image.community_image_fetch_failed'))
+        }
+        this.localItems = []
+      } finally {
+        this.localLoading = false
+      }
+    },
+    async refresh () {
+      this.refreshing = true
+      try {
+        if (this.useExternalItems) {
+          this.$emit('refresh')
+        } else {
+          await this.fetchList()
+          this.$emit('refresh')
+        }
+        this.$message.success(this.$t('common.success'))
+      } finally {
+        this.refreshing = false
+      }
+    },
+    shortDesc (s) {
+      if (!s || s === '-') return ''
+      const trimmed = String(s).trim()
+      return trimmed.length > 100 ? trimmed.slice(0, 97) + '…' : trimmed
+    },
+  },
+}
+</script>
+
+<style scoped>
+.community-image-grid {
+  min-height: 0;
+}
+.community-image-grid ::v-deep .ant-spin-nested-loading,
+.community-image-grid ::v-deep .ant-spin-container {
+  height: auto;
+  overflow: visible;
+}
+.catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+@media (max-width: 1200px) {
+  .catalog-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+@media (max-width: 992px) {
+  .catalog-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 576px) {
+  .catalog-grid { grid-template-columns: 1fr; }
+}
+.catalog-card {
+  cursor: pointer;
+  height: 100%;
+}
+.catalog-card--imported {
+  opacity: 0.85;
+}
+.catalog-card-header {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+.catalog-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 4px;
+  margin-right: 12px;
+  object-fit: contain;
+  background: #fafafa;
+  flex-shrink: 0;
+}
+.catalog-icon-name {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f0f1f5;
+  color: #666;
+  font-weight: 600;
+  font-size: 12px;
+}
+.catalog-card-title {
+  flex: 1;
+  min-width: 0;
+}
+.catalog-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+.catalog-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.catalog-imported-tag {
+  flex-shrink: 0;
+  margin: 0;
+}
+.catalog-subtitle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  min-width: 0;
+}
+.catalog-type-tag {
+  flex-shrink: 0;
+  margin: 0;
+}
+.catalog-app-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: #666;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.catalog-desc {
+  font-size: 12px;
+  color: #666;
+  min-height: 36px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+</style>

--- a/containers/Ai/utils/catalogSpec.js
+++ b/containers/Ai/utils/catalogSpec.js
@@ -72,7 +72,7 @@ export function buildCatalogDeploymentPayload (deployForm, spec, llmType) {
 
   const payload = {
     name: deployForm.name,
-    replicas: deployForm.replicas,
+    replicas: 1,
     placement_strategy: 'spread',
     access_policy: 'authed',
     auto_start: true,

--- a/containers/Ai/utils/communityImages.js
+++ b/containers/Ai/utils/communityImages.js
@@ -1,0 +1,471 @@
+import { getDefaultPortMappingsForType, getDefaultSkuSpecForType } from '@Ai/views/llm-sku/constants/llmTypeConfig'
+
+export const BUNDLE_IMPORT_KIND = 'bundle'
+
+export const LLM_TYPE_ICONS = {
+  openclaw: require('@/assets/images/llm-images/openclaw.svg'),
+  'hermes-agent': require('@/assets/images/llm-images/hermes-agent.svg'),
+  ollama: require('@/assets/images/llm-images/ollama.svg'),
+  vllm: require('@/assets/images/llm-images/vllm.svg'),
+  dify: require('@/assets/images/llm-images/dify.svg'),
+  comfyui: require('@/assets/images/llm-images/comfyui.svg'),
+  desktop: require('@/assets/images/llm-images/linuxserver.png'),
+}
+
+const DEFAULT_ICON = require('@/assets/images/llm-images/default.svg')
+
+export function getTypeIcon (llmType) {
+  return LLM_TYPE_ICONS[llmType] || DEFAULT_ICON
+}
+
+export function parseImageField (imageStr) {
+  const idx = imageStr.lastIndexOf(':')
+  if (idx > 0) {
+    return { image_name: imageStr.substring(0, idx), image_label: imageStr.substring(idx + 1) }
+  }
+  return { image_name: imageStr, image_label: 'latest' }
+}
+
+export function isBundleItem (record) {
+  return record?.import_kind === BUNDLE_IMPORT_KIND
+}
+
+/** 社区镜像导入创建 SKU 前是否需选择 GPU（如 ComfyUI） */
+export function communityImportNeedsGpuSelection (record) {
+  return record?.llm_type === 'comfyui'
+}
+
+/** 导入时 generate_name：桌面镜像以 app_name 开头，其它类型仍为 llm_type-image_label */
+export function buildImportGenerateName (record) {
+  const label = record.image_label || 'latest'
+  if (record.llm_type === 'desktop' && record.app_name) {
+    return `${record.app_name}-${label}`
+  }
+  return `${record.llm_type}-${label}`
+}
+
+export function getCommunityImageKey (record) {
+  if (!record) return ''
+  if (isBundleItem(record)) {
+    return `bundle:${record.name}`
+  }
+  return `${record.llm_type}:${record.image_name}:${record.image_label}`
+}
+
+export function isCommunityImageImported (record, existingImages = {}) {
+  return !!existingImages[getCommunityImageKey(record)]
+}
+
+export function isDesktopCommunityItem (record) {
+  return record?.llm_type === 'desktop'
+}
+
+export function getCommunityItemDisplayTitle (record) {
+  if (!record) return ''
+  if (isDesktopCommunityItem(record)) {
+    if (record.app_name) return record.app_name
+    if (record.desktop?.ui_title) return record.desktop.ui_title
+  }
+  if (record.llm_type) {
+    return record.llm_type
+  }
+  if (record.image_name && record.image_label) {
+    return `${record.image_name}:${record.image_label}`
+  }
+  return record.image || ''
+}
+
+export function formatCommunityDisplayTitle (record, llmTypeLabel) {
+  if (!record) return ''
+  if (isDesktopCommunityItem(record)) {
+    return getCommunityItemDisplayTitle(record)
+  }
+  if (record.llm_type && typeof llmTypeLabel === 'function') {
+    return llmTypeLabel(record.llm_type)
+  }
+  return getCommunityItemDisplayTitle(record)
+}
+
+export function getCommunityItemSubtitle (record) {
+  if (!record) return ''
+  if (isDesktopCommunityItem(record)) {
+    if (record.desktop?.ui_title && record.app_name) {
+      return record.desktop.ui_title
+    }
+    if (record.image_label) return record.image_label
+    return ''
+  }
+  if (isBundleItem(record)) {
+    if (record.name) return record.name
+    const count = record.images?.length || 0
+    return count > 0 ? `${count} images` : ''
+  }
+  if (record.image_label) return record.image_label
+  return record.image || ''
+}
+
+export function getCommunityItemImageLine (record) {
+  if (!record) return ''
+  if (isBundleItem(record)) {
+    const count = record.images?.length || 0
+    return count > 0 ? `${count}` : ''
+  }
+  return record.image || ''
+}
+
+function parseBundleImage (img) {
+  if (!img?.image) return null
+  const { image_name, image_label } = parseImageField(img.image)
+  return {
+    role: img.role,
+    generate_name: img.generate_name,
+    image: img.image,
+    image_name,
+    image_label,
+  }
+}
+
+/**
+ * 解析 llm_images_catalog API 单条记录为前端卡片项（单镜像或 bundle）。
+ * @returns {object|null}
+ */
+export function parseCommunityCatalogItem (item, index) {
+  if (!item?.llm_type) return null
+
+  const base = {
+    id: item.id || item.name || String(index + 1),
+    llm_type: item.llm_type,
+    description: item.description || '-',
+    icon: getTypeIcon(item.llm_type),
+    import_kind: item.import_kind || 'single',
+    sku: item.sku || null,
+  }
+
+  if (item.import_kind === BUNDLE_IMPORT_KIND) {
+    if (!item.name || !Array.isArray(item.images) || item.images.length === 0) return null
+    const images = item.images.map(parseBundleImage).filter(Boolean)
+    if (!images.length) return null
+    return {
+      ...base,
+      name: item.name,
+      images,
+    }
+  }
+
+  if (!item.image) return null
+  const { image_name, image_label } = parseImageField(item.image)
+  return {
+    ...base,
+    image: item.image,
+    image_name,
+    image_label,
+    app_name: item.app_name || '',
+    desktop: item.desktop || null,
+  }
+}
+
+function resolveSkuSpec (record) {
+  if (record.sku && typeof record.sku === 'object') {
+    const { cpu, memory, volume_size_mb, bandwidth } = record.sku
+    if (cpu != null && memory != null && volume_size_mb != null && bandwidth != null) {
+      return { cpu, memory, volume_size_mb, bandwidth }
+    }
+  }
+  return getDefaultSkuSpecForType(record.llm_type)
+}
+
+function normalizePortMappings (portMappings) {
+  if (!Array.isArray(portMappings)) return []
+  return portMappings
+    .map(item => ({
+      protocol: String(item?.protocol || 'tcp').toLowerCase(),
+      container_port: parseInt(item?.container_port, 10),
+    }))
+    .filter(item => item.protocol && Number.isFinite(item.container_port) && item.container_port > 0)
+}
+
+function resolvePortMappings (record) {
+  const fromSku = normalizePortMappings(record.sku?.port_mappings)
+  if (fromSku.length) return fromSku
+  return normalizePortMappings(getDefaultPortMappingsForType(record.llm_type))
+}
+
+function resolveSkuGenerateName (record) {
+  if (record.sku?.generate_name) return record.sku.generate_name
+  return buildImportGenerateName(record)
+}
+
+function applySkuDevices (data, devices) {
+  if (!Array.isArray(devices) || !devices.length) return
+  data.devices = devices.map(model => ({ model }))
+}
+
+function buildCommunitySkuCreateData (record, imageId, { devices } = {}) {
+  const spec = resolveSkuSpec(record)
+  if (!spec) return null
+  const llmType = record.llm_type
+  const data = {
+    generate_name: resolveSkuGenerateName(record),
+    llm_type: llmType,
+    cpu: spec.cpu,
+    memory: spec.memory,
+    bandwidth: spec.bandwidth,
+    volumes: [{ size_mb: spec.volume_size_mb }],
+    disk_size: spec.volume_size_mb,
+  }
+  if (imageId) {
+    data.llm_image_id = imageId
+  }
+  const portMappings = resolvePortMappings(record)
+  if (portMappings.length) {
+    data.port_mappings = portMappings
+  }
+  applySkuDevices(data, devices)
+  return data
+}
+
+/** catalog 条目导入时将使用的 llm_sku 名称，用于与后端同名 SKU 比对 */
+export function getCommunitySkuName (record) {
+  return resolveSkuGenerateName(record)
+}
+
+function buildImageLookupKey (llmType, imageName, imageLabel) {
+  return `${llmType}:${imageName}:${imageLabel}`
+}
+
+/** llm_images_catalog API 返回 llm_images_catalogs，非标准 data 字段 */
+function parseCatalogListResponse (res) {
+  const body = res?.data || {}
+  let items = body.llm_images_catalogs ?? body.data ?? []
+  if (typeof items === 'string') {
+    try {
+      items = JSON.parse(items)
+    } catch (e) {
+      items = []
+    }
+  }
+  return Array.isArray(items) ? items : []
+}
+
+const catalogListInflight = new WeakMap()
+
+async function listCommunityCatalog (catalogManager) {
+  const inflight = catalogListInflight.get(catalogManager)
+  if (inflight) return inflight
+  const promise = catalogManager.list({ params: { limit: 0 } })
+    .finally(() => {
+      catalogListInflight.delete(catalogManager)
+    })
+  catalogListInflight.set(catalogManager, promise)
+  return promise
+}
+
+/**
+ * @param {string[]} allowedTypes
+ * @param {object} catalogManager - Vue $Manager instance for llm_images_catalogs
+ * @returns {Promise<object[]>}
+ */
+export async function fetchCommunityImageItems (allowedTypes = [], catalogManager) {
+  if (!catalogManager) return []
+  const res = await listCommunityCatalog(catalogManager)
+  const items = parseCatalogListResponse(res)
+  if (!items.length) return []
+  const allowed = new Set(allowedTypes)
+  const result = []
+  items.forEach((item, index) => {
+    const parsed = parseCommunityCatalogItem(item, index)
+    if (parsed && allowed.has(parsed.llm_type)) {
+      result.push(parsed)
+    }
+  })
+  return result
+}
+
+function markCommunityItemsImportedBySku (existing, communityItems, existingSkuNames) {
+  if (!Array.isArray(communityItems)) return
+  communityItems.forEach(item => {
+    const skuName = resolveSkuGenerateName(item)
+    if (skuName && existingSkuNames.has(skuName)) {
+      existing[getCommunityImageKey(item)] = true
+    }
+  })
+}
+
+async function listSkusForCommunityImport (skusManager, { scope, typeFilter, llmTypes } = {}) {
+  if (!skusManager) return []
+  try {
+    const filter = []
+    if (typeFilter) {
+      filter.push(typeFilter)
+    } else if (Array.isArray(llmTypes) && llmTypes.length) {
+      filter.push(`llm_type.in(${llmTypes.join(',')})`)
+    }
+    const params = { limit: 2048 }
+    if (filter.length) params.filter = filter
+    if (scope) params.scope = scope
+    const res = await skusManager.list({ params })
+    return res.data?.data || []
+  } catch (e) {
+    return []
+  }
+}
+
+/**
+ * 通过后端是否存在同名 llm_sku 判断 catalog 条目是否已导入。
+ * @param {string[]} llmTypes
+ * @param {object} skusManager - Vue $Manager instance for llm_skus
+ * @param {object[]} [communityItems] - 已解析的 catalog 条目
+ * @param {{ scope?: string, typeFilter?: string }} [listParams]
+ * @returns {Promise<Record<string, boolean>>}
+ */
+export async function fetchExistingCommunityImageKeys (llmTypes, skusManager, communityItems = [], listParams = {}) {
+  const existing = {}
+  if (!skusManager || !llmTypes?.length) return existing
+
+  const skus = await listSkusForCommunityImport(skusManager, {
+    scope: listParams.scope,
+    typeFilter: listParams.typeFilter,
+    llmTypes,
+  })
+  const existingSkuNames = new Set()
+  skus.forEach(sku => {
+    if (sku.name) existingSkuNames.add(sku.name)
+  })
+
+  markCommunityItemsImportedBySku(existing, communityItems, existingSkuNames)
+  return existing
+}
+
+async function listResourcesByLlmType (manager, llmType) {
+  if (!manager) return []
+  try {
+    const res = await manager.list({
+      params: {
+        limit: 2048,
+        filter: [`llm_type.equals('${llmType}')`],
+      },
+    })
+    return res.data?.data || []
+  } catch (e) {
+    return []
+  }
+}
+
+async function buildExistingImageIdMap (llmType, imagesManager) {
+  const map = {}
+  const images = await listResourcesByLlmType(imagesManager, llmType)
+  images.forEach(img => {
+    map[buildImageLookupKey(img.llm_type, img.image_name, img.image_label)] = img.id
+  })
+  return map
+}
+
+async function findOrCreateBundleImage (imgSpec, llmType, imagesManager, existingIdMap) {
+  const key = buildImageLookupKey(llmType, imgSpec.image_name, imgSpec.image_label)
+  if (existingIdMap[key]) return existingIdMap[key]
+
+  const createData = {
+    generate_name: imgSpec.generate_name,
+    llm_type: llmType,
+    image_name: imgSpec.image_name,
+    image_label: imgSpec.image_label,
+  }
+  const imgRes = await imagesManager.create({ data: createData })
+  const imageId = imgRes?.data?.id || ''
+  if (imageId) {
+    existingIdMap[key] = imageId
+  }
+  return imageId
+}
+
+async function findOrCreateCommunityImage (record, imagesManager, existingIdMap) {
+  const key = buildImageLookupKey(record.llm_type, record.image_name, record.image_label)
+  if (existingIdMap[key]) return existingIdMap[key]
+
+  const createData = {
+    generate_name: buildImportGenerateName(record),
+    llm_type: record.llm_type,
+    image_name: record.image_name,
+    image_label: record.image_label,
+  }
+  if (record.desktop && typeof record.desktop === 'object') {
+    createData.desktop_config = record.desktop
+  }
+  if (record.app_name) {
+    createData.app_name = record.app_name
+  }
+  const imgRes = await imagesManager.create({ data: createData })
+  const imageId = imgRes?.data?.id || ''
+  if (imageId) {
+    existingIdMap[key] = imageId
+  }
+  return imageId
+}
+
+/**
+ * 按 yaml bundle 定义创建 9 个 dify 镜像及含 llm_spec.dify 的 SKU。
+ * @returns {{ imageIds: Record<string, string>, skuCreated: boolean, skuError: Error|null }}
+ */
+export async function createDifyBundleAndSku (record, { imagesManager, skusManager, devices } = {}) {
+  const llmType = record.llm_type
+  const existingIdMap = await buildExistingImageIdMap(llmType, imagesManager)
+  const imageIds = {}
+
+  for (const imgSpec of record.images || []) {
+    const imageId = await findOrCreateBundleImage(imgSpec, llmType, imagesManager, existingIdMap)
+    if (!imageId) {
+      throw new Error(`failed to create image: ${imgSpec.image}`)
+    }
+    imageIds[imgSpec.role] = imageId
+  }
+
+  let skuCreated = false
+  let skuError = null
+  const spec = resolveSkuSpec(record)
+  if (spec && skusManager) {
+    const data = buildCommunitySkuCreateData(record, '', { devices })
+    if (data) {
+      data.llm_spec = {
+        dify: { ...imageIds },
+      }
+      delete data.llm_image_id
+      try {
+        await skusManager.create({ data })
+        skuCreated = true
+      } catch (e) {
+        skuError = e
+      }
+    }
+  }
+
+  return { imageIds, skuCreated, skuError }
+}
+
+/**
+ * 创建 llm_image 及默认 llm_sku（若类型支持）。
+ * @returns {{ imageId: string, skuCreated: boolean, skuError: Error|null, imageIds?: Record<string, string> }}
+ */
+export async function createCommunityImageAndSku (record, { imagesManager, skusManager, devices } = {}) {
+  if (isBundleItem(record)) {
+    return createDifyBundleAndSku(record, { imagesManager, skusManager, devices })
+  }
+
+  const existingIdMap = await buildExistingImageIdMap(record.llm_type, imagesManager)
+  const imageId = await findOrCreateCommunityImage(record, imagesManager, existingIdMap)
+  let skuCreated = false
+  let skuError = null
+  const spec = resolveSkuSpec(record)
+  if (imageId && spec && skusManager) {
+    const data = buildCommunitySkuCreateData(record, imageId, { devices })
+    if (data) {
+      try {
+        await skusManager.create({ data })
+        skuCreated = true
+      } catch (e) {
+        skuError = e
+      }
+    }
+  }
+
+  return { imageId, skuCreated, skuError }
+}

--- a/containers/Ai/utils/llmRouteContext.js
+++ b/containers/Ai/utils/llmRouteContext.js
@@ -15,7 +15,6 @@ export function parseLlmImageRoute (path = '') {
     isAgentImageRoute,
     isInferenceImageRoute,
     imageListPath: isDesktopImageRoute ? '/app-desktop-image' : (isAgentImageRoute ? '/agent-llm-image' : '/llm-image'),
-    imageImportCommunityPath: isDesktopImageRoute ? '/app-desktop-image/import-community' : (isAgentImageRoute ? '/agent-llm-image/import-community' : '/llm-image/import-community'),
   }
 }
 
@@ -31,6 +30,12 @@ export function getLlmImageTypeFilter (path = '') {
 }
 
 export function getAllowedImageLlmTypes (path = '') {
+  if (path.includes('/app-llm-sku/import-from-community')) {
+    return [...APP_LLM_TYPES]
+  }
+  if (path.includes('/app-desktop-sku/import-from-community')) {
+    return [...DESKTOP_LLM_TYPES]
+  }
   const { isDesktopImageRoute, isAgentImageRoute } = parseLlmImageRoute(path)
   if (isDesktopImageRoute) {
     return [...DESKTOP_LLM_TYPES]
@@ -66,16 +71,24 @@ export function parseLlmRoute (path = '') {
   let instanceCreatePath = '/llm/create'
   let skuListPath = '/llm-sku'
   let skuCreatePath = '/llm-sku/create'
+  let skuImportFromCommunityPath = ''
+  let skuImportFromModelSetsPath = ''
+  let skuImportFromHuggingfacePath = ''
   if (isApplyType) {
     instanceListPath = '/app-llm'
     instanceCreatePath = '/app-llm/create'
     skuListPath = '/app-llm-sku'
     skuCreatePath = '/app-llm-sku/create'
+    skuImportFromCommunityPath = '/app-llm-sku/import-from-community'
   } else if (isDesktopType) {
     instanceListPath = '/app-desktop'
     instanceCreatePath = '/app-desktop/create'
     skuListPath = '/app-desktop-sku'
     skuCreatePath = '/app-desktop-sku/create'
+    skuImportFromCommunityPath = '/app-desktop-sku/import-from-community'
+  } else if (isInferenceType) {
+    skuImportFromModelSetsPath = '/llm-sku/import-from-model-sets'
+    skuImportFromHuggingfacePath = '/llm-sku/import-from-huggingface'
   }
 
   return {
@@ -87,6 +100,9 @@ export function parseLlmRoute (path = '') {
     instanceCreatePath,
     skuListPath,
     skuCreatePath,
+    skuImportFromCommunityPath,
+    skuImportFromModelSetsPath,
+    skuImportFromHuggingfacePath,
   }
 }
 

--- a/containers/Ai/views/llm-deployment/create/index.vue
+++ b/containers/Ai/views/llm-deployment/create/index.vue
@@ -143,24 +143,11 @@
 
         <a-divider orientation="left">{{ $t('aice.llm_deployment.create.deployment') }}</a-divider>
 
-        <a-form-item :label="$t('aice.llm_deployment.replicas')">
-          <a-input-number v-decorator="decorators.replicas" :min="1" :max="100" />
-        </a-form-item>
         <a-form-item :label="$t('aice.llm_deployment.placement_strategy')">
           <a-radio-group v-decorator="decorators.placement_strategy">
             <a-radio value="spread">{{ $t('aice.llm_deployment.placement_strategy.spread') }}</a-radio>
             <a-radio value="binpack">{{ $t('aice.llm_deployment.placement_strategy.binpack') }}</a-radio>
           </a-radio-group>
-        </a-form-item>
-        <a-form-item :label="$t('aice.llm_deployment.access_policy')">
-          <a-select v-decorator="decorators.access_policy">
-            <a-select-option value="authed">{{ $t('aice.llm_deployment.access_policy.authed') }}</a-select-option>
-            <a-select-option value="public">{{ $t('aice.llm_deployment.access_policy.public') }}</a-select-option>
-            <a-select-option value="allowed_users">{{ $t('aice.llm_deployment.access_policy.allowed_users') }}</a-select-option>
-          </a-select>
-        </a-form-item>
-        <a-form-item :label="$t('aice.llm_deployment.auto_start')">
-          <a-switch v-decorator="decorators.auto_start" />
         </a-form-item>
         <a-form-item :label="$t('compute.text_104')" class="mb-0">
           <server-network
@@ -174,99 +161,6 @@
             :hiddenAdd="true"
             :isDialog="true" />
         </a-form-item>
-        <a-form-item :label="$t('aice.host_paths')" :extra="$t('aice.host_paths.extra')">
-            <div v-for="hp in hostPathRows" :key="hp.key" style="display: flex; align-items: stretch; gap: 10px; margin-bottom: 12px;">
-              <div style="flex: 1; border: 1px solid #e8e8e8; border-radius: 4px; padding: 12px;">
-                <a-row :gutter="8">
-                  <a-col :span="8">
-                    <a-form-item>
-                      <fixed-label-filter :label="$t('aice.host_paths.type')">
-                        <a-select v-decorator="decoratorsHostPaths.type(hp.key)" :placeholder="$t('common.tips.select', [$t('aice.host_paths.type')])">
-                          <a-select-option value="directory">directory</a-select-option>
-                          <a-select-option value="file">file</a-select-option>
-                        </a-select>
-                      </fixed-label-filter>
-                    </a-form-item>
-                  </a-col>
-                  <a-col :span="16">
-                    <a-form-item>
-                      <fixed-label-filter :label="$t('aice.host_paths.path')">
-                        <a-input v-decorator="decoratorsHostPaths.path(hp.key)" :placeholder="$t('aice.host_paths.path.placeholder')" />
-                      </fixed-label-filter>
-                    </a-form-item>
-                  </a-col>
-                </a-row>
-                <a-row :gutter="8">
-                  <a-col :span="24">
-                    <a-form-item>
-                      <a-checkbox v-decorator="decoratorsHostPaths.auto_create(hp.key)">{{ $t('aice.host_paths.auto_create') }}</a-checkbox>
-                    </a-form-item>
-                  </a-col>
-                </a-row>
-                <a-row :gutter="8" v-if="form.fd[`host_path_auto_create_${hp.key}`]">
-                  <a-col :span="8">
-                    <a-form-item>
-                      <fixed-label-filter :label="$t('aice.host_paths.auto_create_config.uid')">
-                        <a-input v-decorator="decoratorsHostPaths.auto_uid(hp.key)" :placeholder="$t('aice.host_paths.auto_create_config.uid.placeholder')" />
-                      </fixed-label-filter>
-                    </a-form-item>
-                  </a-col>
-                  <a-col :span="8">
-                    <a-form-item>
-                      <fixed-label-filter :label="$t('aice.host_paths.auto_create_config.gid')">
-                        <a-input v-decorator="decoratorsHostPaths.auto_gid(hp.key)" :placeholder="$t('aice.host_paths.auto_create_config.gid.placeholder')" />
-                      </fixed-label-filter>
-                    </a-form-item>
-                  </a-col>
-                  <a-col :span="8">
-                    <a-form-item>
-                      <fixed-label-filter :label="$t('aice.host_paths.permissions')">
-                        <a-input v-decorator="decoratorsHostPaths.auto_perm(hp.key)" :placeholder="$t('aice.host_paths.permissions.placeholder')" />
-                      </fixed-label-filter>
-                    </a-form-item>
-                  </a-col>
-                </a-row>
-                <div style="margin: 8px 0; font-weight: 500;">{{ $t('aice.host_paths.containers') }}</div>
-                <div v-for="c in hp.containerRows" :key="c.key">
-                  <input type="hidden" v-decorator="decoratorsHostPaths.container_index(hp.key, c.key)" />
-                  <a-row :gutter="8">
-                    <a-col :span="12">
-                      <a-form-item>
-                        <fixed-label-filter :label="$t('aice.host_paths.mount_path')">
-                          <a-input v-decorator="decoratorsHostPaths.mount_path(hp.key, c.key)" :placeholder="$t('aice.host_paths.mount_path.placeholder')" />
-                        </fixed-label-filter>
-                      </a-form-item>
-                    </a-col>
-                    <a-col :span="12">
-                      <a-form-item>
-                        <fixed-label-filter :label="$t('aice.host_paths.propagation')">
-                          <a-select v-decorator="decoratorsHostPaths.propagation(hp.key, c.key)" :placeholder="$t('common.tips.select', [$t('aice.host_paths.propagation')])" optionLabelProp="label" :dropdownMatchSelectWidth="false">
-                            <a-select-option value="private" label="private">private - {{ $t('aice.host_paths.propagation.private') }}</a-select-option>
-                            <a-select-option value="rslave" label="rslave">rslave - {{ $t('aice.host_paths.propagation.rslave') }}</a-select-option>
-                            <a-select-option value="rshared" label="rshared">rshared - {{ $t('aice.host_paths.propagation.rshared') }}</a-select-option>
-                          </a-select>
-                        </fixed-label-filter>
-                      </a-form-item>
-                    </a-col>
-                  </a-row>
-                  <a-row :gutter="8">
-                    <a-col :span="4">
-                      <a-form-item>
-                        <a-checkbox v-decorator="decoratorsHostPaths.read_only(hp.key, c.key)">{{ $t('aice.host_paths.read_only') }}</a-checkbox>
-                      </a-form-item>
-                    </a-col>
-                  </a-row>
-                </div>
-              </div>
-              <div style="width: 34px; display: flex; align-items: center; justify-content: center;">
-                <a-button shape="circle" icon="minus" size="small" @click="delHostPath(hp)" />
-              </div>
-            </div>
-            <div class="d-flex align-items-center">
-              <a-button type="primary" shape="circle" icon="plus" size="small" @click="addHostPath" />
-              <a-button type="link" @click="addHostPath">{{ $t('aice.host_paths.add') }}</a-button>
-            </div>
-          </a-form-item>
       </a-form>
     </page-body>
     <page-footer>
@@ -303,7 +197,6 @@ export default {
     return {
       loading: false,
       portMappings,
-      hostPathRows: [],
       catalogContext: null,
       form: {
         fc: this.$form.createForm(this, {
@@ -318,7 +211,6 @@ export default {
           llm_type: defaultLlmType,
           import_model: false,
           model_source: '',
-          auto_start: true,
         },
         fi: {
           networkList: [],
@@ -364,13 +256,7 @@ export default {
         }],
         model_source: ['model_source', { initialValue: '' }],
         model_repo_id: ['model_repo_id', {}],
-        replicas: ['replicas', {
-          initialValue: 1,
-          rules: [{ required: true, message: this.$t('common.tips.input', [this.$t('aice.llm_deployment.replicas')]) }],
-        }],
         placement_strategy: ['placement_strategy', { initialValue: 'spread' }],
-        access_policy: ['access_policy', { initialValue: 'authed' }],
-        auto_start: ['auto_start', { valuePropName: 'checked', initialValue: true }],
         network: {
           networkType: ['networkType', { initialValue: NETWORK_OPTIONS_MAP.default.key }],
           networkConfig: {
@@ -413,22 +299,6 @@ export default {
           initialValue: getInitVal(portMappings, rowKey, 'container_port'),
           rules: [{ type: 'number', min: 1, max: 65535, message: this.$t('aice.container_port.message'), transform: v => v != null ? Number(v) : v }],
         }],
-      },
-      decoratorsHostPaths: {
-        type: rowKey => [`host_path_type_${rowKey}`, { initialValue: 'directory' }],
-        path: rowKey => [`host_path_path_${rowKey}`, {
-          rules: [{ required: true, message: this.$t('aice.host_paths.path.required') }],
-        }],
-        auto_create: rowKey => [`host_path_auto_create_${rowKey}`, { valuePropName: 'checked', initialValue: false }],
-        auto_uid: rowKey => [`host_path_auto_uid_${rowKey}`, {}],
-        auto_gid: rowKey => [`host_path_auto_gid_${rowKey}`, {}],
-        auto_perm: rowKey => [`host_path_auto_perm_${rowKey}`, {}],
-        container_index: (hpKey, cKey) => [`host_path_container_index_${hpKey}__${cKey}`, { initialValue: 0 }],
-        mount_path: (hpKey, cKey) => [`host_path_mount_path_${hpKey}__${cKey}`, {
-          rules: [{ required: true, message: this.$t('aice.host_paths.mount_path.required') }],
-        }],
-        read_only: (hpKey, cKey) => [`host_path_read_only_${hpKey}__${cKey}`, { valuePropName: 'checked', initialValue: false }],
-        propagation: (hpKey, cKey) => [`host_path_propagation_${hpKey}__${cKey}`, { initialValue: 'rslave' }],
       },
       manager: new Manager('llm_deployments'),
     }
@@ -597,48 +467,6 @@ export default {
     removePortMapping (idx) {
       this.portMappings.splice(idx, 1)
     },
-    addHostPath () {
-      this.hostPathRows.push({ key: uuid(), containerRows: [{ key: uuid() }] })
-    },
-    delHostPath (hp) {
-      const idx = this.hostPathRows.findIndex(v => v.key === hp.key)
-      if (idx >= 0) this.hostPathRows.splice(idx, 1)
-    },
-    buildHostPaths (values) {
-      return this.hostPathRows.map(hp => {
-        const hpKey = hp.key
-        const type = values[`host_path_type_${hpKey}`]
-        const path = values[`host_path_path_${hpKey}`]
-        const autoCreate = !!values[`host_path_auto_create_${hpKey}`]
-        const out = { type, path }
-        if (autoCreate) {
-          out.auto_create = true
-          const uid = values[`host_path_auto_uid_${hpKey}`]
-          const gid = values[`host_path_auto_gid_${hpKey}`]
-          const perm = values[`host_path_auto_perm_${hpKey}`]
-          const cfg = {}
-          if (uid !== undefined && uid !== null && uid !== '') cfg.uid = uid
-          if (gid !== undefined && gid !== null && gid !== '') cfg.gid = gid
-          if (perm != null && String(perm).trim() !== '') cfg.permissions = String(perm).trim()
-          if (Object.keys(cfg).length > 0) out.auto_create_config = cfg
-        }
-        const containers = {}
-        ;(hp.containerRows || []).forEach(c => {
-          const composite = `${hpKey}__${c.key}`
-          const idx = values[`host_path_container_index_${composite}`] ?? 0
-          const mountPath = values[`host_path_mount_path_${composite}`]
-          if (mountPath == null || String(mountPath).trim() === '') return
-          const k = String(idx).trim()
-          if (!k) return
-          const m = { mount_path: String(mountPath).trim(), read_only: !!values[`host_path_read_only_${composite}`] }
-          const prop = values[`host_path_propagation_${composite}`]
-          if (prop != null && String(prop).trim() !== '') m.propagation = String(prop).trim()
-          containers[k] = m
-        })
-        if (Object.keys(containers).length > 0) out.containers = containers
-        return out
-      }).filter(v => v && v.type && v.path)
-    },
     genNetworks (values) {
       const networkType = this.form.fd.networkType
       if (networkType === NETWORK_OPTIONS_MAP.manual.key) {
@@ -667,14 +495,12 @@ export default {
     buildPayload (values) {
       const payload = {
         name: values.name,
-        replicas: values.replicas,
+        replicas: 1,
         placement_strategy: values.placement_strategy,
-        access_policy: values.access_policy,
-        auto_start: !!values.auto_start,
+        access_policy: 'authed',
+        auto_start: true,
         nets: this.genNetworks(values),
       }
-      const host_paths = this.buildHostPaths(values)
-      if (host_paths.length > 0) payload.host_paths = host_paths
       if (values.mode === 'reuse') {
         payload.llm_sku_id = values.llm_sku_id
         return payload

--- a/containers/Ai/views/llm-deployment/shared/CatalogDeployForm.vue
+++ b/containers/Ai/views/llm-deployment/shared/CatalogDeployForm.vue
@@ -36,9 +36,6 @@
         {{ $t('aice.llm_deployment.create.devices.help') }}
       </div>
     </a-form-model-item>
-    <a-form-model-item :label="$t('aice.llm_deployment.replicas')">
-      <a-input-number v-model="deployForm.replicas" :min="1" :max="100" />
-    </a-form-model-item>
     <a-form-model-item label="CPU">
       <a-input-number v-model="deployForm.cpu" :min="1" :max="128" />
     </a-form-model-item>

--- a/containers/Ai/views/llm-image/components/List.vue
+++ b/containers/Ai/views/llm-image/components/List.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import { parseLlmImageRoute, getLlmImageTypeFilter } from '@Ai/utils/llmRouteContext'
+import { getLlmImageTypeFilter } from '@Ai/utils/llmRouteContext'
 import WindowsMixin from '@/mixins/windows'
 import ListMixin from '@/mixins/list'
 import SingleActionsMixin from '../mixins/singleActions'
@@ -47,13 +47,6 @@ export default {
               buttonType: 'primary',
               validate: true,
             }
-          },
-        },
-        {
-          label: this.$t('aice.llm_image.import_community_image'),
-          action: () => {
-            const imageCtx = parseLlmImageRoute(this.$route.path)
-            this.$router.push({ path: imageCtx.imageImportCommunityPath })
           },
         },
         {

--- a/containers/Ai/views/llm-image/import-community/index.vue
+++ b/containers/Ai/views/llm-image/import-community/index.vue
@@ -21,47 +21,18 @@
 </template>
 
 <script>
-import axios from 'axios'
-import yaml from 'js-yaml'
 import marked from 'marked'
 import { parseLlmImageRoute, getAllowedImageLlmTypes } from '@Ai/utils/llmRouteContext'
+import {
+  createCommunityImageAndSku,
+  fetchCommunityImageItems,
+  fetchExistingCommunityImageKeys,
+  getCommunityImageKey,
+  getTypeIcon,
+  isCommunityImageImported,
+} from '@Ai/utils/communityImages'
 import WindowsMixin from '@/mixins/windows'
 import ListMixin from '@/mixins/list'
-import { getDefaultPortMappingsForType, getDefaultSkuSpecForType } from '../../llm-sku/constants/llmTypeConfig'
-
-const LLM_IMAGES_URL = 'https://www.cloudpods.org/llmimages.yaml'
-
-const LLM_TYPE_ICONS = {
-  openclaw: require('@/assets/images/llm-images/openclaw.svg'),
-  'hermes-agent': require('@/assets/images/llm-images/hermes-agent.svg'),
-  ollama: require('@/assets/images/llm-images/ollama.svg'),
-  vllm: require('@/assets/images/llm-images/vllm.svg'),
-  dify: require('@/assets/images/llm-images/dify.svg'),
-  comfyui: require('@/assets/images/llm-images/comfyui.svg'),
-  desktop: require('@/assets/images/llm-images/linuxserver.png'),
-}
-const DEFAULT_ICON = require('@/assets/images/llm-images/default.svg')
-
-function getTypeIcon (llmType) {
-  return LLM_TYPE_ICONS[llmType] || DEFAULT_ICON
-}
-
-function parseImageField (imageStr) {
-  const idx = imageStr.lastIndexOf(':')
-  if (idx > 0) {
-    return { image_name: imageStr.substring(0, idx), image_label: imageStr.substring(idx + 1) }
-  }
-  return { image_name: imageStr, image_label: 'latest' }
-}
-
-/** 导入时 generate_name：桌面镜像以 app_name 开头，其它类型仍为 llm_type-image_label */
-function buildImportGenerateName (record) {
-  const label = record.image_label || 'latest'
-  if (record.llm_type === 'desktop' && record.app_name) {
-    return `${record.app_name}-${label}`
-  }
-  return `${record.llm_type}-${label}`
-}
 
 export default {
   name: 'LlmImageImportCommunityPage',
@@ -82,6 +53,9 @@ export default {
         resource: 'llm_images',
         responseData: { data: [] },
       }),
+      imagesManager: new this.$Manager('llm_images'),
+      skusManager: new this.$Manager('llm_skus'),
+      catalogManager: new this.$Manager('llm_images_catalogs', 'v1'),
     }
   },
   computed: {
@@ -104,15 +78,6 @@ export default {
       })
       return ret
     },
-    llmTypeColumnTitle () {
-      if (this.imageRouteCtx.isDesktopImageRoute) {
-        return this.$t('aice.llm_type')
-      }
-      if (this.imageRouteCtx.isAgentImageRoute) {
-        return this.$t('aice.llm_type.app')
-      }
-      return this.$t('aice.llm_type.llm')
-    },
     columns () {
       return [
         {
@@ -123,7 +88,7 @@ export default {
         },
         {
           field: 'llm_type',
-          title: this.llmTypeColumnTitle,
+          title: this.$t('aice.llm_type'),
           width: 120,
           slots: {
             default: ({ row }, h) => {
@@ -189,28 +154,27 @@ export default {
   methods: {
     async fetchExistingByType (llmType) {
       if (!llmType) return
-      try {
-        const manager = new this.$Manager('llm_images')
-        const res = await manager.list({ params: { limit: 0, llm_type: llmType } })
-        const images = res.data?.data || []
-        // 先清除该类型旧数据
-        const prefix = `${llmType}:`
-        Object.keys(this.existingImages).forEach(key => {
-          if (key.startsWith(prefix)) {
-            this.$delete(this.existingImages, key)
-          }
-        })
-        // 写入最新数据
-        images.forEach(img => {
-          const key = `${img.llm_type}:${img.image_name}:${img.image_label}`
-          this.$set(this.existingImages, key, true)
-        })
-      } catch (e) {
-        // ignore
-      }
+      const prefix = `${llmType}:`
+      Object.keys(this.existingImages).forEach(key => {
+        if (key.startsWith(prefix)) {
+          this.$delete(this.existingImages, key)
+        }
+      })
+      const partial = await fetchExistingCommunityImageKeys(
+        [llmType],
+        this.skusManager,
+        this.allItems.filter(item => item.llm_type === llmType),
+        {
+          scope: this.$store.getters.scope,
+          typeFilter: `llm_type.equals('${llmType}')`,
+        },
+      )
+      Object.keys(partial).forEach(key => {
+        this.$set(this.existingImages, key, true)
+      })
     },
     isImported (record) {
-      return !!this.existingImages[`${record.llm_type}:${record.image_name}:${record.image_label}`]
+      return isCommunityImageImported(record, this.existingImages)
     },
     getFilteredItems () {
       if (!this.form.llm_type) return this.allItems
@@ -224,28 +188,10 @@ export default {
     async fetchData () {
       this.list.loading = true
       try {
-        const res = await axios.get(LLM_IMAGES_URL)
-        const items = yaml.safeLoad(res.data)
-        if (!Array.isArray(items)) { this.list.loading = false; return }
-        const allowed = new Set(this.allowedImageLlmTypes)
-        this.allItems = items.filter(i => i?.image && i.llm_type && allowed.has(i.llm_type)).map((item, index) => {
-          const { image_name, image_label } = parseImageField(item.image)
-          return {
-            id: String(index + 1),
-            image: item.image,
-            image_name,
-            image_label,
-            llm_type: item.llm_type || '',
-            app_name: item.app_name || '',
-            description: item.description || '-',
-            desktop: item.desktop || null,
-            icon: getTypeIcon(item.llm_type || ''),
-          }
-        })
+        this.allItems = await fetchCommunityImageItems(this.allowedImageLlmTypes, this.catalogManager)
         if (this.typeList.length > 0) {
           this.form.llm_type = this.typeList[0].value
         }
-        // 查询当前选中类型的已导入镜像
         await this.fetchExistingByType(this.form.llm_type)
         this.refreshList()
       } catch (err) {
@@ -259,57 +205,20 @@ export default {
       return marked(text)
     },
     async handleImport (record) {
-      // 先创建 llm_image，再用其 id 创建对应的默认 SKU。
-      // SKU 默认规格取自 onecloud-operator 的 DefaultLLMSku（见 llmTypeConfig.js）。
-      // dify 单镜像无法构造完整 spec，只创建 image 不建 SKU。
-      // SKU 创建失败时仅警告，不回滚 image。
-      let imageId = ''
       try {
-        const createData = {
-          generate_name: buildImportGenerateName(record),
-          llm_type: record.llm_type,
-          image_name: record.image_name,
-          image_label: record.image_label,
+        const { skuError } = await createCommunityImageAndSku(record, {
+          imagesManager: this.imagesManager,
+          skusManager: this.skusManager,
+        })
+        this.$set(this.existingImages, getCommunityImageKey(record), true)
+        if (skuError) {
+          this.$message.warning(this.$t('aice.llm_image.sku_auto_create_failed', [skuError?.message || skuError]))
+        } else {
+          this.$message.success(this.$t('common.success'))
         }
-        if (record.desktop && typeof record.desktop === 'object') {
-          createData.desktop_config = record.desktop
-        }
-        if (record.app_name) {
-          createData.app_name = record.app_name
-        }
-        const imgRes = await new this.$Manager('llm_images').create({ data: createData })
-        imageId = imgRes?.data?.id
-        this.$set(this.existingImages, `${record.llm_type}:${record.image_name}:${record.image_label}`, true)
       } catch (err) {
         throw err
       }
-      try {
-        await this.maybeCreateDefaultSku(record, imageId)
-        this.$message.success(this.$t('common.success'))
-      } catch (err) {
-        this.$message.warning(this.$t('aice.llm_image.sku_auto_create_failed', [err?.message || err]))
-      }
-    },
-    async maybeCreateDefaultSku (record, imageId) {
-      if (!imageId) return
-      const spec = getDefaultSkuSpecForType(record.llm_type)
-      if (!spec) return // dify 等无默认 SKU 模板的类型直接跳过
-      const portMappings = getDefaultPortMappingsForType(record.llm_type)
-      const data = {
-        generate_name: buildImportGenerateName(record),
-        llm_type: record.llm_type,
-        llm_image_id: imageId,
-        cpu: spec.cpu,
-        memory: spec.memory,
-        bandwidth: spec.bandwidth,
-        volumes: [{ size_mb: spec.volume_size_mb }],
-        disk_size: spec.volume_size_mb,
-        llm_sku: { [record.llm_type]: {} },
-      }
-      if (portMappings.length > 0) {
-        data.port_mappings = portMappings
-      }
-      await new this.$Manager('llm_skus').create({ data })
     },
   },
 }

--- a/containers/Ai/views/llm-sku/components/List.vue
+++ b/containers/Ai/views/llm-sku/components/List.vue
@@ -85,13 +85,13 @@ export default {
             {
               label: this.$t('aice.llm_deployment.deploy.from_catalog'),
               action: () => {
-                this.$router.push({ path: '/llm-sku/import-from-model-sets' })
+                this.$router.push({ path: this.llmRouteCtx.skuImportFromModelSetsPath })
               },
             },
             {
               label: this.$t('aice.llm_deployment.deploy.from_huggingface'),
               action: () => {
-                this.$router.push({ path: '/llm-sku/import-from-huggingface' })
+                this.$router.push({ path: this.llmRouteCtx.skuImportFromHuggingfacePath })
               },
             },
           ],
@@ -99,9 +99,18 @@ export default {
             buttonType: 'primary',
             validate: true,
           }),
-          hidden: () => {
-            return this.isApplyType || this.isDesktopType
+          hidden: () => !this.llmRouteCtx.isInferenceType,
+        },
+        {
+          label: this.$t('aice.import'),
+          action: () => {
+            this.$router.push({ path: this.llmRouteCtx.skuImportFromCommunityPath })
           },
+          meta: () => ({
+            buttonType: 'primary',
+            validate: true,
+          }),
+          hidden: () => !(this.isApplyType || this.isDesktopType),
         },
         {
           label: this.$t('table.action.delete'),

--- a/containers/Ai/views/llm-sku/components/LlmSkuGrid.vue
+++ b/containers/Ai/views/llm-sku/components/LlmSkuGrid.vue
@@ -84,6 +84,12 @@
               :title="mountedModelText(item)">
               {{ $t('aice.model') }}：{{ mountedModelText(item) }}
             </div>
+            <div
+              v-if="!isApplyType && !isDesktopType && inferenceModelText(item)"
+              class="meta-row meta-ellipsis"
+              :title="inferenceModelText(item)">
+              {{ $t('aice.model') }}：{{ inferenceModelText(item) }}
+            </div>
             <div v-if="item.description" class="catalog-desc">{{ shortDesc(item.description) }}</div>
             <div v-if="item.tenant || domainName(item)" class="meta-row meta-scope" @click.stop>
               <list-body-cell-wrap
@@ -126,6 +132,7 @@ import { sizestr } from '@/utils/utils'
 import expectStatus from '@/constants/expectStatus'
 import Actions from '@/components/PageList/Actions'
 import Status from '@/components/Status'
+import { getSkuModelDisplayText } from '../utils/modelDisplay'
 import { LLM_TYPE_OPTIONS } from '../constants/llmTypeConfig'
 
 const INFERENCE_LLM_TYPES = ['vllm', 'ollama', 'sglang']
@@ -249,6 +256,9 @@ export default {
       const list = item.mounted_model_details || []
       if (!list.length) return ''
       return list.map(v => v.fullname).join(', ')
+    },
+    inferenceModelText (item) {
+      return getSkuModelDisplayText(item)
     },
     shortDesc (s) {
       if (!s) return ''

--- a/containers/Ai/views/llm-sku/constants/llmTypeConfig.js
+++ b/containers/Ai/views/llm-sku/constants/llmTypeConfig.js
@@ -50,7 +50,7 @@ export function getDefaultPortMappingsForType (llmType) {
 /**
  * 社区镜像导入时自动创建 SKU 用的默认资源规格。
  * 字段单位与后端 LLMSkuCreateInput 一致：memory MB，volume size_mb，bandwidth Mbps。
- * dify 不在表里：单镜像导入无法构造完整 dify spec（需要 7 个 image id），跳过自动建 SKU。
+ * dify 单镜像导入无法构造完整 dify spec；bundle 导入由 yaml sku 块提供规格。
  * 取自 onecloud-operator pkg/apis/onecloud/v1alpha1/defaults.go 的 DefaultLLMSku。
  */
 export const LLM_TYPE_DEFAULT_SKU_SPEC = {

--- a/containers/Ai/views/llm-sku/create/Form.vue
+++ b/containers/Ai/views/llm-sku/create/Form.vue
@@ -426,6 +426,7 @@ export default {
     const isApplyType = llmRouteCtx.isApplyType
     const isDesktopType = llmRouteCtx.isDesktopType
     const catalogLlmTypeInit = this.catalogSpec ? backendToLlmType(this.catalogSpec.backend) : null
+    const catalogResourceDefaults = this.catalogSpec ? { cpu: 4, memory: 8192 } : null
     let llmTypeOptions
     if (isDesktopType) {
       llmTypeOptions = LLM_TYPE_OPTIONS.filter(opt => opt.id === 'desktop')
@@ -441,8 +442,8 @@ export default {
       tenant,
       name,
       llm_type: rowLlmType,
-      cpu = 2,
-      memory = 2048,
+      cpu = catalogResourceDefaults?.cpu ?? 2,
+      memory = catalogResourceDefaults?.memory ?? 2048,
       volume = { size: 10240, storage_type: 'local', template_id: undefined },
       image_id,
       envs = [],
@@ -985,6 +986,8 @@ export default {
       this.form.fc.setFieldsValue({
         llm_type: llmType,
         name: defaultNameFromSpec(this.catalogSpec, this.catalogSet),
+        cpu: 4,
+        memory: 8,
       })
       if (!this.isEditMode) {
         const next = getDefaultPortMappingsForType(llmType).map(item => ({ ...item, key: uuid() }))

--- a/containers/Ai/views/llm-sku/import-from-community/index.vue
+++ b/containers/Ai/views/llm-sku/import-from-community/index.vue
@@ -1,0 +1,301 @@
+<!--
+  Agent / 桌面模板：从社区目录导入镜像 + 默认 SKU。
+-->
+<template>
+  <div>
+    <page-header :title="headerTitle" />
+    <page-body class="catalog-grid-page-body">
+      <div class="catalog-model-page">
+        <community-image-grid
+          :allowed-types="allowedTypes"
+          :catalog-items="catalogItems"
+          :existing-images="existingImages"
+          :loading="catalogLoading"
+          @select="onItemSelect"
+          @refresh="loadExistingImages" />
+      </div>
+    </page-body>
+
+    <a-drawer
+      wrap-class-name="catalog-drawer-wrap"
+      :visible="drawerVisible"
+      :width="720"
+      destroy-on-close
+      placement="right"
+      @close="clearItem">
+      <div v-if="selectedItem" class="catalog-drawer-layout">
+        <div class="catalog-drawer-header">
+          <div class="catalog-drawer-name">{{ displayTitle(selectedItem) }}</div>
+        </div>
+
+        <div class="catalog-drawer-scroll">
+          <a-descriptions :column="1" size="small" bordered class="mb-3">
+            <a-descriptions-item v-if="selectedItem.app_name" :label="$t('aice.llm_image.app_name')">
+              {{ selectedItem.app_name }}
+            </a-descriptions-item>
+            <a-descriptions-item v-if="isBundleItem(selectedItem) && itemSubtitle(selectedItem)" :label="$t('aice.llm_image.name')">
+              {{ itemSubtitle(selectedItem) }}
+            </a-descriptions-item>
+            <a-descriptions-item :label="$t('aice.llm_image.name')">
+              {{ imageLine(selectedItem) }}
+            </a-descriptions-item>
+            <a-descriptions-item v-if="isDesktopCommunityItem(selectedItem)" :label="$t('aice.llm_type.app')">
+              {{ llmTypeLabel(selectedItem.llm_type) }}
+            </a-descriptions-item>
+            <a-descriptions-item v-if="isItemImported" :label="$t('common.status')">
+              <a-tag color="green">{{ $t('aice.llm_image.imported') }}</a-tag>
+            </a-descriptions-item>
+          </a-descriptions>
+          <a-divider orientation="left">{{ $t('common.description') }}</a-divider>
+          <div class="md-desc" v-html="descriptionHtml" />
+
+          <template v-if="needsGpuSelection">
+            <a-divider orientation="left">{{ $t('aice.llm_catalog.import_config') }}</a-divider>
+            <a-form-model
+              ref="importFormRef"
+              :model="importForm"
+              :rules="importRules"
+              :label-col="{ span: 6 }"
+              :wrapper-col="{ span: 18 }">
+              <a-form-model-item :label="$t('aice.devices')" prop="devices">
+                <llm-gpu-device-select v-model="importForm.devices" />
+              </a-form-model-item>
+            </a-form-model>
+          </template>
+        </div>
+
+        <div class="catalog-drawer-footer">
+          <a-button class="mr-2" @click="clearItem">{{ $t('common.cancel') }}</a-button>
+          <a-button
+            type="primary"
+            :loading="submitLoading"
+            :disabled="isItemImported"
+            @click="handleImport">
+            {{ $t('aice.import') }}
+          </a-button>
+        </div>
+      </div>
+    </a-drawer>
+  </div>
+</template>
+
+<script>
+import marked from 'marked'
+import CommunityImageGrid from '@Ai/sections/community-images/components/CommunityImageGrid.vue'
+import LlmGpuDeviceSelect from '@Ai/sections/LlmGpuDeviceSelect.vue'
+import { parseLlmRoute, getLlmSkuTypeFilter } from '@Ai/utils/llmRouteContext'
+import {
+  communityImportNeedsGpuSelection,
+  createCommunityImageAndSku,
+  fetchCommunityImageItems,
+  fetchExistingCommunityImageKeys,
+  formatCommunityDisplayTitle,
+  getCommunityImageKey,
+  getCommunityItemImageLine,
+  getCommunityItemSubtitle,
+  isBundleItem,
+  isCommunityImageImported,
+  isDesktopCommunityItem,
+} from '@Ai/utils/communityImages'
+
+export default {
+  name: 'LlmSkuImportFromCommunity',
+  components: {
+    CommunityImageGrid,
+    LlmGpuDeviceSelect,
+  },
+  data () {
+    return {
+      selectedItem: null,
+      catalogItems: [],
+      catalogLoading: false,
+      existingImages: {},
+      submitLoading: false,
+      importForm: {
+        devices: [],
+      },
+      imagesManager: new this.$Manager('llm_images'),
+      skusManager: new this.$Manager('llm_skus'),
+      catalogManager: new this.$Manager('llm_images_catalogs', 'v1'),
+    }
+  },
+  computed: {
+    llmRouteCtx () {
+      return parseLlmRoute(this.$route.path)
+    },
+    allowedTypes () {
+      return this.llmRouteCtx.llmTypes || []
+    },
+    headerTitle () {
+      const skuLabel = this.llmRouteCtx.isDesktopType
+        ? this.$t('aice.desktop_llm_sku')
+        : this.$t('aice.app_llm_sku')
+      return this.$t('aice.import') + ' - ' + skuLabel
+    },
+    drawerVisible () {
+      return !!this.selectedItem
+    },
+    isItemImported () {
+      return isCommunityImageImported(this.selectedItem, this.existingImages)
+    },
+    descriptionHtml () {
+      const text = this.selectedItem?.description
+      if (!text || text === '-') return '-'
+      return marked(text)
+    },
+    needsGpuSelection () {
+      return communityImportNeedsGpuSelection(this.selectedItem)
+    },
+    importRules () {
+      return {
+        devices: [{
+          required: true,
+          type: 'array',
+          validator: (rule, value, callback) => {
+            if (!Array.isArray(value) || value.length < 1) {
+              callback(new Error(this.$t('common.tips.select', [this.$t('aice.devices')])))
+              return
+            }
+            callback()
+          },
+        }],
+      }
+    },
+  },
+  activated () {
+    this.loadExistingImages()
+  },
+  beforeRouteEnter (to, from, next) {
+    next(vm => {
+      vm.loadExistingImages()
+    })
+  },
+  beforeRouteUpdate (to, from, next) {
+    this.loadExistingImages()
+    next()
+  },
+  methods: {
+    displayTitle (item) {
+      return formatCommunityDisplayTitle(item, type => this.llmTypeLabel(type))
+    },
+    itemSubtitle (item) {
+      return getCommunityItemSubtitle(item)
+    },
+    isDesktopCommunityItem,
+    isBundleItem,
+    imageLine (item) {
+      if (!item) return ''
+      if (isBundleItem(item)) {
+        const count = item.images?.length || 0
+        return count > 0 ? `${count} images` : '-'
+      }
+      return getCommunityItemImageLine(item) || '-'
+    },
+    llmTypeLabel (type) {
+      if (!type) return '-'
+      const key = `aice.llm_type.${String(type).replace(/-/g, '_')}`
+      return this.$te(key) ? this.$t(key) : type
+    },
+    async loadExistingImages () {
+      if (this._loadExistingPromise) {
+        return this._loadExistingPromise
+      }
+      this._loadExistingPromise = this._fetchExistingImages()
+        .finally(() => {
+          this._loadExistingPromise = null
+        })
+      return this._loadExistingPromise
+    },
+    async _fetchExistingImages () {
+      this.catalogLoading = true
+      try {
+        const items = await fetchCommunityImageItems(this.allowedTypes, this.catalogManager)
+        this.catalogItems = items
+        this.existingImages = await fetchExistingCommunityImageKeys(
+          this.allowedTypes,
+          this.skusManager,
+          items,
+          {
+            scope: this.$store.getters.scope,
+            typeFilter: getLlmSkuTypeFilter(this.llmRouteCtx),
+          },
+        )
+      } catch (err) {
+        if (err && !err.__CANCEL__) {
+          this.$message.error(this.$t('aice.llm_image.community_image_fetch_failed'))
+        }
+      } finally {
+        this.catalogLoading = false
+      }
+    },
+    onItemSelect (item) {
+      this.selectedItem = item
+      this.resetImportForm()
+    },
+    clearItem () {
+      this.selectedItem = null
+      this.resetImportForm()
+    },
+    resetImportForm () {
+      this.importForm.devices = []
+      this.$nextTick(() => {
+        if (this.$refs.importFormRef) {
+          this.$refs.importFormRef.clearValidate()
+        }
+      })
+    },
+    async validateImportForm () {
+      if (!this.needsGpuSelection || !this.$refs.importFormRef) return true
+      return new Promise(resolve => {
+        this.$refs.importFormRef.validate(valid => resolve(valid))
+      })
+    },
+    async handleImport () {
+      if (!this.selectedItem || this.isItemImported) return
+      const valid = await this.validateImportForm()
+      if (!valid) return
+      this.submitLoading = true
+      try {
+        const devices = this.needsGpuSelection ? this.importForm.devices : undefined
+        const { skuError } = await createCommunityImageAndSku(this.selectedItem, {
+          imagesManager: this.imagesManager,
+          skusManager: this.skusManager,
+          devices,
+        })
+        this.$set(this.existingImages, getCommunityImageKey(this.selectedItem), true)
+        if (skuError) {
+          this.$message.warning(this.$t('aice.llm_image.sku_auto_create_failed', [skuError?.message || skuError]))
+        } else {
+          this.$message.success(this.$t('common.success'))
+          this.clearItem()
+          this.$router.push(this.llmRouteCtx.skuListPath)
+        }
+      } catch (err) {
+        if (err?.message) {
+          this.$message.error(err.message)
+        }
+        throw err
+      } finally {
+        this.submitLoading = false
+      }
+    },
+  },
+}
+</script>
+
+<style lang="less" scoped>
+.catalog-grid-page-body {
+  overflow: hidden;
+}
+</style>
+
+<style lang="less" src="@Ai/sections/catalog-model-sets/catalog-model-page.less"></style>
+<style lang="less" src="@Ai/sections/catalog-model-sets/catalog-drawer.less"></style>
+<style>
+.md-desc p {
+  margin-bottom: 0;
+}
+.md-desc a {
+  color: #1890ff;
+}
+</style>

--- a/containers/Ai/views/llm-sku/import-from-huggingface/index.vue
+++ b/containers/Ai/views/llm-sku/import-from-huggingface/index.vue
@@ -71,6 +71,7 @@ import CatalogDrawerMetaPanel from '@Ai/sections/catalog-model-sets/components/C
 import { repoIdOf } from '@Ai/utils/hfRepo'
 import CatalogImportSkuForm from '@Ai/views/llm-sku/shared/CatalogImportSkuForm.vue'
 import { resolveCatalogLlmType } from '@Ai/utils/catalogSpec'
+import { parseLlmRoute } from '@Ai/utils/llmRouteContext'
 import { buildHfCatalogSet, buildHfCatalogSpec } from '@Ai/utils/hfImportSpec'
 
 export default {
@@ -88,6 +89,9 @@ export default {
     }
   },
   computed: {
+    llmRouteCtx () {
+      return parseLlmRoute(this.$route.path)
+    },
     headerTitle () {
       return this.$t('aice.import_model') + ' - ' + this.$t('aice.llm_sku')
     },
@@ -146,7 +150,7 @@ export default {
     },
     onImportSuccess () {
       this.closeDrawer()
-      this.$router.push('/llm-sku')
+      this.$router.push(this.llmRouteCtx.skuListPath)
     },
   },
 }

--- a/containers/Ai/views/llm-sku/import-from-model-sets/index.vue
+++ b/containers/Ai/views/llm-sku/import-from-model-sets/index.vue
@@ -84,6 +84,7 @@ import {
   getCatalogSpecId,
   isCatalogInferenceBackend,
 } from '@Ai/utils/catalogSpec'
+import { parseLlmRoute } from '@Ai/utils/llmRouteContext'
 
 export default {
   name: 'LlmSkuImportFromModelSets',
@@ -100,6 +101,9 @@ export default {
     }
   },
   computed: {
+    llmRouteCtx () {
+      return parseLlmRoute(this.$route.path)
+    },
     headerTitle () {
       return this.$t('aice.import_model') + ' - ' + this.$t('aice.llm_sku')
     },
@@ -143,7 +147,7 @@ export default {
     },
     onImportSuccess () {
       this.clearSet()
-      this.$router.push('/llm-sku')
+      this.$router.push(this.llmRouteCtx.skuListPath)
     },
   },
 }

--- a/containers/Ai/views/llm-sku/mixins/columns.js
+++ b/containers/Ai/views/llm-sku/mixins/columns.js
@@ -15,11 +15,12 @@ import {
   getMemoryTableColumn,
   getDiskTableColumn,
   getLlmTypeTableColumn,
+  getLlmModelNameTableColumn,
 } from '../utils/columns'
 
 export default {
   created () {
-    const { isApplyType, isDesktopType } = parseLlmRoute(this.$route.path)
+    const { isApplyType, isDesktopType, isInferenceType } = parseLlmRoute(this.$route.path)
     this.columns = [
       getNameDescriptionTableColumn({
         onManager: this.onManager,
@@ -36,6 +37,7 @@ export default {
       getDiskTableColumn(),
       getImageTableColumn({ vm: this }),
       ...(isDesktopType ? [getAppNameTableColumn()] : []),
+      ...(isInferenceType ? [getLlmModelNameTableColumn({ vm: this })] : []),
       getBandwidthTableColumn(),
       getLlmTypeTableColumn({ isApplyType, isDesktopType }),
       getProjectTableColumn(),

--- a/containers/Ai/views/llm-sku/utils/columns.js
+++ b/containers/Ai/views/llm-sku/utils/columns.js
@@ -1,5 +1,6 @@
 import { sizestr } from '@/utils/utils'
 import i18n from '@/locales'
+import { getSkuModelDisplayText } from './modelDisplay'
 
 export const getDeviceModelTableColumn = () => {
   return {
@@ -154,10 +155,8 @@ export const getLlmModelNameTableColumn = ({ vm = {} } = {}) => {
     field: 'mounted_models',
     title: i18n.t('aice.model'),
     formatter: ({ row }) => {
-      if (row.mounted_model_details && row.mounted_model_details.length) {
-        return row.mounted_model_details.map(v => v.fullname).join(',')
-      }
-      return '-'
+      const text = getSkuModelDisplayText(row)
+      return text || '-'
     },
     slots: {
       default: ({ row }, h) => {
@@ -171,6 +170,10 @@ export const getLlmModelNameTableColumn = ({ vm = {} } = {}) => {
             )
           })
           return ret
+        }
+        const text = getSkuModelDisplayText(row)
+        if (text) {
+          return [h('span', text)]
         }
         return '-'
       },

--- a/containers/Ai/views/llm-sku/utils/modelDisplay.js
+++ b/containers/Ai/views/llm-sku/utils/modelDisplay.js
@@ -1,0 +1,45 @@
+const INFERENCE_LLM_TYPES = ['vllm', 'ollama', 'sglang']
+
+/**
+ * Resolve display text for the model used by an llm_sku row (inference templates).
+ * @param {object} item
+ * @returns {string}
+ */
+export function getSkuModelDisplayText (item) {
+  if (!item) return ''
+
+  const mounted = item.mounted_model_details || []
+  if (mounted.length) {
+    return mounted.map(v => v.fullname).filter(Boolean).join(', ')
+  }
+
+  const llmType = item.llm_type
+  const spec = item.llm_spec
+  if (spec && typeof spec === 'object' && !Array.isArray(spec)) {
+    if (llmType && spec[llmType] && spec[llmType].preferred_model) {
+      return String(spec[llmType].preferred_model)
+    }
+    for (let i = 0; i < INFERENCE_LLM_TYPES.length; i++) {
+      const key = INFERENCE_LLM_TYPES[i]
+      const block = spec[key]
+      if (block && block.preferred_model) {
+        return String(block.preferred_model)
+      }
+    }
+  }
+
+  if (item.preferred_model) {
+    return String(item.preferred_model)
+  }
+  if (item.huggingface_repo_id) {
+    return String(item.huggingface_repo_id)
+  }
+  if (item.model_scope_model_id) {
+    return String(item.model_scope_model_id)
+  }
+  if (item.llm_model_name) {
+    return String(item.llm_model_name)
+  }
+
+  return ''
+}

--- a/containers/Application/router/index.js
+++ b/containers/Application/router/index.js
@@ -7,9 +7,9 @@ const AppDesktop = () => import(/* webpackChunkName: "application" */ '@Applicat
 const AppDesktopSku = () => import(/* webpackChunkName: "application" */ '@Application/views/app-desktop-sku')
 const AppDesktopImage = () => import(/* webpackChunkName: "application" */ '@Application/views/app-desktop-image')
 const AppLlmImageRedirect = () => import(/* webpackChunkName: "application" */ '@Application/views/app-llm-image-redirect')
-const LlmImageImportCommunity = () => import(/* webpackChunkName: "application" */ '@Ai/views/llm-image/import-community')
 const LlmCreate = () => import(/* webpackChunkName: "application" */ '@Ai/views/llm/create')
 const LlmSkuCreate = () => import(/* webpackChunkName: "application" */ '@Ai/views/llm-sku/create/index')
+const LlmSkuImportFromCommunity = () => import(/* webpackChunkName: "application" */ '@Ai/views/llm-sku/import-from-community')
 
 export default {
   index: 60.5,
@@ -71,6 +71,11 @@ export default {
               path: 'create',
               component: LlmSkuCreate,
             },
+            {
+              name: 'AppDesktopSkuImportFromCommunity',
+              path: 'import-from-community',
+              component: LlmSkuImportFromCommunity,
+            },
           ],
         },
         {
@@ -91,11 +96,6 @@ export default {
               name: 'AppDesktopImageList',
               path: '',
               component: AppDesktopImage,
-            },
-            {
-              name: 'AppDesktopImageImportCommunity',
-              path: 'import-community',
-              component: LlmImageImportCommunity,
             },
           ],
         },


### PR DESCRIPTION
Add import-from-community flow for LLM SKU, extract shared CommunityImageGrid and communityImages utilities, introduce LlmGpuDeviceSelect and model display helpers, and remove standalone llm-image import-community routes.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0