### PR TITLE
feat(ai): 即时模型列表与详情展示导入进度

### DIFF
--- a/containers/Ai/views/llm-instantmodel/components/InstantModelImportStatus.vue
+++ b/containers/Ai/views/llm-instantmodel/components/InstantModelImportStatus.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="instant-model-import-status">
+    <status
+      v-if="showStatus"
+      :status="status"
+      status-module="image"
+      :process="progress" />
+    <a-progress
+      v-if="showProgressBar"
+      class="instant-model-import-status__bar"
+      :percent="curProcess"
+      :show-info="true"
+      size="small"
+      status="active" />
+  </div>
+</template>
+
+<script>
+const IMPORT_PROGRESS_STATUSES = ['init', 'packaging', 'saving', 'queued', 'converting']
+
+export default {
+  name: 'InstantModelImportStatus',
+  props: {
+    status: {
+      type: String,
+      required: true,
+    },
+    progress: {
+      type: Number,
+      default: 0,
+    },
+    showStatus: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  computed: {
+    curProcess () {
+      return Math.ceil(+this.progress * 100) / 100
+    },
+    showProgressBar () {
+      if (!(this.curProcess > 0 && this.curProcess < 100)) return false
+      return IMPORT_PROGRESS_STATUSES.includes(this.status)
+    },
+  },
+}
+</script>
+
+<style scoped lang="less">
+.instant-model-import-status {
+  width: 100%;
+
+  &__bar {
+    width: 140px;
+    margin-top: 4px;
+    margin-left: 5px;
+  }
+}
+</style>

--- a/containers/Ai/views/llm-instantmodel/components/List.vue
+++ b/containers/Ai/views/llm-instantmodel/components/List.vue
@@ -35,7 +35,7 @@ export default {
         filterOptions,
         hiddenColumns: [],
         steadyStatus: {
-          status: expectStatus.mcp ? Object.values(expectStatus.image).flat() : [],
+          status: Object.values(expectStatus.image).flat(),
         },
       }),
       groupActions: [

--- a/containers/Ai/views/llm-instantmodel/mixins/columns.js
+++ b/containers/Ai/views/llm-instantmodel/mixins/columns.js
@@ -1,11 +1,12 @@
+import i18n from '@/locales'
 import {
   getNameDescriptionTableColumn,
-  getStatusTableColumn,
   getEnabledTableColumn,
   getProjectTableColumn,
   getTimeTableColumn,
   getPublicScopeTableColumn,
 } from '@/utils/common/tableColumn'
+import InstantModelImportStatus from '../components/InstantModelImportStatus.vue'
 import {
   // getPackageNameTableColumn,
   // getAppIdTableColumn,
@@ -21,6 +22,9 @@ import {
 } from '../utils/columns'
 
 export default {
+  components: {
+    InstantModelImportStatus,
+  },
   created () {
     this.columns = [
       // getIconTableColumn(),
@@ -33,7 +37,22 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'image', showStatusProgress: true }),
+      {
+        field: 'status',
+        title: i18n.t('common.status'),
+        sortable: true,
+        minWidth: 160,
+        slots: {
+          default: ({ row }) => {
+            return [
+              <instant-model-import-status status={row.status} progress={row.progress} />,
+            ]
+          },
+        },
+        formatter: ({ row }) => {
+          return i18n.te(`status.image.${row.status}`) ? i18n.t(`status.image.${row.status}`) : row.status
+        },
+      },
       getEnabledTableColumn(),
       getEnabledTableColumn({
         field: 'auto_cache',

--- a/containers/Ai/views/llm-instantmodel/sidepage/Detail.vue
+++ b/containers/Ai/views/llm-instantmodel/sidepage/Detail.vue
@@ -67,6 +67,23 @@ export default {
       ],
       extraInfo: [
         {
+          field: 'import_progress',
+          title: this.$t('aice.llm_image.progress'),
+          hidden: () => !this.showImportProgress,
+          slots: {
+            default: ({ row }) => {
+              const progress = Math.ceil(+row.progress * 100) / 100
+              return [
+                <a-progress
+                  percent={progress}
+                  show-info={true}
+                  size="small"
+                  status="active" />,
+              ]
+            },
+          },
+        },
+        {
           field: 'mounts',
           title: this.$t('aice.mounted_apps.mounts'),
           slots: {
@@ -80,6 +97,11 @@ export default {
     }
   },
   computed: {
+    showImportProgress () {
+      const progress = +this.data.progress
+      if (!(progress > 0 && progress < 100)) return false
+      return ['init', 'packaging', 'saving', 'queued', 'converting'].includes(this.data.status)
+    },
     mountPaths () {
       if (!this.data.mounts || !Array.isArray(this.data.mounts)) {
         return ''

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -245,6 +245,7 @@
     },
     "image": {
       "init": "Initialize",
+      "packaging": "Packaging",
       "saving": "Saving",
       "saved": "Saved",
       "caching": "Cached",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -245,6 +245,7 @@
     },
     "image": {
       "init": "初期化する",
+      "packaging": "パッケージング中",
       "saving": "節約",
       "saved": "保存",
       "caching": "キャッシュ内",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -252,6 +252,7 @@
     },
     "image": {
       "init": "初始化",
+      "packaging": "打包中",
       "saving": "正在保存",
       "saved": "已保存",
       "caching": "缓存中",


### PR DESCRIPTION
新增 InstantModelImportStatus 组件，在列表状态列与详情页展示导入中的进度条，并修正列表 steadyStatus 配置。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0