### PR TITLE
feat(ai): 即时模型列表与详情展示导入进度

### DIFF
--- a/containers/Ai/sections/InstantModelImportStatus.vue
+++ b/containers/Ai/sections/InstantModelImportStatus.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="instant-model-import-status">
+    <status
+      v-if="showStatus && !statusAfterBar"
+      :status="status"
+      status-module="image"
+      :process="progress" />
+    <a-progress
+      v-if="showProgressBar"
+      class="instant-model-import-status__bar"
+      :percent="curProcess"
+      :show-info="true"
+      size="small"
+      status="active" />
+    <status
+      v-if="showStatus && statusAfterBar"
+      class="instant-model-import-status__status-after"
+      :status="status"
+      status-module="image"
+      :process="progress" />
+  </div>
+</template>
+
+<script>
+const IMPORT_PROGRESS_STATUSES = ['init', 'packaging', 'saving', 'queued', 'converting']
+
+export default {
+  name: 'InstantModelImportStatus',
+  props: {
+    status: {
+      type: String,
+      required: true,
+    },
+    progress: {
+      type: Number,
+      default: 0,
+    },
+    showStatus: {
+      type: Boolean,
+      default: true,
+    },
+    statusAfterBar: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    curProcess () {
+      return Math.ceil(+this.progress * 100) / 100
+    },
+    showProgressBar () {
+      if (!IMPORT_PROGRESS_STATUSES.includes(this.status)) return false
+      return this.curProcess < 100
+    },
+  },
+}
+</script>
+
+<style scoped lang="less">
+.instant-model-import-status {
+  width: 100%;
+
+  &__bar {
+    width: 140px;
+    margin-top: 4px;
+    margin-left: 5px;
+  }
+
+  &__status-after {
+    margin-top: 4px;
+  }
+}
+</style>

--- a/containers/Ai/utils/instantModelImportPoll.js
+++ b/containers/Ai/utils/instantModelImportPoll.js
@@ -1,0 +1,146 @@
+export const POLL_INTERVAL_MS = 3000
+
+const INFERENCE_LLM_TYPES = ['vllm', 'ollama', 'sglang']
+
+function parseLlmSpec (sku) {
+  const raw = sku?.llm_spec
+  if (!raw) return null
+  if (typeof raw === 'object') return raw
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw)
+    } catch (e) {
+      return null
+    }
+  }
+  return null
+}
+
+function preferredModelFromSku (sku) {
+  const llmType = sku?.llm_type
+  const spec = parseLlmSpec(sku)
+  if (!spec) return ''
+  if (llmType && spec[llmType]?.preferred_model) {
+    return String(spec[llmType].preferred_model).trim()
+  }
+  for (let i = 0; i < INFERENCE_LLM_TYPES.length; i++) {
+    const key = INFERENCE_LLM_TYPES[i]
+    const block = spec[key]
+    if (block?.preferred_model) {
+      return String(block.preferred_model).trim()
+    }
+  }
+  return ''
+}
+
+function parseOllamaPreferredModel (preferred) {
+  const s = String(preferred).trim()
+  if (!s) return null
+  const idx = s.indexOf(':')
+  if (idx >= 0) {
+    return {
+      model_name: s.slice(0, idx),
+      model_tag: s.slice(idx + 1) || 'latest',
+      llm_type: 'ollama',
+    }
+  }
+  return { model_name: s, model_tag: 'latest', llm_type: 'ollama' }
+}
+
+export function resolveInstantModelIdFromSku (sku) {
+  const ids = sku?.mounted_models
+  if (Array.isArray(ids) && ids.length > 0) {
+    const id = String(ids[0] || '').trim()
+    if (id) return id
+  }
+  const mounted = sku?.mounted_model_details || []
+  if (mounted.length > 0 && mounted[0]?.id) {
+    return String(mounted[0].id)
+  }
+  return ''
+}
+
+export function resolveInstantModelQueryFromSku (sku) {
+  if (!sku) return null
+
+  const llmType = sku.llm_type
+  if (sku.huggingface_repo_id) {
+    return {
+      model_name: sku.huggingface_repo_id,
+      model_tag: sku.huggingface_filename || 'main',
+      llm_type: llmType,
+    }
+  }
+
+  const preferred = preferredModelFromSku(sku)
+  if (preferred) {
+    if (llmType === 'ollama' || sku.source === 'ollama') {
+      return parseOllamaPreferredModel(preferred)
+    }
+    return {
+      model_name: preferred,
+      model_tag: sku.huggingface_filename || 'main',
+      llm_type: llmType,
+    }
+  }
+
+  return null
+}
+
+export async function findInstantModelByQuery (manager, query, scope) {
+  if (!query?.model_name) return null
+  const listRes = await manager.list({
+    params: {
+      scope,
+      llm_type: query.llm_type,
+      model_name: query.model_name,
+      limit: 20,
+      details: true,
+    },
+  })
+  const items = listRes.data?.data || []
+  const wantTag = query.model_tag || 'main'
+  let matched = items.filter((item) => {
+    const nameOk = item.model_name === query.model_name
+    const tagOk = (item.model_tag || 'main') === wantTag
+    return nameOk && tagOk
+  })
+  if (matched.length === 0) {
+    matched = items.filter(item => item.model_name === query.model_name)
+  }
+  if (matched.length === 0) return null
+  matched.sort((a, b) => {
+    const ta = new Date(a.created_at || 0).getTime()
+    const tb = new Date(b.created_at || 0).getTime()
+    return tb - ta
+  })
+  return matched[0]
+}
+
+async function getInstantModelDetail (manager, id, scope) {
+  const res = await manager.get({
+    id,
+    params: {
+      scope,
+      details: true,
+      _t: Date.now(),
+    },
+  })
+  return res.data
+}
+
+/** 优先 get(mounted_models id)，否则 list 匹配后 get */
+export async function fetchInstantModelForSku (manager, sku, scope) {
+  const instantModelId = resolveInstantModelIdFromSku(sku)
+  if (instantModelId) {
+    return getInstantModelDetail(manager, instantModelId, scope)
+  }
+
+  const query = resolveInstantModelQueryFromSku(sku)
+  if (!query) return null
+
+  const found = await findInstantModelByQuery(manager, query, scope)
+  if (!found?.id) return found
+
+  return getInstantModelDetail(manager, found.id, scope)
+}

--- a/containers/Ai/utils/llmSkuStatus.js
+++ b/containers/Ai/utils/llmSkuStatus.js
@@ -1,0 +1,8 @@
+import expectStatus from '@/constants/expectStatus'
+
+/** 列表 steadyStatus：导入中需继续轮询，不包含 importing_model */
+export function getLlmSkuListSteadyStatuses () {
+  const m = expectStatus.llmSku || {}
+  const info = (m.info || []).filter(s => s !== 'importing_model')
+  return [...new Set([...(m.success || []), ...(m.danger || []), ...info])]
+}

--- a/containers/Ai/views/llm-instantmodel/mixins/columns.js
+++ b/containers/Ai/views/llm-instantmodel/mixins/columns.js
@@ -6,7 +6,7 @@ import {
   getTimeTableColumn,
   getPublicScopeTableColumn,
 } from '@/utils/common/tableColumn'
-import InstantModelImportStatus from '../components/InstantModelImportStatus.vue'
+import InstantModelImportStatus from '@Ai/sections/InstantModelImportStatus.vue'
 import {
   // getPackageNameTableColumn,
   // getAppIdTableColumn,

--- a/containers/Ai/views/llm-instantmodel/sidepage/Detail.vue
+++ b/containers/Ai/views/llm-instantmodel/sidepage/Detail.vue
@@ -15,9 +15,7 @@ import {
   getPublicScopeTableColumn,
 } from '@/utils/common/tableColumn'
 import {
-  // getPackageNameTableColumn,
-  // getPackageVersionTableColumn,
-  // getAppImageTableColumn,
+  getAppImageTableColumn,
   getAppSizeTableColumn,
   getAppCacheStatusColumn,
   getModelIdTableColumn,
@@ -63,6 +61,7 @@ export default {
         getModelNameTableColumn(),
         getLlmTypeTableColumn(),
         getPublicScopeTableColumn(),
+        getAppImageTableColumn({ vm: this }),
         getAppSizeTableColumn(),
       ],
       extraInfo: [

--- a/containers/Ai/views/llm-instantmodel/utils/columns.js
+++ b/containers/Ai/views/llm-instantmodel/utils/columns.js
@@ -55,13 +55,17 @@ export const getPackageVersionTableColumn = () => {
 export const getAppImageTableColumn = ({ vm = {} } = {}) => {
   return {
     field: 'image_id',
-    title: i18n.t('aice.template'),
+    title: i18n.t('aice.image'),
     width: 120,
     slots: {
       default: ({ row }, h) => {
+        if (!row.image_id) {
+          return '-'
+        }
+        const label = row.image || row.image_id
         return [
-          <list-body-cell-wrap copy hideField={true} field='image_id' row={row} message={row.image}>
-            <side-page-trigger permission='images_get' name='SystemImageSidePage' list={vm.list} id={row.image_id} vm={vm} tab="system-image-detail">{row.image}</side-page-trigger>
+          <list-body-cell-wrap copy hideField={true} field='image_id' row={row} message={label}>
+            <side-page-trigger permission='images_get' name='SystemImageSidePage' id={row.image_id} vm={vm} tab="system-image-detail">{label}</side-page-trigger>
           </list-body-cell-wrap>,
         ]
       },

--- a/containers/Ai/views/llm-sku/components/List.vue
+++ b/containers/Ai/views/llm-sku/components/List.vue
@@ -32,6 +32,7 @@ import { mapGetters, mapState } from 'vuex'
 import { parseLlmRoute, getLlmSkuTypeFilter } from '@Ai/utils/llmRouteContext'
 import WindowsMixin from '@/mixins/windows'
 import ListMixin from '@/mixins/list'
+import { getLlmSkuListSteadyStatuses } from '@Ai/utils/llmSkuStatus'
 import LlmSkuGrid from './LlmSkuGrid'
 import SingleActionsMixin from '../mixins/singleActions'
 import ColumnsMixin from '../mixins/columns'
@@ -62,6 +63,9 @@ export default {
         getParams: this.getParam,
         filterOptions,
         hiddenColumns: [],
+        steadyStatus: {
+          status: getLlmSkuListSteadyStatuses(),
+        },
       }),
       groupActions: [
         {

--- a/containers/Ai/views/llm-sku/components/LlmSkuGrid.vue
+++ b/containers/Ai/views/llm-sku/components/LlmSkuGrid.vue
@@ -37,11 +37,10 @@
                   <span class="catalog-card-name-text">{{ item.name }}</span>
                 </list-body-cell-wrap>
               </div>
-              <div class="catalog-subtitle">
-                <status
-                  v-if="item.status"
-                  :status="item.status"
-                  status-module="llmSku" />
+              <div
+                class="catalog-subtitle"
+                :class="{ 'catalog-subtitle--importing': item.status === 'importing_model' }">
+                <llm-sku-import-status v-if="item.status" :row="item" />
                 <span v-if="item.llm_type" class="llm-type-text">{{ llmTypeLabel(item.llm_type) }}</span>
               </div>
             </div>
@@ -84,12 +83,10 @@
               :title="mountedModelText(item)">
               {{ $t('aice.model') }}：{{ mountedModelText(item) }}
             </div>
-            <div
-              v-if="!isApplyType && !isDesktopType && inferenceModelText(item)"
-              class="meta-row meta-ellipsis"
-              :title="inferenceModelText(item)">
-              {{ $t('aice.model') }}：{{ inferenceModelText(item) }}
-            </div>
+            <llm-sku-mounted-models
+              v-if="!isApplyType && !isDesktopType"
+              :row="item"
+              :vm="vm" />
             <div v-if="item.description" class="catalog-desc">{{ shortDesc(item.description) }}</div>
             <div v-if="item.tenant || domainName(item)" class="meta-row meta-scope" @click.stop>
               <list-body-cell-wrap
@@ -126,13 +123,12 @@
 </template>
 
 <script>
-import * as R from 'ramda'
 import { getModelIcon, getModelIconLabel } from '@Ai/utils/index'
 import { sizestr } from '@/utils/utils'
-import expectStatus from '@/constants/expectStatus'
+import { getLlmSkuListSteadyStatuses } from '@Ai/utils/llmSkuStatus'
 import Actions from '@/components/PageList/Actions'
-import Status from '@/components/Status'
-import { getSkuModelDisplayText } from '../utils/modelDisplay'
+import LlmSkuImportStatus from './LlmSkuImportStatus.vue'
+import LlmSkuMountedModels from './LlmSkuMountedModels.vue'
 import { LLM_TYPE_OPTIONS } from '../constants/llmTypeConfig'
 
 const INFERENCE_LLM_TYPES = ['vllm', 'ollama', 'sglang']
@@ -141,7 +137,8 @@ export default {
   name: 'LlmSkuGrid',
   components: {
     Actions,
-    Status,
+    LlmSkuImportStatus,
+    LlmSkuMountedModels,
   },
   props: {
     items: {
@@ -177,8 +174,7 @@ export default {
   },
   computed: {
     steadyStatus () {
-      const module = expectStatus.llmSku
-      return module ? R.uniq(R.flatten(Object.values(module))) : []
+      return getLlmSkuListSteadyStatuses()
     },
     scrollStyle () {
       return {
@@ -256,9 +252,6 @@ export default {
       const list = item.mounted_model_details || []
       if (!list.length) return ''
       return list.map(v => v.fullname).join(', ')
-    },
-    inferenceModelText (item) {
-      return getSkuModelDisplayText(item)
     },
     shortDesc (s) {
       if (!s) return ''
@@ -379,6 +372,16 @@ export default {
   gap: 6px;
   margin-top: 4px;
   min-width: 0;
+}
+.catalog-subtitle--importing {
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+.catalog-subtitle--importing ::v-deep .llm-sku-import-status {
+  flex: 1 1 100%;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
 }
 .catalog-subtitle ::v-deep .status-wrapper {
   width: auto;

--- a/containers/Ai/views/llm-sku/components/LlmSkuImportStatus.vue
+++ b/containers/Ai/views/llm-sku/components/LlmSkuImportStatus.vue
@@ -1,0 +1,182 @@
+<template>
+  <div class="llm-sku-import-status">
+    <template v-if="status === 'importing_model'">
+      <status :status="status" status-module="llmSku" class="llm-sku-import-status__sku" />
+      <instant-model-import-status
+        :key="progressRenderKey"
+        class="llm-sku-import-status__progress"
+        :status="instantStatus"
+        :progress="progress"
+        :show-status="true"
+        status-after-bar />
+    </template>
+    <status v-else :status="status" status-module="llmSku" />
+  </div>
+</template>
+
+<script>
+import InstantModelImportStatus from '@Ai/sections/InstantModelImportStatus.vue'
+import { fetchInstantModelForSku, POLL_INTERVAL_MS } from '@Ai/utils/instantModelImportPoll'
+
+export default {
+  name: 'LlmSkuImportStatus',
+  components: {
+    InstantModelImportStatus,
+  },
+  props: {
+    row: {
+      type: Object,
+      required: true,
+    },
+  },
+  data () {
+    return {
+      instantModelId: '',
+      instantStatus: 'init',
+      progress: 0,
+      progressRenderKey: 0,
+      pollTimer: null,
+      polling: false,
+    }
+  },
+  computed: {
+    status () {
+      return this.row?.status || ''
+    },
+  },
+  watch: {
+    status: {
+      immediate: true,
+      handler (val) {
+        if (val === 'importing_model') {
+          this.startPoll()
+        } else {
+          this.stopPoll()
+          this.resetInstantModelCache()
+        }
+      },
+    },
+    'row.id' () {
+      if (this.status === 'importing_model') {
+        this.instantModelId = ''
+        this.startPoll()
+      }
+    },
+    row: {
+      deep: true,
+      handler () {
+        if (this.status !== 'importing_model') return
+        if (!this.polling) {
+          this.startPoll()
+        }
+      },
+    },
+  },
+  beforeDestroy () {
+    this.stopPoll()
+  },
+  methods: {
+    getInstantModelManager () {
+      if (!this._instantModelManager) {
+        this._instantModelManager = new this.$Manager('llm_instant_models')
+      }
+      return this._instantModelManager
+    },
+    resetInstantModelCache () {
+      this.instantModelId = ''
+      this.instantStatus = 'init'
+      this.progress = 0
+      this.progressRenderKey = 0
+    },
+    applyInstantModelSnapshot (im) {
+      if (!im) return
+      const nextStatus = im.status || 'init'
+      const nextProgress = im.progress ?? 0
+      if (im.id && im.id !== this.instantModelId) {
+        this.instantModelId = im.id
+      }
+      if (nextStatus !== this.instantStatus || nextProgress !== this.progress) {
+        this.instantStatus = nextStatus
+        this.progress = nextProgress
+        this.progressRenderKey += 1
+      }
+    },
+    async fetchInstantModelProgress () {
+      try {
+        const im = await fetchInstantModelForSku(
+          this.getInstantModelManager(),
+          this.row,
+          this.$store.getters.scope,
+        )
+        this.applyInstantModelSnapshot(im)
+      } catch (e) {
+        // ignore transient/cancelled errors during poll
+      }
+    },
+    scheduleNextPoll () {
+      if (this.pollTimer) {
+        clearTimeout(this.pollTimer)
+      }
+      this.pollTimer = setTimeout(() => {
+        this.pollTimer = null
+        this.runPollLoop()
+      }, POLL_INTERVAL_MS)
+    },
+    async runPollLoop () {
+      if (this.status !== 'importing_model') {
+        this.stopPoll()
+        return
+      }
+      this.polling = true
+      await this.fetchInstantModelProgress()
+      if (this.status === 'importing_model') {
+        this.scheduleNextPoll()
+      } else {
+        this.polling = false
+      }
+    },
+    startPoll () {
+      this.stopPoll()
+      this.polling = true
+      this.runPollLoop()
+    },
+    stopPoll () {
+      this.polling = false
+      if (this.pollTimer) {
+        clearTimeout(this.pollTimer)
+        this.pollTimer = null
+      }
+    },
+  },
+}
+</script>
+
+<style scoped lang="less">
+.llm-sku-import-status {
+  min-width: 0;
+  max-width: 100%;
+
+  &__sku {
+    margin-bottom: 2px;
+  }
+
+  &__progress {
+    max-width: 100%;
+
+    ::v-deep .instant-model-import-status {
+      max-width: 100%;
+    }
+
+    ::v-deep .instant-model-import-status__bar {
+      width: 100%;
+      max-width: 140px;
+      margin-left: 0;
+      margin-top: 2px;
+    }
+
+    ::v-deep .instant-model-import-status__status-after {
+      margin-top: 2px;
+    }
+  }
+}
+</style>

--- a/containers/Ai/views/llm-sku/components/LlmSkuMountedModels.vue
+++ b/containers/Ai/views/llm-sku/components/LlmSkuMountedModels.vue
@@ -1,0 +1,75 @@
+<template>
+  <div
+    v-if="hasContent"
+    :class="wrapperClass"
+    :title="displayTitle"
+    @click.stop>
+    <span v-if="showLabel" class="meta-label">{{ $t('aice.llm_instantmodel.menu') }}：</span>
+    <template v-if="mountedItems.length">
+      <template v-for="(item, idx) in mountedItems">
+        <list-body-cell-wrap
+          :key="item.id"
+          copy
+          hide-field
+          field="id"
+          :row="item"
+          :message="item.fullname">
+          <side-page-trigger
+            permission="llm_instant_models_get"
+            name="LlmInstantModelSidePage"
+            :id="item.id"
+            :vm="vm">
+            <span class="meta-ellipsis-text">{{ item.fullname }}</span>
+          </side-page-trigger>
+        </list-body-cell-wrap>
+        <span v-if="idx < mountedItems.length - 1" :key="`${item.id}-sep`">, </span>
+      </template>
+    </template>
+    <span v-else class="meta-ellipsis-text">{{ fallbackText }}</span>
+  </div>
+</template>
+
+<script>
+import { getSkuModelDisplayText } from '../utils/modelDisplay'
+
+export default {
+  name: 'LlmSkuMountedModels',
+  props: {
+    row: {
+      type: Object,
+      required: true,
+    },
+    vm: {
+      type: Object,
+      default: null,
+    },
+    showLabel: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  computed: {
+    mountedItems () {
+      const list = this.row?.mounted_model_details || []
+      return list.filter(v => v && v.id && v.fullname)
+    },
+    fallbackText () {
+      if (this.mountedItems.length) return ''
+      return getSkuModelDisplayText(this.row)
+    },
+    hasContent () {
+      return this.mountedItems.length > 0 || Boolean(this.fallbackText)
+    },
+    displayTitle () {
+      if (this.mountedItems.length) {
+        return this.mountedItems.map(v => v.fullname).join(', ')
+      }
+      return this.fallbackText
+    },
+    wrapperClass () {
+      if (!this.showLabel) return ''
+      return 'meta-row meta-row--copy meta-ellipsis'
+    },
+  },
+}
+</script>

--- a/containers/Ai/views/llm-sku/create/Form.vue
+++ b/containers/Ai/views/llm-sku/create/Form.vue
@@ -462,6 +462,15 @@ export default {
     const catalogNameInit = this.catalogSpec
       ? defaultNameFromSpec(this.catalogSpec, this.catalogSet, catalogLlmTypeInit)
       : null
+    const isCatalogImport = !!getCatalogSpecId(this.catalogSpec) && this.catalogSubmitType === 'import'
+    const catalogImportDeviceRules = isCatalogImport
+      ? [{
+        type: 'array',
+        required: true,
+        min: 1,
+        message: this.$t('common.tips.select', [this.$t('aice.devices')]),
+      }]
+      : []
     const typeLlmSpec = (llmSpec && (initialLlmTypeForSpec === 'vllm' || initialLlmTypeForSpec === 'sglang') && llmSpec[initialLlmTypeForSpec])
       ? llmSpec[initialLlmTypeForSpec]
       : {}
@@ -770,6 +779,7 @@ export default {
           'device',
           {
             initialValue: devices && devices.length > 0 ? devices.map(v => v.model) : [],
+            rules: catalogImportDeviceRules,
           },
         ],
         mounted_apps: [
@@ -899,6 +909,21 @@ export default {
       let base = LLM_TYPE_FORM_CONFIG[type] || []
       if (this.isCatalogMode) {
         base = base.filter(f => f.fieldKey !== 'mounted_models' && f.fieldKey !== 'preferred_model')
+      }
+      if (this.isCatalogMode && this.catalogSubmitType === 'import' && !base.some(f => f.fieldKey === 'device')) {
+        base = [
+          ...base,
+          {
+            fieldKey: 'device',
+            label: 'aice.devices',
+            component: 'base-select',
+            props: {
+              optionsKey: 'specList',
+              placeholderKey: 'aice.devices',
+              selectProps: { mode: 'multiple' },
+            },
+          },
+        ]
       }
       if (type !== 'vllm' && type !== 'sglang') return base
       const out = []

--- a/containers/Ai/views/llm-sku/mixins/columns.js
+++ b/containers/Ai/views/llm-sku/mixins/columns.js
@@ -1,11 +1,12 @@
 import { parseLlmRoute } from '@Ai/utils/llmRouteContext'
+import i18n from '@/locales'
 import {
   getNameDescriptionTableColumn,
   getProjectTableColumn,
   getTimeTableColumn,
   getPublicScopeTableColumn,
-  getStatusTableColumn,
 } from '@/utils/common/tableColumn'
+import LlmSkuImportStatus from '../components/LlmSkuImportStatus.vue'
 import {
   // getDeviceModelTableColumn,
   getAppNameTableColumn,
@@ -31,7 +32,17 @@ export default {
           )
         },
       }),
-      getStatusTableColumn({ statusModule: 'llmSku' }),
+      {
+        field: 'status',
+        title: i18n.t('common.status'),
+        sortable: true,
+        minWidth: 160,
+        slots: {
+          default: ({ row }) => {
+            return [this.$createElement(LlmSkuImportStatus, { props: { row } })]
+          },
+        },
+      },
       getCpuTableColumn(),
       getMemoryTableColumn(),
       getDiskTableColumn(),

--- a/containers/Ai/views/llm-sku/sidepage/Detail.vue
+++ b/containers/Ai/views/llm-sku/sidepage/Detail.vue
@@ -4,6 +4,7 @@
     :data="data"
     :base-info="baseInfo"
     :extra-info="extraInfo"
+    :hidden-keys="detailHiddenKeys"
     status-module="llmSku"
     resource="llm_skus" />
 </template>
@@ -11,6 +12,7 @@
 <script>
 import { parseLlmRoute } from '@Ai/utils/llmRouteContext'
 import WindowsMixin from '@/mixins/windows'
+import LlmSkuImportStatus from '../components/LlmSkuImportStatus.vue'
 import {
   getDeviceModelTableColumn,
   getAppNameTableColumn,
@@ -43,6 +45,15 @@ export default {
       credentialNamesMap: {},
       difyImageNamesMap: {},
       baseInfo: [
+        {
+          field: 'status',
+          title: this.$t('common.status'),
+          slots: {
+            default: ({ row }) => {
+              return [this.$createElement(LlmSkuImportStatus, { props: { row } })]
+            },
+          },
+        },
         getDeviceModelTableColumn(),
         getImageTableColumn({ vm: this }),
         ...(isDesktopType ? [getAppNameTableColumn()] : []),
@@ -135,6 +146,9 @@ export default {
     }
   },
   computed: {
+    detailHiddenKeys () {
+      return ['status']
+    },
     extraInfo () {
       return getLlmSpecSections(this)
     },

--- a/containers/Ai/views/llm-sku/utils/columns.js
+++ b/containers/Ai/views/llm-sku/utils/columns.js
@@ -1,6 +1,7 @@
 import { sizestr } from '@/utils/utils'
 import i18n from '@/locales'
 import { getSkuModelDisplayText } from './modelDisplay'
+import LlmSkuMountedModels from '../components/LlmSkuMountedModels.vue'
 
 export const getDeviceModelTableColumn = () => {
   return {
@@ -153,29 +154,21 @@ export const getLlmTypeTableColumn = (opts = {}) => {
 export const getLlmModelNameTableColumn = ({ vm = {} } = {}) => {
   return {
     field: 'mounted_models',
-    title: i18n.t('aice.model'),
+    title: i18n.t('aice.llm_instantmodel.menu'),
     formatter: ({ row }) => {
       const text = getSkuModelDisplayText(row)
       return text || '-'
     },
     slots: {
-      default: ({ row }, h) => {
-        if (row.mounted_model_details && row.mounted_model_details.length) {
-          const ret = []
-          row.mounted_model_details.forEach(v => {
-            ret.push(
-              <list-body-cell-wrap copy hideField={true} field='id' row={v} message={v.fullname}>
-                <side-page-trigger permission='llm_instant_models_get' name='LlmInstantModelSidePage' id={v.id} vm={vm}>{v.fullname}</side-page-trigger>
-              </list-body-cell-wrap>,
-            )
-          })
-          return ret
+      default: ({ row }) => {
+        if (!row.mounted_model_details?.length && !getSkuModelDisplayText(row)) {
+          return '-'
         }
-        const text = getSkuModelDisplayText(row)
-        if (text) {
-          return [h('span', text)]
-        }
-        return '-'
+        return [
+          vm.$createElement(LlmSkuMountedModels, {
+            props: { row, vm, showLabel: false },
+          }),
+        ]
       },
     },
   }

--- a/src/components/SidePageTrigger/config/index.js
+++ b/src/components/SidePageTrigger/config/index.js
@@ -187,6 +187,7 @@ export default {
   },
   LlmInstantModelSidePage: {
     resource: 'llm_instant_models',
+    getParams: () => ({ details: true }),
   },
   LlmSkuSidePage: {
     resource: 'llm_skus',

--- a/src/constants/expectStatus.js
+++ b/src/constants/expectStatus.js
@@ -650,8 +650,8 @@ export default {
   },
   llmSku: {
     success: ['ready', 'available'],
-    danger: ['create_failed', 'delete_failed'],
-    info: ['unknown'],
+    danger: ['create_failed', 'delete_failed', 'import_model_failed'],
+    info: ['unknown', 'importing_model'],
   },
   llmDeployment: {
     info: ['unknown', 'partial', 'start_delete', 'deleted', 'deploying', 'syncing', 'aiproxy_pending', 'aiproxy_syncing', 'aiproxy_partial'],

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1370,7 +1370,8 @@
       "available": "Available",
       "create_failed": "Create Failed",
       "delete_failed": "Delete Failed",
-      "importing_model": "Importing Model"
+      "importing_model": "Importing Model",
+      "import_model_failed": "Import Model Failed"
     }
   },
   "skuCategoryOptions": {

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -1385,7 +1385,8 @@
       "available": "利用可能",
       "create_failed": "作成に失敗しました",
       "delete_failed": "削除に失敗しました",
-      "importing_model": "モデルインポート中"
+      "importing_model": "モデルインポート中",
+      "import_model_failed": "モデルインポート失敗"
     }
   },
   "skuCategoryOptions": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1392,7 +1392,8 @@
       "available": "可用",
       "create_failed": "创建失败",
       "delete_failed": "删除失败",
-      "importing_model": "导入模型中"
+      "importing_model": "导入模型中",
+      "import_model_failed": "导入模型失败"
     }
   },
   "skuCategoryOptions": {


### PR DESCRIPTION
新增 InstantModelImportStatus 组件，在列表状态列与详情页展示导入中的进度条，并修正列表 steadyStatus 配置。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0