### PR TITLE
feat(ai): 隐藏 /llm 入口并重定向至部署，复用实例批量操作

### DIFF
--- a/containers/Ai/router/index.js
+++ b/containers/Ai/router/index.js
@@ -3,7 +3,6 @@ import i18n from '@/locales'
 import { isScopedPolicyMenuHidden } from '@/utils/scopedPolicy'
 import { featureMenuHiddenCheck } from '@/utils/auth'
 
-const Llm = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm')
 const LlmSku = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-sku')
 const LlmSkuCreate = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-sku/create/index')
 const LlmSkuImportFromModelSets = () => import(/* webpackChunkName: "k8s" */ /* webpackPrefetch: true */ '@Ai/views/llm-sku/import-from-model-sets')
@@ -165,24 +164,17 @@ export default {
           path: '/llm',
           meta: {
             label: i18n.t('aice.llm'),
-            hidden: (userInfo, menu) => {
-              if (isScopedPolicyMenuHidden('sub_hidden_menus.llm')) {
-                return true
-              }
-              return featureMenuHiddenCheck(menu)
-            },
+            hidden: () => true,
           },
           component: Layout,
           children: [
             {
-              name: 'LlmList',
               path: '',
-              component: Llm,
+              redirect: '/llm-deployment',
             },
             {
-              name: 'LlmCreate',
               path: 'create',
-              component: LlmCreate,
+              redirect: '/llm-deployment/create',
             },
           ],
         },

--- a/containers/Ai/utils/llmRouteContext.js
+++ b/containers/Ai/utils/llmRouteContext.js
@@ -69,6 +69,8 @@ export function parseLlmRoute (path = '') {
 
   let instanceListPath = '/llm'
   let instanceCreatePath = '/llm/create'
+  const deploymentListPath = '/llm-deployment'
+  const deploymentCreatePath = '/llm-deployment/create'
   let skuListPath = '/llm-sku'
   let skuCreatePath = '/llm-sku/create'
   let skuImportFromCommunityPath = ''
@@ -98,6 +100,8 @@ export function parseLlmRoute (path = '') {
     llmTypes,
     instanceListPath,
     instanceCreatePath,
+    deploymentListPath,
+    deploymentCreatePath,
     skuListPath,
     skuCreatePath,
     skuImportFromCommunityPath,

--- a/containers/Ai/views/llm-deployment/sidepage/InstancesList.vue
+++ b/containers/Ai/views/llm-deployment/sidepage/InstancesList.vue
@@ -2,27 +2,30 @@
   <page-list
     :list="list"
     :columns="columns"
-    :show-search="false" />
+    :group-actions="groupActions"
+    :single-actions="singleActions"
+    :show-searchbox="false"
+    :show-tag-filter="false" />
 </template>
 
 <script>
-import {
-  getLlmIpColumn,
-  getCpuTableColumn,
-  getMemoryTableColumn,
-  getDiskTableColumn,
-} from '@Ai/views/llm/utils/columns'
-import ListMixin from '@/mixins/list'
+import expectStatus from '@/constants/expectStatus'
 import WindowsMixin from '@/mixins/windows'
-import {
-  getNameDescriptionTableColumn,
-  getStatusTableColumn,
-  getTimeTableColumn,
-} from '@/utils/common/tableColumn'
+import ListMixin from '@/mixins/list'
+import ColumnsMixin from '@Ai/views/llm/mixins/columns'
+import SingleActionsMixin from '@Ai/views/llm/mixins/singleActions'
+import InstanceGroupActionsMixin from '@Ai/views/llm/mixins/instanceGroupActions'
 
 export default {
   name: 'LlmDeploymentInstancesList',
-  mixins: [ListMixin, WindowsMixin],
+  mixins: [
+    WindowsMixin,
+    ListMixin,
+    ColumnsMixin,
+    SingleActionsMixin,
+    InstanceGroupActionsMixin,
+  ],
+  inheritAttrs: false,
   props: {
     id: String,
     resId: String,
@@ -34,47 +37,65 @@ export default {
   data () {
     return {
       list: this.$list.createList(this, {
+        id: this.id || 'LlmDeploymentInstancesList',
         resource: 'llms',
-        getParams: {
-          llm_deployment: this.data.id,
-          details: true,
+        getParams: this.getParam,
+        steadyStatus: {
+          status: Object.values(expectStatus.server).flat(),
+          llm_status: Object.values(expectStatus.container).flat(),
         },
-        idKey: 'id',
+        fetchDataCb: (response) => {
+          this.enrichLlmRowsWithCmpInfo(response)
+        },
       }),
-      columns: [
-        getNameDescriptionTableColumn({
-          hideField: true,
-          slotCallback: row => {
-            return (
-              <side-page-trigger onTrigger={() => this.handleOpenSidepage(row)}>{row.name}</side-page-trigger>
-            )
-          },
-        }),
-        getStatusTableColumn({ statusModule: 'server' }),
-        getStatusTableColumn({ field: 'llm_status', statusModule: 'container', title: this.$t('aice.container_status') }),
-        getLlmIpColumn(),
-        getCpuTableColumn(),
-        getMemoryTableColumn(),
-        getDiskTableColumn(),
-        {
-          field: 'host',
-          title: this.$t('compute.text_111'),
-          showOverflow: 'title',
-          minWidth: 120,
-          formatter: ({ row }) => row.host || '-',
-        },
-        getTimeTableColumn(),
-      ],
     }
   },
+  computed: {
+    groupActions () {
+      return this.instanceGroupActions
+    },
+  },
   created () {
+    this.serverManager = new this.$Manager('servers')
     this.list.fetchData()
   },
   methods: {
+    getParam () {
+      return {
+        llm_deployment: this.data.id,
+        details: true,
+      }
+    },
+    async enrichLlmRowsWithCmpInfo (response) {
+      const rows = response?.data?.data
+      if (!Array.isArray(rows) || !rows.length) return
+      const params = {
+        scope: this.$store.getters.scope,
+      }
+      const patch = {}
+      await Promise.all(
+        rows.map(async (row) => {
+          if (!row.cmp_id) return
+          try {
+            const { data } = await this.serverManager.get({ id: row.cmp_id, params })
+            if (data) {
+              patch[row.id] = { cmp_info: data }
+            }
+          } catch (e) {
+            // 单行失败不影响列表
+          }
+        }),
+      )
+      if (this._isDestroyed) return
+      if (Object.keys(patch).length) {
+        this.list.updatesProperty(patch)
+      }
+    },
     handleOpenSidepage (row) {
       this.sidePageTriggerHandle(this, 'LlmSidePage', {
         id: row.id,
         resource: 'llms',
+        getParams: this.getParam,
       }, {
         list: this.list,
       })

--- a/containers/Ai/views/llm-deployment/sidepage/index.vue
+++ b/containers/Ai/views/llm-deployment/sidepage/index.vue
@@ -44,6 +44,7 @@ export default {
   components: {
     Detail,
     InstancesList,
+    'instances-list': InstancesList,
     AiproxyAccessPanel,
     ChatTest,
     Actions,

--- a/containers/Ai/views/llm/components/List.vue
+++ b/containers/Ai/views/llm/components/List.vue
@@ -1,12 +1,12 @@
 <template>
   <page-list
-    show-tag-filter
-    :show-searchbox="true"
+    :show-tag-filter="!embedded"
+    :show-searchbox="!embedded"
     :list="list"
     :columns="columns"
     :group-actions="groupActions"
     :single-actions="singleActions"
-    :export-data-options="exportDataOptions" />
+    :export-data-options="embedded ? undefined : exportDataOptions" />
 </template>
 
 <script>
@@ -26,12 +26,17 @@ import {
 import { LLM_TYPE_OPTIONS } from '../../llm-sku/constants/llmTypeConfig'
 import SingleActionsMixin from '../mixins/singleActions'
 import ColumnsMixin from '../mixins/columns'
+import InstanceGroupActionsMixin from '../mixins/instanceGroupActions'
 
 export default {
   name: 'PhoneList',
-  mixins: [WindowsMixin, ListMixin, ColumnsMixin, SingleActionsMixin],
+  mixins: [WindowsMixin, ListMixin, ColumnsMixin, SingleActionsMixin, InstanceGroupActionsMixin],
   props: {
     id: String,
+    embedded: {
+      type: Boolean,
+      default: false,
+    },
     getParams: {
       type: Object,
     },
@@ -103,202 +108,6 @@ export default {
           this.enrichLlmRowsWithCmpInfo(response)
         },
       }),
-      groupActions: [
-        {
-          label: this.$t('common.create'),
-          action: () => {
-            this.$router.push(this.llmRouteCtx.instanceCreatePath)
-          },
-          meta: () => {
-            return {
-              buttonType: 'primary',
-              validate: true,
-            }
-          },
-        },
-        // 开机
-        {
-          label: this.$t('compute.text_272'),
-          action: () => {
-            this.createDialog('LlmBatchConfirmDialog', {
-              data: this.list.selectedItems,
-              columns: this.columns,
-              onManager: this.onManager,
-              action: 'start',
-              actionText: this.$t('compute.text_272'),
-              steadyStatus: 'running',
-            })
-          },
-          meta: () => {
-            let ret = {
-              validate: true,
-              tooltip: null,
-            }
-            ret.validate = this.list.selectedItems.length > 0
-            if (!ret.validate) return ret
-            ret = this.$isValidateResourceLock(this.list.selectedItems, () => {
-              ret.validate = this.list.selectedItems.every(item => item.status === 'ready')
-              return ret
-            })
-            return ret
-          },
-          // hidden: () => this.$isScopedPolicyMenuHidden('vminstance_hidden_menus.server_perform_start'),
-        },
-        // 重启
-        {
-          label: this.$t('compute.text_274'),
-          permission: 'llms_perform_restart',
-          action: () => {
-            this.createDialog('LlmBatchConfirmDialog', {
-              data: this.list.selectedItems,
-              columns: this.columns,
-              onManager: this.onManager,
-              action: 'restart',
-              actionText: this.$t('compute.text_274'),
-              steadyStatus: 'running',
-            })
-          },
-          meta: () => {
-            let ret = {
-              validate: true,
-              tooltip: null,
-            }
-            ret.validate = this.list.selectedItems.length > 0
-            if (!ret.validate) return ret
-            ret = this.$isValidateResourceLock(this.list.selectedItems, () => {
-              ret.validate = this.list.selectedItems.every(item => ['running', 'stop_fail', 'ready'].includes(item.status))
-              return ret
-            })
-            return ret
-          },
-        },
-        // 同步状态
-        {
-          label: this.$t('common.text00043'),
-          action: () => {
-            this.onManager('batchPerformAction', {
-              steadyStatus: ['running', 'ready'],
-              managerArgs: {
-                action: 'syncstatus',
-              },
-            })
-          },
-          meta: () => {
-            return {
-              validate: this.list.selectedItems.length > 0,
-            }
-          },
-        },
-        /* 批量操作 */
-        {
-          label: this.$t('compute.text_275'),
-          actions: () => {
-            return [
-              // 更改项目
-              {
-                label: this.$t('compute.perform_change_owner', [this.$t('dictionary.project')]),
-                permission: 'llms_perform_public',
-                action: (obj) => {
-                  this.createDialog('ChangeOwenrDialog', {
-                    data: this.list.selectedItems,
-                    columns: this.columns,
-                    onManager: this.onManager,
-                    refresh: this.refresh,
-                    resource: 'llms',
-                  })
-                },
-                meta: () => {
-                  const ret = {
-                    validate: true,
-                    tooltip: null,
-                  }
-                  ret.validate = this.list.selectedItems.length > 0
-                  return ret
-                },
-              },
-              // 关机
-              {
-                label: this.$t('compute.text_273'),
-                permission: 'llms_perform_stop',
-                action: () => {
-                  this.createDialog('LlmBatchConfirmDialog', {
-                    data: this.list.selectedItems,
-                    columns: this.columns,
-                    onManager: this.onManager,
-                    action: 'stop',
-                    actionText: this.$t('compute.text_273'),
-                    steadyStatus: 'ready',
-                  })
-                },
-                meta: () => {
-                  let ret = {
-                    validate: true,
-                    tooltip: null,
-                  }
-                  ret.validate = this.list.selectedItems.length > 0
-                  if (!ret.validate) return ret
-                  ret = this.$isValidateResourceLock(this.list.selectedItems, () => {
-                    ret.validate = this.list.selectedItems.every(item => item.status === 'running')
-                    return ret
-                  })
-                  return ret
-                },
-                // hidden: () => this.$isScopedPolicyMenuHidden('vminstance_hidden_menus.server_perform_stop'),
-              },
-              // // 安装秒装应用
-              // {
-              //   label: this.$t('aice.instant_app.install'),
-              //   action: () => {
-              //     this.createDialog('PhoneAppInstallConfirmDialog', {
-              //       vm: this,
-              //       data: this.list.selectedItems,
-              //       columns: this.columns,
-              //       title: this.$t('aice.instant_app.install'),
-              //       name: this.$t('aice.instant_app'),
-              //       action: this.$t('aice.instant_app.install'),
-              //       actionText: this.$t('aice.instant_app.install'),
-              //     })
-              //   },
-              //   meta: () => {
-              //     let ret = {
-              //       validate: true,
-              //       tooltip: null,
-              //     }
-              //     ret.validate = this.list.selectedItems.length > 0
-              //     if (!ret.validate) return ret
-              //     ret = this.$isValidateResourceLock(this.list.selectedItems, () => {
-              //       ret.validate = this.list.selectedItems.every(item => ['running', 'ready'].includes(item.status))
-              //       return ret
-              //     })
-              //     return ret
-              //   },
-              // },
-              // 删除
-              {
-                label: this.$t('table.action.delete'),
-                action: () => {
-                  this.createDialog('DeleteResDialog', {
-                    vm: this,
-                    data: this.list.selectedItems,
-                    columns: this.columns,
-                    title: this.$t('table.action.delete'),
-                    name: this.$t('aice.llm'),
-                    onManager: this.onManager,
-                  })
-                },
-                meta: () => {
-                  const ret = { validate: this.list.selected.length }
-                  if (this.list.selectedItems.some(item => !item.can_delete)) {
-                    ret.validate = false
-                    return ret
-                  }
-                  return ret
-                },
-              },
-            ]
-          },
-        },
-      ],
     }
   },
   computed: {
@@ -337,11 +146,31 @@ export default {
         ],
       }
     },
+    groupActions () {
+      if (this.embedded) {
+        return this.instanceGroupActions
+      }
+      return [
+        {
+          label: this.$t('common.create'),
+          action: () => {
+            this.$router.push(this.llmRouteCtx.instanceCreatePath)
+          },
+          meta: () => ({
+            buttonType: 'primary',
+            validate: true,
+          }),
+        },
+        ...this.instanceGroupActions,
+      ]
+    },
   },
   created () {
     this.$hM = new this.$Manager('hosts')
     this.serverManager = new this.$Manager('servers')
-    this.initSidePageTab('detail')
+    if (!this.embedded) {
+      this.initSidePageTab('detail')
+    }
     this.list.fetchData()
   },
   methods: {

--- a/containers/Ai/views/llm/create.vue
+++ b/containers/Ai/views/llm/create.vue
@@ -854,6 +854,12 @@ export default {
       if (this.isApplyType) return this.$t('aice.app_llm_create')
       return this.$t('aice.llm_create')
     },
+    instanceRedirectListPath () {
+      if (this.llmRouteCtx.isInferenceType) {
+        return this.llmRouteCtx.deploymentListPath
+      }
+      return this.llmRouteCtx.instanceListPath
+    },
     llmTypeLabel () {
       if (this.isDesktopType) return this.$t('aice.llm_type')
       if (this.isApplyType) return this.$t('aice.llm_type.app')
@@ -1660,7 +1666,7 @@ export default {
           data,
         })
         this.$message.success(this.$t('common.success'))
-        this.$router.push(this.llmRouteCtx.instanceListPath)
+        this.$router.push(this.instanceRedirectListPath)
       } catch (error) {
         throw error
       } finally {
@@ -1668,7 +1674,7 @@ export default {
       }
     },
     handleCancel () {
-      this.$router.push(this.llmRouteCtx.instanceListPath)
+      this.$router.push(this.instanceRedirectListPath)
     },
   },
 }

--- a/containers/Ai/views/llm/mixins/instanceGroupActions.js
+++ b/containers/Ai/views/llm/mixins/instanceGroupActions.js
@@ -1,0 +1,153 @@
+export default {
+  data () {
+    return {
+      instanceGroupActions: [
+        {
+          label: this.$t('compute.text_272'),
+          action: () => {
+            this.createDialog('LlmBatchConfirmDialog', {
+              data: this.list.selectedItems,
+              columns: this.columns,
+              onManager: this.onManager,
+              action: 'start',
+              actionText: this.$t('compute.text_272'),
+              steadyStatus: 'running',
+            })
+          },
+          meta: () => {
+            let ret = {
+              validate: true,
+              tooltip: null,
+            }
+            ret.validate = this.list.selectedItems.length > 0
+            if (!ret.validate) return ret
+            ret = this.$isValidateResourceLock(this.list.selectedItems, () => {
+              ret.validate = this.list.selectedItems.every(item => item.status === 'ready')
+              return ret
+            })
+            return ret
+          },
+        },
+        {
+          label: this.$t('compute.text_274'),
+          permission: 'llms_perform_restart',
+          action: () => {
+            this.createDialog('LlmBatchConfirmDialog', {
+              data: this.list.selectedItems,
+              columns: this.columns,
+              onManager: this.onManager,
+              action: 'restart',
+              actionText: this.$t('compute.text_274'),
+              steadyStatus: 'running',
+            })
+          },
+          meta: () => {
+            let ret = {
+              validate: true,
+              tooltip: null,
+            }
+            ret.validate = this.list.selectedItems.length > 0
+            if (!ret.validate) return ret
+            ret = this.$isValidateResourceLock(this.list.selectedItems, () => {
+              ret.validate = this.list.selectedItems.every(item => ['running', 'stop_fail', 'ready'].includes(item.status))
+              return ret
+            })
+            return ret
+          },
+        },
+        {
+          label: this.$t('common.text00043'),
+          action: () => {
+            this.onManager('batchPerformAction', {
+              steadyStatus: ['running', 'ready'],
+              managerArgs: {
+                action: 'syncstatus',
+              },
+            })
+          },
+          meta: () => {
+            return {
+              validate: this.list.selectedItems.length > 0,
+            }
+          },
+        },
+        {
+          label: this.$t('compute.text_275'),
+          actions: () => {
+            return [
+              {
+                label: this.$t('compute.perform_change_owner', [this.$t('dictionary.project')]),
+                permission: 'llms_perform_public',
+                action: () => {
+                  this.createDialog('ChangeOwenrDialog', {
+                    data: this.list.selectedItems,
+                    columns: this.columns,
+                    onManager: this.onManager,
+                    refresh: this.refresh,
+                    resource: 'llms',
+                  })
+                },
+                meta: () => {
+                  const ret = {
+                    validate: true,
+                    tooltip: null,
+                  }
+                  ret.validate = this.list.selectedItems.length > 0
+                  return ret
+                },
+              },
+              {
+                label: this.$t('compute.text_273'),
+                permission: 'llms_perform_stop',
+                action: () => {
+                  this.createDialog('LlmBatchConfirmDialog', {
+                    data: this.list.selectedItems,
+                    columns: this.columns,
+                    onManager: this.onManager,
+                    action: 'stop',
+                    actionText: this.$t('compute.text_273'),
+                    steadyStatus: 'ready',
+                  })
+                },
+                meta: () => {
+                  let ret = {
+                    validate: true,
+                    tooltip: null,
+                  }
+                  ret.validate = this.list.selectedItems.length > 0
+                  if (!ret.validate) return ret
+                  ret = this.$isValidateResourceLock(this.list.selectedItems, () => {
+                    ret.validate = this.list.selectedItems.every(item => item.status === 'running')
+                    return ret
+                  })
+                  return ret
+                },
+              },
+              {
+                label: this.$t('table.action.delete'),
+                action: () => {
+                  this.createDialog('DeleteResDialog', {
+                    vm: this,
+                    data: this.list.selectedItems,
+                    columns: this.columns,
+                    title: this.$t('table.action.delete'),
+                    name: this.$t('aice.llm'),
+                    onManager: this.onManager,
+                  })
+                },
+                meta: () => {
+                  const ret = { validate: this.list.selected.length }
+                  if (this.list.selectedItems.some(item => !item.can_delete)) {
+                    ret.validate = false
+                    return ret
+                  }
+                  return ret
+                },
+              },
+            ]
+          },
+        },
+      ],
+    }
+  },
+}


### PR DESCRIPTION
将 /llm 菜单隐藏并重定向到 /llm-deployment；部署详情实例列表复用
LLM 列定义与批量操作 mixin；推理类型创建完成后跳转到部署列表。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0