### PR TITLE
feat(ai): 桌面模板可选 GPU 并调整推理默认类型

### DIFF
--- a/containers/Ai/sections/LlmGpuDevicesEditor.vue
+++ b/containers/Ai/sections/LlmGpuDevicesEditor.vue
@@ -1,7 +1,8 @@
 <!--
-  GPU 型号 + 共享模式 + 数量编辑，用于推理模板创建/编辑。
+  GPU 型号 + 共享模式 + 数量编辑，用于推理/桌面模板创建/编辑。
   HAMI 时可选手动显存（memory_mb）；留空则建 Pod 时回退模型估算 claim。
   local_path 场景下可通过 requireHamiMemoryMb 强制必填。
+  allowEmpty 为 true 时（如桌面模板）默认不展示空行，仅通过「添加 GPU」再填。
 -->
 <template>
   <div class="llm-gpu-devices-editor">
@@ -48,7 +49,7 @@
         <span class="llm-gpu-devices-editor__unit">MB</span>
       </template>
       <a-button
-        v-if="innerRows.length > 1"
+        v-if="canRemoveRow"
         shape="circle"
         icon="minus"
         size="small"
@@ -72,6 +73,7 @@ import {
   createEmptyDeviceRow,
   normalizeDeviceRows,
   LLM_SHARING_MODE_VALUES,
+  DEFAULT_SHARING_MODE,
   resolveSharingMode,
   listVendorsForSharingMode,
   buildModelSelectEntries,
@@ -102,6 +104,18 @@ export default {
       type: Boolean,
       default: false,
     },
+    allowEmpty: {
+      type: Boolean,
+      default: false,
+    },
+    sharingModeValues: {
+      type: Array,
+      default: null,
+    },
+    defaultSharingMode: {
+      type: String,
+      default: '',
+    },
   },
   data () {
     return {
@@ -112,8 +126,21 @@ export default {
     podPciModels () {
       return getPodPciModelTypes(this.$store.getters.capability)
     },
+    resolvedSharingModeValues () {
+      if (Array.isArray(this.sharingModeValues) && this.sharingModeValues.length) {
+        return this.sharingModeValues
+      }
+      return LLM_SHARING_MODE_VALUES
+    },
+    resolvedDefaultSharingMode () {
+      const preferred = String(this.defaultSharingMode || '').trim()
+      if (preferred && this.resolvedSharingModeValues.includes(preferred)) {
+        return preferred
+      }
+      return this.resolvedSharingModeValues[0] || DEFAULT_SHARING_MODE
+    },
     sharingModeOptions () {
-      return LLM_SHARING_MODE_VALUES.map(value => ({
+      return this.resolvedSharingModeValues.map(value => ({
         key: value,
         label: this.$t(SHARING_MODE_I18N[value] || value),
       }))
@@ -147,7 +174,10 @@ export default {
         : this.$t('aice.devices.memory_mb.help')
     },
     innerRows () {
-      return normalizeDeviceRows(this.value)
+      return this.resolveRows(this.value)
+    },
+    canRemoveRow () {
+      return this.allowEmpty ? this.innerRows.length >= 1 : this.innerRows.length > 1
     },
     showVendorField () {
       return shouldShowVendorSelect(this.podPciModels)
@@ -157,7 +187,7 @@ export default {
     value: {
       immediate: true,
       handler (val) {
-        const rows = normalizeDeviceRows(val)
+        const rows = this.resolveRows(val)
         while (this.rowKeys.length < rows.length) {
           this.rowKeys.push(uuid())
         }
@@ -165,6 +195,7 @@ export default {
           this.rowKeys.pop()
         }
         this.maybeAutoFillVendors(rows)
+        this.maybeCoerceSharingModes(rows)
       },
     },
     podPciModels () {
@@ -172,6 +203,46 @@ export default {
     },
   },
   methods: {
+    emptyRow () {
+      return createEmptyDeviceRow(this.resolvedDefaultSharingMode)
+    },
+    coerceSharingMode (mode) {
+      const raw = String(mode || '').trim()
+      if (this.resolvedSharingModeValues.includes(raw)) return raw
+      return this.resolvedDefaultSharingMode
+    },
+    resolveRows (rows) {
+      if (this.allowEmpty && (!Array.isArray(rows) || rows.length === 0)) {
+        return []
+      }
+      return normalizeDeviceRows(rows).map((row) => {
+        const sharingMode = this.coerceSharingMode(row.sharing_mode)
+        const next = { ...row, sharing_mode: sharingMode }
+        if (sharingMode !== 'HAMI') {
+          delete next.memory_mb
+        }
+        return next
+      })
+    },
+    maybeCoerceSharingModes (rows) {
+      if (!Array.isArray(rows) || rows.length === 0) return
+      let changed = false
+      const next = rows.map((row) => {
+        const sharingMode = this.coerceSharingMode(row.sharing_mode)
+        if (sharingMode === row.sharing_mode && (sharingMode === 'HAMI' || !row.memory_mb)) {
+          return row
+        }
+        changed = true
+        const coerced = { ...row, sharing_mode: sharingMode }
+        if (sharingMode !== 'HAMI') {
+          delete coerced.memory_mb
+        }
+        return coerced
+      })
+      if (changed) {
+        this.emitRows(next)
+      }
+    },
     maybeAutoFillVendors (rows) {
       if (!Array.isArray(rows) || rows.length === 0) return
       let changed = false
@@ -230,12 +301,14 @@ export default {
       return entries
     },
     emitRows (rows) {
-      const normalized = normalizeDeviceRows(rows)
+      const normalized = this.allowEmpty && (!Array.isArray(rows) || rows.length === 0)
+        ? []
+        : this.resolveRows(rows.length ? rows : (this.allowEmpty ? [] : [this.emptyRow()]))
       this.$emit('input', normalized)
       this.$emit('change', normalized)
     },
     onSharingModeChange (index, sharingMode) {
-      const mode = resolveSharingMode(sharingMode)
+      const mode = this.coerceSharingMode(sharingMode)
       const rows = this.innerRows.map((row, i) => {
         if (i !== index) return { ...row }
         const next = { ...row, sharing_mode: mode }
@@ -320,7 +393,7 @@ export default {
     },
     addRow () {
       this.rowKeys.push(uuid())
-      const newRow = createEmptyDeviceRow()
+      const newRow = this.emptyRow()
       const vendors = listVendorsForSharingMode(this.podPciModels, newRow.sharing_mode)
       if (vendors.length === 1) {
         newRow.vendor = vendors[0]
@@ -328,10 +401,14 @@ export default {
       this.emitRows([...this.innerRows, newRow])
     },
     removeRow (index) {
-      if (this.innerRows.length <= 1) return
+      if (!this.allowEmpty && this.innerRows.length <= 1) return
       this.rowKeys.splice(index, 1)
       const rows = this.innerRows.filter((_, i) => i !== index)
-      this.emitRows(rows.length ? rows : [createEmptyDeviceRow()])
+      if (rows.length === 0 && this.allowEmpty) {
+        this.emitRows([])
+        return
+      }
+      this.emitRows(rows.length ? rows : [this.emptyRow()])
     },
   },
 }

--- a/containers/Ai/utils/deviceFormUtils.js
+++ b/containers/Ai/utils/deviceFormUtils.js
@@ -10,6 +10,10 @@ export const DEFAULT_DEV_TYPE = 'GPU'
 /** LLM-oriented sharing modes (subset of compute isolated-device modes). */
 export const LLM_SHARING_MODE_VALUES = ['HAMI', 'UNLIMITED', 'MPS', 'EXCLUSIVE']
 
+/** Desktop SKU: no HAMI/MPS; only exclusive or unlimited share. */
+export const DESKTOP_SHARING_MODE_VALUES = ['UNLIMITED', 'EXCLUSIVE']
+export const DESKTOP_DEFAULT_SHARING_MODE = 'UNLIMITED'
+
 const LEGACY_DEV_TYPE_TO_SHARING = {
   NVIDIA_GPU: 'EXCLUSIVE',
   NVIDIA_MPS: 'MPS',
@@ -343,8 +347,9 @@ export function deviceRowsHaveContent (rows) {
   return Array.isArray(rows) && rows.some(row => String(row?.model || '').trim())
 }
 
-export function createEmptyDeviceRow () {
-  return { model: undefined, count: 1, sharing_mode: DEFAULT_SHARING_MODE }
+export function createEmptyDeviceRow (sharingMode = DEFAULT_SHARING_MODE) {
+  const mode = String(sharingMode || '').trim() || DEFAULT_SHARING_MODE
+  return { model: undefined, count: 1, sharing_mode: mode }
 }
 
 export function normalizeDeviceRows (rows) {

--- a/containers/Ai/utils/llmRouteContext.js
+++ b/containers/Ai/utils/llmRouteContext.js
@@ -1,4 +1,4 @@
-const INFERENCE_LLM_TYPES = ['vllm', 'ollama', 'sglang']
+const INFERENCE_LLM_TYPES = ['vllm', 'sglang', 'ollama']
 const APP_LLM_TYPES = ['dify', 'openclaw', 'comfyui', 'hermes-agent']
 const DESKTOP_LLM_TYPES = ['desktop']
 

--- a/containers/Ai/views/llm-image/dialogs/create.vue
+++ b/containers/Ai/views/llm-image/dialogs/create.vue
@@ -54,10 +54,12 @@ export default {
     const data = this.params.type === 'edit' ? this.params.data[0] : {}
     const imageRouteCtx = parseLlmImageRoute(this.$route.path)
     const allowedTypes = getAllowedImageLlmTypes(this.$route.path)
-    const filteredOptions = LLM_TYPE_OPTIONS.filter(opt => allowedTypes.includes(opt.id))
+    const filteredOptions = allowedTypes
+      .map(id => LLM_TYPE_OPTIONS.find(opt => opt.id === id))
+      .filter(Boolean)
     const fallbackLlmType = imageRouteCtx.isDesktopImageRoute
       ? 'desktop'
-      : (imageRouteCtx.isAgentImageRoute ? 'openclaw' : 'ollama')
+      : (imageRouteCtx.isAgentImageRoute ? 'openclaw' : 'vllm')
     const defaultLlmType = (filteredOptions[0] && filteredOptions[0].id) || allowedTypes[0] || fallbackLlmType
     return {
       loading: false,
@@ -88,8 +90,9 @@ export default {
   computed: {
     llmTypeOptions () {
       const allowedTypes = getAllowedImageLlmTypes(this.$route.path)
-      return LLM_TYPE_OPTIONS
-        .filter(opt => allowedTypes.includes(opt.id))
+      return allowedTypes
+        .map(id => LLM_TYPE_OPTIONS.find(opt => opt.id === id))
+        .filter(Boolean)
         .map(opt => ({ id: opt.id, name: this.$t(opt.name) }))
     },
     llmTypeName () {

--- a/containers/Ai/views/llm-sku/components/LlmSkuGrid.vue
+++ b/containers/Ai/views/llm-sku/components/LlmSkuGrid.vue
@@ -90,7 +90,7 @@
               {{ $t('aice.model') }}：{{ mountedModelText(item) }}
             </div>
             <div
-              v-if="!isApplyType && !isDesktopType && deviceText(item)"
+              v-if="!isApplyType && deviceText(item)"
               class="meta-row meta-ellipsis"
               :title="deviceText(item)">
               {{ $t('aice.device') }}：{{ deviceText(item) }}

--- a/containers/Ai/views/llm-sku/create/Form.vue
+++ b/containers/Ai/views/llm-sku/create/Form.vue
@@ -145,7 +145,10 @@
           :label="$t(field.label)">
           <llm-gpu-devices-editor
             v-decorator="decorators[field.fieldKey]"
-            :require-hami-memory-mb="isLocalPathSku" />
+            :require-hami-memory-mb="isLocalPathSku"
+            :allow-empty="!isDeviceRequired"
+            :sharing-mode-values="deviceSharingModeValues"
+            :default-sharing-mode="deviceDefaultSharingMode" />
         </a-form-item>
         <a-form-item v-else-if="field.component === 'input-number'" :key="field.fieldKey" :label="$t(field.label)">
           <a-input-number
@@ -451,6 +454,8 @@ import {
   getPodPciModelTypes,
   isValidDeviceRows,
   resolveSharingMode,
+  DESKTOP_SHARING_MODE_VALUES,
+  DESKTOP_DEFAULT_SHARING_MODE,
 } from '@Ai/utils/deviceFormUtils'
 import {
   formValuesToBackendParameters,
@@ -563,7 +568,15 @@ export default {
     const isCatalogImport = !!getCatalogSpecId(this.catalogSpec) && this.catalogSubmitType === 'import'
     const isLocalPathImport = this.importMode === 'local_path'
     const deviceRowsInit = aggregateDevicesToRows(devices)
-    const deviceInitialValue = deviceRowsInit.length ? deviceRowsInit : [createEmptyDeviceRow()]
+    const deviceFieldInit = (LLM_TYPE_FORM_CONFIG[initialLlmTypeForSpec] || []).find(f => f.fieldKey === 'device')
+    const isLocalPathSkuInit = isLocalPathImport || (this.mode === 'edit' && String(data?.source || '').trim() === 'local_path')
+    const hasInjectedDeviceInit = (isCatalogImport && !isApplyType && !isDesktopType) || isLocalPathSkuInit
+    const deviceRequiredInit = !!(deviceFieldInit?.rules?.some(r => r.required) || hasInjectedDeviceInit || isCatalogImport || isLocalPathImport)
+    const deviceInitialValue = deviceRowsInit.length
+      ? deviceRowsInit
+      : (deviceRequiredInit
+        ? [createEmptyDeviceRow(isDesktopType ? DESKTOP_DEFAULT_SHARING_MODE : undefined)]
+        : [])
     const typeLlmSpec = (llmSpec && (initialLlmTypeForSpec === 'vllm' || initialLlmTypeForSpec === 'sglang') && llmSpec[initialLlmTypeForSpec])
       ? llmSpec[initialLlmTypeForSpec]
       : {}
@@ -1050,6 +1063,21 @@ export default {
       const source = this.editData?.source ?? this.form?.fd?.source
       return String(source || '').trim() === 'local_path'
     },
+    isDeviceRequired () {
+      const type = (this.isCatalogMode || this.isLocalPathImportMode)
+        ? this.catalogLlmType
+        : (this.form?.fd?.llm_type)
+      const field = (LLM_TYPE_FORM_CONFIG[type] || []).find(f => f.fieldKey === 'device')
+      const hasInjectedDevice = (this.isCatalogMode && this.catalogSubmitType === 'import' && !this.isApplyType && !this.isDesktopType) || this.isLocalPathSku
+      const isCatalogImport = this.isCatalogMode && this.catalogSubmitType === 'import'
+      return !!(field?.rules?.some(r => r.required) || hasInjectedDevice || isCatalogImport || this.isLocalPathImportMode)
+    },
+    deviceSharingModeValues () {
+      return this.isDesktopType ? DESKTOP_SHARING_MODE_VALUES : null
+    },
+    deviceDefaultSharingMode () {
+      return this.isDesktopType ? DESKTOP_DEFAULT_SHARING_MODE : ''
+    },
     localPathMountPreview () {
       if (!this.isLocalPathImportMode) return null
       const path = String(this.form.fd.local_path || '').trim()
@@ -1396,7 +1424,12 @@ export default {
         if ((effectiveLlmType === 'vllm' || effectiveLlmType === 'sglang') && key === 'preferred_model') return
         if (key === 'device') {
           const expanded = expandRowsToDevices(v, this.podPciModels)
-          if (expanded.length) data.devices = expanded
+          if (expanded.length) {
+            data.devices = expanded
+          } else if (this.isEditMode) {
+            // 编辑时清空 GPU 需显式传空数组，否则后端保留原 devices
+            data.devices = []
+          }
         } else {
           data[key] = v
         }


### PR DESCRIPTION
- LlmGpuDevicesEditor 支持 allowEmpty，桌面等场景可不填 GPU
- 推理镜像/套餐默认类型改为 vllm，类型选项按路由顺序展示
- 桌面 SKU 列表展示 GPU 信息；编辑清空 GPU 时显式提交空数组

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
