### PR TITLE
feat(ai): 创建推理部署前增加套餐调度检查

### DIFF
--- a/containers/Ai/locales/en.json
+++ b/containers/Ai/locales/en.json
@@ -468,6 +468,8 @@
   "aice.container_status": "Container Status",
   "aice.llm_deployment": "Inference Deployment",
   "aice.llm_deployment_create": "Create Inference Deployment",
+  "aice.llm_deployment.create.schedulable_check.failed": "Scheduling check failed",
+  "aice.llm_deployment.create.schedulable_check.title": "Unable to create inference deployment",
   "aice.llm_deployment.replicas": "Replicas",
   "aice.llm_deployment.backend": "Backend",
   "aice.llm_deployment.backend_version": "Backend Version",

--- a/containers/Ai/locales/ja-JP.json
+++ b/containers/Ai/locales/ja-JP.json
@@ -467,6 +467,8 @@
   "aice.container_status": "コンテナ状態",
   "aice.llm_deployment": "推論デプロイ",
   "aice.llm_deployment_create": "推論デプロイ作成",
+  "aice.llm_deployment.create.schedulable_check.failed": "スケジューリングチェックに失敗しました",
+  "aice.llm_deployment.create.schedulable_check.title": "推論デプロイを作成できません",
   "aice.llm_deployment.replicas": "レプリカ数",
   "aice.llm_deployment.backend": "バックエンド",
   "aice.llm_deployment.backend_version": "バックエンドバージョン",

--- a/containers/Ai/locales/zh-CN.json
+++ b/containers/Ai/locales/zh-CN.json
@@ -471,6 +471,8 @@
   "aice.container_status": "容器状态",
   "aice.llm_deployment": "推理部署",
   "aice.llm_deployment_create": "创建推理部署",
+  "aice.llm_deployment.create.schedulable_check.failed": "调度检查未通过",
+  "aice.llm_deployment.create.schedulable_check.title": "无法创建推理部署",
   "aice.llm_deployment.replicas": "副本数",
   "aice.llm_deployment.backend": "后端引擎",
   "aice.llm_deployment.backend_version": "后端版本",

--- a/containers/Ai/utils/skuSchedulableCheck.js
+++ b/containers/Ai/utils/skuSchedulableCheck.js
@@ -1,0 +1,61 @@
+import i18n from '@/locales'
+import { FORECAST_FILTERS_MAP } from '@Compute/constants'
+
+function asArray (value) {
+  if (!value) return []
+  if (Array.isArray(value)) return value
+  return [value]
+}
+
+/**
+ * POST /llm_skus/{id}/schedulable-check
+ */
+export function checkSkuSchedulable (manager, skuId) {
+  return manager.performAction({
+    id: skuId,
+    action: 'schedulable-check',
+    data: {},
+  })
+}
+
+/**
+ * Map schedulable-check / forecast payload into SideErrors shape.
+ */
+export function getSchedulableCheckErrors (data = {}) {
+  const candidates = asArray(data.filtered_candidates)
+  const errors = []
+  if (candidates.length > 0) {
+    candidates.forEach((item) => {
+      const hostName = item.name || item.host_name || item.id || ''
+      let message = hostName
+        ? `${i18n.t('dictionary.host')}【${hostName}】`
+        : ''
+      const filterMapItem = FORECAST_FILTERS_MAP[item.filter_name]
+      if (filterMapItem) {
+        message += filterMapItem
+      } else if (item.filter_name) {
+        message += i18n.t('compute.text_1325', [item.filter_name])
+      } else if (!message) {
+        message = data.reason || i18n.t('aice.llm_deployment.create.schedulable_check.failed')
+      }
+      errors.push({
+        message,
+        children: asArray(item.reasons),
+      })
+    })
+  } else {
+    errors.push({
+      message: data.reason || i18n.t('aice.llm_deployment.create.schedulable_check.failed'),
+    })
+  }
+  const notAllowReasons = asArray(data.not_allow_reasons)
+  if (!notAllowReasons.length && data.reason) {
+    notAllowReasons.push(data.reason)
+  }
+  return {
+    errors,
+    allow_count: data.allow_count || data.qualified_hosts || 0,
+    req_count: data.req_count || 1,
+    not_allow_reasons: notAllowReasons,
+  }
+}

--- a/containers/Ai/views/llm-deployment/create/index.vue
+++ b/containers/Ai/views/llm-deployment/create/index.vue
@@ -58,6 +58,10 @@
       <template v-slot:right>
         <a-button type="primary" :loading="loading" @click="handleSubmit">{{ $t('common.create') }}</a-button>
         <a-button class="ml-2" @click="handleCancel">{{ $t('common.cancel') }}</a-button>
+        <side-errors
+          :error-title="$t('aice.llm_deployment.create.schedulable_check.title')"
+          :errors="errors"
+          @update:errors="errors = {}" />
       </template>
     </page-footer>
   </div>
@@ -69,14 +73,16 @@ import ServerNetwork from '@Compute/sections/ServerNetwork'
 import { NETWORK_OPTIONS_MAP } from '@Compute/constants'
 import LlmSkuSelect from '@Ai/sections/LlmSkuSelect'
 import { normalizePreferHosts } from '@Ai/utils/localPathImport'
+import { checkSkuSchedulable, getSchedulableCheckErrors } from '@Ai/utils/skuSchedulableCheck'
 import NameRepeated from '@/sections/NameRepeated'
+import SideErrors from '@/sections/SideErrors'
 import { Manager } from '@/utils/manager'
 import { uuid } from '@/utils/utils'
 import validateForm from '@/utils/validate'
 
 export default {
   name: 'LlmDeploymentCreate',
-  components: { LlmSkuSelect, ServerNetwork, NameRepeated },
+  components: { LlmSkuSelect, ServerNetwork, NameRepeated, SideErrors },
   provide () {
     return {
       form: this.form,
@@ -86,6 +92,7 @@ export default {
     return {
       loading: false,
       selectedSkuDetail: null,
+      errors: {},
       form: {
         fc: this.$form.createForm(this, {
           onValuesChange: (props, values) => {
@@ -244,6 +251,7 @@ export default {
       }
     },
     handleSkuChange (skuId) {
+      this.errors = {}
       this.loadSkuDetail(skuId)
     },
     applyFromSku (skuId) {
@@ -301,6 +309,12 @@ export default {
       try {
         const values = await this.form.fc.validateFields()
         this.loading = true
+        this.errors = {}
+        const { data: check } = await checkSkuSchedulable(this.skuManager, values.llm_sku_id)
+        if (!check.schedulable) {
+          this.errors = getSchedulableCheckErrors(check)
+          return
+        }
         const payload = this.buildPayload(values)
         await this.manager.create({ data: payload })
         this.$message.success(this.$t('common.success'))

--- a/src/constants/permission.js
+++ b/src/constants/permission.js
@@ -1537,6 +1537,7 @@ export const PERMISSION = {
   llm_skus_perform_syncstatus: ['llm', 'llm_skus', 'perform', 'syncstatus'],
   llm_skus_perform_change_owner: ['llm', 'llm_skus', 'perform', 'change-owner'],
   llm_skus_perform_public: ['llm', 'llm_skus', 'perform', 'public'],
+  'llm_skus_perform_schedulable-check': ['llm', 'llm_skus', 'perform', 'schedulable-check'],
 
   llm_images_list: ['llm', 'llm_images', 'list'],
   llm_images_get: ['llm', 'llm_images', 'get'],


### PR DESCRIPTION
提交前调用 schedulable-check，不可调度时在侧栏展示失败原因，避免创建后才发现无法调度。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0.4