### PR TITLE
feat(ai): rewrite aiproxy URL to same-origin proxy and improve catalog import

### DIFF
--- a/containers/Ai/sections/Chat/index.vue
+++ b/containers/Ai/sections/Chat/index.vue
@@ -162,6 +162,7 @@ import {
   isPlaceholderApiKey,
   resolveAiproxyAnthropicMessagesUrl,
   resolveAiproxyChatCompletionsUrl,
+  rewriteAiproxyUrlForBrowser,
 } from '@Ai/utils/aiproxyEndpoint'
 import {
   appendAnthropicStreamLine,
@@ -532,12 +533,15 @@ export default {
 
       this.anthropicStreamState = {}
 
-      const response = await fetch(url, {
+      const apiBase = this.$http.defaults.baseURL || process.env.VUE_APP_BASE_API || '/api'
+      const fetchUrl = rewriteAiproxyUrlForBrowser(url, apiBase)
+      const response = await fetch(fetchUrl, {
         method: 'POST',
         headers: {
           Accept: 'text/event-stream',
           ...headers,
         },
+        credentials: 'include',
         body: JSON.stringify(requestBody),
         signal: this.abortController.signal,
       })

--- a/containers/Ai/utils/aiproxyEndpoint.js
+++ b/containers/Ai/utils/aiproxyEndpoint.js
@@ -7,6 +7,31 @@ export function normalizeBaseUrl (url) {
   return raw.replace(/\/+$/, '')
 }
 
+/**
+ * Rewrite a public aiproxy inference URL to the same-origin apigateway
+ * reverse proxy so the browser does not hit an untrusted TLS cert on
+ * access_address. Only rewrites paths under /ai/.
+ *
+ * https://host/ai/openai/v1/chat/completions
+ *   -> /api/s/aiproxy/ai/openai/v1/chat/completions
+ */
+export function rewriteAiproxyUrlForBrowser (url, apiBase = '') {
+  const raw = String(url || '').trim()
+  if (!raw) return ''
+  let parsed
+  try {
+    parsed = new URL(raw, 'http://localhost')
+  } catch (e) {
+    return raw
+  }
+  const pathname = parsed.pathname || ''
+  if (!/^\/ai\//i.test(pathname)) {
+    return raw
+  }
+  const base = normalizeBaseUrl(apiBase) || '/api'
+  return `${base}/s/aiproxy${pathname}${parsed.search || ''}`
+}
+
 export function buildOpenAIBaseUrl (baseUrl) {
   const base = normalizeBaseUrl(baseUrl)
   if (!base) return ''

--- a/containers/Ai/views/llm-sku/constants/llmTypeConfig.js
+++ b/containers/Ai/views/llm-sku/constants/llmTypeConfig.js
@@ -30,7 +30,7 @@ export function getParamsForType (llmType) {
 export const LLM_TYPE_DEFAULT_PORT_MAPPINGS = {
   ollama: [{ protocol: 'tcp', container_port: 11434 }],
   vllm: [{ protocol: 'tcp', container_port: 8000 }],
-  sglang: [{ protocol: 'tcp', container_port: 8000 }],
+  sglang: [{ protocol: 'tcp', container_port: 30000 }],
   comfyui: [{ protocol: 'tcp', container_port: 8188 }],
   dify: [{ protocol: 'tcp', container_port: 80 }],
   openclaw: [{ protocol: 'tcp', container_port: 3001 }],

--- a/containers/Ai/views/llm-sku/create/Form.vue
+++ b/containers/Ai/views/llm-sku/create/Form.vue
@@ -19,7 +19,7 @@
       </a-form-item>
       <a-form-item :label="$t('aice.llm_type')">
         <a-radio-group
-          v-if="!isEditMode && !isCatalogMode"
+          v-if="!isEditMode && (!isCatalogMode || catalogTypeSelectable)"
           class="llm-type-picker"
           button-style="solid"
           v-decorator="decorators.llm_type"
@@ -89,6 +89,7 @@
       <a-form-item v-else :label="$t('aice.llm_image')">
         <catalog-llm-image-select
           v-if="isCatalogImportMode"
+          :key="`catalog-image-${catalogLlmType}`"
           ref="catalogImageSelect"
           v-decorator="decorators.llm_image_id"
           :llm-type="catalogLlmType"
@@ -516,13 +517,19 @@ export default {
       type: String,
       default: null,
     },
+    catalogTypeSelectable: {
+      type: Boolean,
+      default: false,
+    },
   },
   data () {
     const data = this.mode === 'edit' && this.editData ? this.editData : {}
     const llmRouteCtx = parseLlmRoute(this.$route.path)
     const isApplyType = llmRouteCtx.isApplyType
     const isDesktopType = llmRouteCtx.isDesktopType
-    const catalogLlmTypeInit = this.catalogSpec ? backendToLlmType(this.catalogSpec.backend) : null
+    const catalogLlmTypeInit = this.catalogTypeSelectable
+      ? 'vllm'
+      : (this.catalogSpec ? backendToLlmType(this.catalogSpec.backend) : null)
     const catalogResourceDefaults = this.catalogSpec ? { cpu: 4, memory: 8192 } : null
     const isLocalPathImportInit = this.importMode === 'local_path'
     const localPathResourceDefaults = isLocalPathImportInit
@@ -533,7 +540,7 @@ export default {
       llmTypeOptions = LLM_TYPE_OPTIONS.filter(opt => opt.id === 'desktop')
     } else if (isApplyType) {
       llmTypeOptions = LLM_TYPE_OPTIONS.filter(opt => !['vllm', 'ollama', 'sglang', 'desktop'].includes(opt.id))
-    } else if (isLocalPathImportInit) {
+    } else if (isLocalPathImportInit || this.catalogTypeSelectable) {
       llmTypeOptions = LLM_TYPE_OPTIONS.filter(opt => ['vllm', 'sglang'].includes(opt.id))
     } else {
       llmTypeOptions = LLM_TYPE_OPTIONS.filter(opt => ['vllm', 'ollama', 'sglang'].includes(opt.id))
@@ -1108,7 +1115,11 @@ export default {
       return !!getCatalogSpecId(this.catalogSpec)
     },
     catalogLlmType () {
-      if (this.isLocalPathImportMode) return this.form?.fd?.llm_type || 'vllm'
+      if (this.isLocalPathImportMode || this.catalogTypeSelectable) {
+        const fromForm = this.form?.fd?.llm_type
+        if (fromForm === 'vllm' || fromForm === 'sglang') return fromForm
+        return 'vllm'
+      }
       return this.catalogSpec ? backendToLlmType(this.catalogSpec.backend) : ''
     },
     llmTypeName () {
@@ -1220,6 +1231,13 @@ export default {
           this.$nextTick(() => this.syncLocalPathHostPathRows(path))
         }
       }
+      if (this.catalogTypeSelectable && this.catalogSpec && oldVal) {
+        this.form.fc.setFieldsValue({
+          llm_image_id: undefined,
+          name: defaultNameFromSpec(this.catalogSpec, this.catalogSet, val),
+        })
+        this.$set(this.form.fd, 'llm_image_id', undefined)
+      }
     },
   },
   mounted () {
@@ -1233,6 +1251,15 @@ export default {
   methods: {
     resolveCreateLlmType (values = {}) {
       if (this.isCatalogMode) {
+        if (this.catalogTypeSelectable) {
+          const raw = values.llm_type ??
+            this.form.fc?.getFieldValue?.('llm_type') ??
+            this.form.fd?.llm_type ??
+            this.catalogLlmType
+          const llmType = String(raw || '').trim()
+          if (llmType === 'vllm' || llmType === 'sglang') return llmType
+          return 'vllm'
+        }
         return this.catalogLlmType
       }
       const raw = values.llm_type ??

--- a/containers/Ai/views/llm-sku/import-from-huggingface/index.vue
+++ b/containers/Ai/views/llm-sku/import-from-huggingface/index.vue
@@ -26,35 +26,23 @@
 
         <div class="catalog-drawer-scroll">
           <catalog-drawer-meta-panel :set="hfCatalogSet" />
-          <a-divider orientation="left">{{ $t('aice.llm_type') }}</a-divider>
-          <a-radio-group v-model="selectedBackend" class="mb-3" button-style="solid">
-            <a-radio-button value="vLLM">vLLM</a-radio-button>
-            <a-radio-button value="SGLang">SGLang</a-radio-button>
-          </a-radio-group>
-
           <a-divider
-            v-if="catalogLlmType"
+            v-if="hfCatalogSpec"
             orientation="left">
             {{ $t('aice.llm_catalog.import_config') }}
           </a-divider>
           <catalog-import-sku-form
-            v-if="catalogLlmType"
+            v-if="hfCatalogSpec"
             ref="importFormRef"
-            :key="formKey"
+            :key="formRepoId"
             :catalog-set="hfCatalogSet"
             :catalog-spec="hfCatalogSpec"
+            catalog-type-selectable
             @success="onImportSuccess"
             @cancel="closeDrawer" />
-
-          <a-alert
-            v-else
-            type="warning"
-            :message="$t('aice.llm_catalog.unsupported_backend')"
-            show-icon
-            class="mb-3" />
         </div>
 
-        <div v-if="catalogLlmType" class="catalog-drawer-footer">
+        <div v-if="hfCatalogSpec" class="catalog-drawer-footer">
           <a-button class="mr-2" @click="closeDrawer">{{ $t('common.cancel') }}</a-button>
           <a-button type="primary" :loading="submitLoading" @click="handleImport">
             {{ $t('aice.import_model') }}
@@ -70,7 +58,6 @@ import HfBrowsePane from '@Ai/sections/import-from-huggingface/components/HfBrow
 import CatalogDrawerMetaPanel from '@Ai/sections/catalog-model-sets/components/CatalogDrawerMetaPanel.vue'
 import { repoIdOf } from '@Ai/utils/hfRepo'
 import CatalogImportSkuForm from '@Ai/views/llm-sku/shared/CatalogImportSkuForm.vue'
-import { resolveCatalogLlmType } from '@Ai/utils/catalogSpec'
 import { parseLlmRoute } from '@Ai/utils/llmRouteContext'
 import { buildHfCatalogSet, buildHfCatalogSpec } from '@Ai/utils/hfImportSpec'
 
@@ -84,7 +71,6 @@ export default {
   data () {
     return {
       formRepo: null,
-      selectedBackend: 'vLLM',
       submitLoading: false,
     }
   },
@@ -107,36 +93,18 @@ export default {
     },
     hfCatalogSpec () {
       if (!this.formRepoId) return null
-      return buildHfCatalogSpec(this.formRepoId, this.selectedBackend, this.formRepo)
-    },
-    catalogLlmType () {
-      return resolveCatalogLlmType(this.hfCatalogSpec, { fallbackBackend: this.selectedBackend })
-    },
-    formKey () {
-      return `${this.formRepoId}-${this.selectedBackend}`
-    },
-  },
-  watch: {
-    selectedBackend () {
-      this.$nextTick(() => {
-        const form = this.$refs.importFormRef
-        if (form && form.applyCatalogSpec) {
-          form.applyCatalogSpec()
-        }
-      })
+      return buildHfCatalogSpec(this.formRepoId, 'vLLM', this.formRepo)
     },
   },
   methods: {
     onOpenDrawer (item) {
       this.formRepo = item
-      this.selectedBackend = 'vLLM'
       if (this.$refs.browse) {
         this.$refs.browse.ensurePreview(item)
       }
     },
     closeDrawer () {
       this.formRepo = null
-      this.selectedBackend = 'vLLM'
     },
     async handleImport () {
       const form = this.$refs.importFormRef

--- a/containers/Ai/views/llm-sku/import-from-modelscope/index.vue
+++ b/containers/Ai/views/llm-sku/import-from-modelscope/index.vue
@@ -26,35 +26,23 @@
 
         <div class="catalog-drawer-scroll">
           <catalog-drawer-meta-panel :set="msCatalogSet" />
-          <a-divider orientation="left">{{ $t('aice.llm_type') }}</a-divider>
-          <a-radio-group v-model="selectedBackend" class="mb-3" button-style="solid">
-            <a-radio-button value="vLLM">vLLM</a-radio-button>
-            <a-radio-button value="SGLang">SGLang</a-radio-button>
-          </a-radio-group>
-
           <a-divider
-            v-if="catalogLlmType"
+            v-if="msCatalogSpec"
             orientation="left">
             {{ $t('aice.llm_catalog.import_config') }}
           </a-divider>
           <catalog-import-sku-form
-            v-if="catalogLlmType"
+            v-if="msCatalogSpec"
             ref="importFormRef"
-            :key="formKey"
+            :key="formModelId"
             :catalog-set="msCatalogSet"
             :catalog-spec="msCatalogSpec"
+            catalog-type-selectable
             @success="onImportSuccess"
             @cancel="closeDrawer" />
-
-          <a-alert
-            v-else
-            type="warning"
-            :message="$t('aice.llm_catalog.unsupported_backend')"
-            show-icon
-            class="mb-3" />
         </div>
 
-        <div v-if="catalogLlmType" class="catalog-drawer-footer">
+        <div v-if="msCatalogSpec" class="catalog-drawer-footer">
           <a-button class="mr-2" @click="closeDrawer">{{ $t('common.cancel') }}</a-button>
           <a-button type="primary" :loading="submitLoading" @click="handleImport">
             {{ $t('aice.import_model') }}
@@ -69,7 +57,6 @@
 import MsBrowsePane from '@Ai/sections/import-from-modelscope/components/MsBrowsePane.vue'
 import CatalogDrawerMetaPanel from '@Ai/sections/catalog-model-sets/components/CatalogDrawerMetaPanel.vue'
 import CatalogImportSkuForm from '@Ai/views/llm-sku/shared/CatalogImportSkuForm.vue'
-import { resolveCatalogLlmType } from '@Ai/utils/catalogSpec'
 import { parseLlmRoute } from '@Ai/utils/llmRouteContext'
 import { buildMsCatalogSet, buildMsCatalogSpec, modelIdOf } from '@Ai/utils/msImportSpec'
 
@@ -83,7 +70,6 @@ export default {
   data () {
     return {
       formRepo: null,
-      selectedBackend: 'vLLM',
       submitLoading: false,
     }
   },
@@ -106,36 +92,18 @@ export default {
     },
     msCatalogSpec () {
       if (!this.formModelId) return null
-      return buildMsCatalogSpec(this.formModelId, this.selectedBackend, this.formRepo)
-    },
-    catalogLlmType () {
-      return resolveCatalogLlmType(this.msCatalogSpec, { fallbackBackend: this.selectedBackend })
-    },
-    formKey () {
-      return `${this.formModelId}-${this.selectedBackend}`
-    },
-  },
-  watch: {
-    selectedBackend () {
-      this.$nextTick(() => {
-        const form = this.$refs.importFormRef
-        if (form && form.applyCatalogSpec) {
-          form.applyCatalogSpec()
-        }
-      })
+      return buildMsCatalogSpec(this.formModelId, 'vLLM', this.formRepo)
     },
   },
   methods: {
     onOpenDrawer (item) {
       this.formRepo = item
-      this.selectedBackend = 'vLLM'
       if (this.$refs.browse) {
         this.$refs.browse.ensurePreview(item)
       }
     },
     closeDrawer () {
       this.formRepo = null
-      this.selectedBackend = 'vLLM'
     },
     async handleImport () {
       const form = this.$refs.importFormRef

--- a/containers/Ai/views/llm-sku/shared/CatalogImportSkuForm.vue
+++ b/containers/Ai/views/llm-sku/shared/CatalogImportSkuForm.vue
@@ -8,6 +8,7 @@
     hide-footer
     :catalog-set="catalogSet"
     :catalog-spec="catalogSpec"
+    :catalog-type-selectable="catalogTypeSelectable"
     catalog-submit-type="import"
     v-bind="$attrs"
     v-on="$listeners" />
@@ -30,6 +31,10 @@ export default {
     catalogSpec: {
       type: Object,
       default: null,
+    },
+    catalogTypeSelectable: {
+      type: Boolean,
+      default: false,
     },
   },
   methods: {


### PR DESCRIPTION
- Add rewriteAiproxyUrlForBrowser() to route /ai/* inference requests through apigateway reverse proxy, avoiding untrusted TLS certs
- Fix sglang default container port from 8000 to 30000
- Allow vLLM/SGLang type selection in catalog import (huggingface & modelscope), moving radio group into shared Form component
- Reset image selection when switching llm_type in catalog mode

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
