### PR TITLE
feat(compute): add riscv64 architecture support

### DIFF
--- a/containers/Cloudenv/views/server-price-comparator/create/form/IDC.vue
+++ b/containers/Cloudenv/views/server-price-comparator/create/form/IDC.vue
@@ -145,6 +145,12 @@ export default {
     isArm () {
       return this.form.fd.os_arch === HOST_CPU_ARCHS.arm.key
     },
+    isRiscv64 () {
+      return this.form.fd.os_arch === HOST_CPU_ARCHS.riscv64.key
+    },
+    isArmOrRiscv () {
+      return this.isArm || this.isRiscv64
+    },
     isLoongarch64 () {
       return this.form.fd.os_arch === HOST_CPU_ARCHS.loongarch64.key
     },
@@ -184,6 +190,7 @@ export default {
       if (this.form.fd.imageType === 'vmware') params.image_type = 'system'
       if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
       if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+      if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
       return params
     },
     showSku () {
@@ -400,6 +407,7 @@ export default {
       }
       if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
       if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+      if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
       return params
     },
     archOptions () {
@@ -409,6 +417,7 @@ export default {
           if (item === HOST_CPU_ARCHS.arm.capabilityKey) return HOST_CPU_ARCHS.arm.key
           if (item === HOST_CPU_ARCHS.x86.capabilityKey) return HOST_CPU_ARCHS.x86.key
           if (item === HOST_CPU_ARCHS.loongarch64.capabilityKey) return HOST_CPU_ARCHS.loongarch64.key
+          if (item === HOST_CPU_ARCHS.riscv64.capabilityKey) return HOST_CPU_ARCHS.riscv64.key
           return item
         })
       }
@@ -496,7 +505,7 @@ export default {
     uefi (val) {
       this.setBios(val)
     },
-    isArm (val, oldV) {
+    isArmOrRiscv (val, oldV) {
       this.setBios(val)
     },
   },

--- a/containers/Compute/locales/en.json
+++ b/containers/Compute/locales/en.json
@@ -185,6 +185,7 @@
   "compute.text_179": "CPU",
   "compute.cpu_arch": "CPU Arch",
   "compute.cpu_arch.aarch64": "ARM",
+  "compute.cpu_arch.riscv64": "RISC-V 64-bit",
   "compute.cpu_arch.x86": "x86",
   "compute.text_180": "Memory (GB)",
   "compute.text_181": "Price",

--- a/containers/Compute/locales/ja-JP.json
+++ b/containers/Compute/locales/ja-JP.json
@@ -185,6 +185,7 @@
   "compute.text_179": "CPU (コア)",
   "compute.cpu_arch": "CPU (アーキテクチャ)",
   "compute.cpu_arch.aarch64": "腕",
+  "compute.cpu_arch.riscv64": "RISC-V 64ビット",
   "compute.cpu_arch.x86": "x86",
   "compute.text_180": "メモリ (GB)",
   "compute.text_181": "価格",

--- a/containers/Compute/locales/zh-CN.json
+++ b/containers/Compute/locales/zh-CN.json
@@ -185,6 +185,7 @@
   "compute.text_179": "CPU(核)",
   "compute.cpu_arch": "CPU(架构)",
   "compute.cpu_arch.aarch64": "ARM",
+  "compute.cpu_arch.riscv64": "RISC-V 64位",
   "compute.cpu_arch.x86": "x86",
   "compute.text_180": "内存(GB)",
   "compute.text_181": "价格",

--- a/containers/Compute/utils/createServer.js
+++ b/containers/Compute/utils/createServer.js
@@ -1983,7 +1983,8 @@ export class GenCreateData {
     }
     // 安装监控 agent
     if (this.isIDC) {
-      if ((this.isWindows() && this.fd.os_arch !== HOST_CPU_ARCHS.arm.key) || !this.isWindows()) {
+      const windowsAgentUnsupportedArchs = [HOST_CPU_ARCHS.arm.key, HOST_CPU_ARCHS.riscv64.key]
+      if ((this.isWindows() && !windowsAgentUnsupportedArchs.includes(this.fd.os_arch)) || !this.isWindows()) {
         if (this.fd.deploy_telegraf) {
           data.deploy_telegraf = this.fd.deploy_telegraf
         }

--- a/containers/Compute/views/host/mixins/singleActions.js
+++ b/containers/Compute/views/host/mixins/singleActions.js
@@ -349,7 +349,7 @@ export default {
                       validate: false,
                       tooltip: '',
                     }
-                  } else if (obj.cpu_architecture === HOST_CPU_ARCHS.arm.capabilityKey) {
+                  } else if ([HOST_CPU_ARCHS.arm.capabilityKey, HOST_CPU_ARCHS.riscv64.capabilityKey].includes(obj.cpu_architecture)) {
                     return {
                       validate: false,
                       tooltip: i18n.t('compute.text_1364'),

--- a/containers/Compute/views/image/dialogs/EditAttributes.vue
+++ b/containers/Compute/views/image/dialogs/EditAttributes.vue
@@ -71,7 +71,7 @@
               v-for="(item, index) in biosOptions"
               :value="item.value"
               :key="index"
-              :disabled="isArm && item.value==='BIOS'">{{item.text}}</a-radio-button>
+              :disabled="requiresUefi && item.value==='BIOS'">{{item.text}}</a-radio-button>
           </a-radio-group>
         </a-form-item>
         <a-form-item :label="$t('compute.vdi_protocol')">
@@ -116,7 +116,12 @@ export default {
     const data = this.params.data[0]
     let os_arch = data.os_arch || HOST_CPU_ARCHS.x86.key
     if (data.properties && data.properties.os_arch) {
-      os_arch = data.properties.os_arch.includes('x86') ? HOST_CPU_ARCHS.x86.key : HOST_CPU_ARCHS.arm.key
+      const propertyOsArch = data.properties.os_arch.toLowerCase()
+      if (propertyOsArch.includes('riscv')) {
+        os_arch = HOST_CPU_ARCHS.riscv64.key
+      } else {
+        os_arch = propertyOsArch.includes('x86') ? HOST_CPU_ARCHS.x86.key : HOST_CPU_ARCHS.arm.key
+      }
     }
     let bios = 'BIOS'
     const { properties = {} } = data
@@ -128,9 +133,9 @@ export default {
     } else if (uefi_support !== 'true') {
       bios = 'BIOS'
     }
-    const isArm = (os_arch === HOST_CPU_ARCHS.arm.key)
+    const requiresUefi = [HOST_CPU_ARCHS.arm.key, HOST_CPU_ARCHS.riscv64.key].includes(os_arch)
     return {
-      isArm: isArm,
+      requiresUefi,
       loading: false,
       form: {
         fc: this.$form.createForm(this),
@@ -364,7 +369,7 @@ export default {
       })
     },
     osArchChangeHandle (e) {
-      this.isArm = (e === HOST_CPU_ARCHS.arm.key)
+      this.requiresUefi = [HOST_CPU_ARCHS.arm.key, HOST_CPU_ARCHS.riscv64.key].includes(e)
       this.$nextTick(() => {
         this.form.fc.setFieldsValue({ bios: 'UEFI' })
       })

--- a/containers/Compute/views/vminstance-container/components/AdjustConfigForm.vue
+++ b/containers/Compute/views/vminstance-container/components/AdjustConfigForm.vue
@@ -198,7 +198,8 @@ export default {
       return this.params.data.some(val => val.status === 'running')
     },
     isSomeArm () {
-      return this.selectedItem.os_arch === 'arm'
+      const osArch = (this.selectedItem.os_arch || '').toLowerCase()
+      return osArch === 'arm' || osArch.startsWith('riscv')
     },
     runningArm () {
       return this.isSomeArm && this.isSomeRunning

--- a/containers/Compute/views/vminstance-container/create/form/IDC.vue
+++ b/containers/Compute/views/vminstance-container/create/form/IDC.vue
@@ -231,7 +231,7 @@ import Labels from '@Compute/sections/Labels'
 import SpecContainer from '@Compute/sections/SpecContainer'
 import { NETWORK_OPTIONS_MAP } from '@Compute/constants'
 import OsArch from '@/sections/OsArch'
-import { IMAGES_TYPE_MAP, STORAGE_TYPES, HOST_CPU_ARCHS } from '@/constants/compute'
+import { IMAGES_TYPE_MAP, STORAGE_TYPES, HOST_CPU_ARCHS, resolveHostCpuArch } from '@/constants/compute'
 import { resolveValueChangeField } from '@/utils/common/ant'
 import { HYPERVISORS_MAP } from '@/constants'
 import { diskSupportTypeMedium, getOriginDiskKey } from '@/utils/common/hypervisor'
@@ -268,6 +268,12 @@ export default {
     },
     isArm () {
       return this.form.fd.os_arch === HOST_CPU_ARCHS.arm.key
+    },
+    isRiscv64 () {
+      return this.form.fd.os_arch === HOST_CPU_ARCHS.riscv64.key
+    },
+    isArmOrRiscv () {
+      return this.isArm || this.isRiscv64
     },
     isLoongarch64 () {
       return this.form.fd.os_arch === HOST_CPU_ARCHS.loongarch64.key
@@ -318,6 +324,7 @@ export default {
       if (this.form.fd.imageType === 'vmware') {
         params.image_type = 'system'
       }
+      if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
       return params
     },
     showSku () {
@@ -374,6 +381,7 @@ export default {
         }
         if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
         if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+        if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
         return params
       }
       return {}
@@ -527,6 +535,7 @@ export default {
       }
       if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
       if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+      if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
       return params
     },
     archOptions () {
@@ -536,6 +545,7 @@ export default {
           if (item === HOST_CPU_ARCHS.arm.capabilityKey) return HOST_CPU_ARCHS.arm
           if (item === HOST_CPU_ARCHS.x86.capabilityKey) return HOST_CPU_ARCHS.x86
           if (item === HOST_CPU_ARCHS.loongarch64.capabilityKey) return HOST_CPU_ARCHS.loongarch64
+          if (item === HOST_CPU_ARCHS.riscv64.capabilityKey) return HOST_CPU_ARCHS.riscv64
           return item
         })
       }
@@ -800,12 +810,8 @@ export default {
         const { os_arch } = this.$route.query
         // 数据延迟回填
         if (os_arch) {
-          let canUseOsArch = ''
-          if (os_arch.indexOf('x86') !== -1) {
-            canUseOsArch = HOST_CPU_ARCHS.x86.key
-          } else if (os_arch.indexOf('aarch') !== -1) {
-            canUseOsArch = HOST_CPU_ARCHS.arm.key
-          }
+          const archConfig = resolveHostCpuArch(os_arch)
+          const canUseOsArch = archConfig ? archConfig.key : ''
           if (!canUseOsArch) return
           this.form.fc.setFieldsValue({ os_arch: canUseOsArch })
         }
@@ -813,7 +819,7 @@ export default {
     },
     getMachineDecorator () {
       let initValue = 'pc'
-      if (this.isArm) {
+      if (this.isArmOrRiscv) {
         initValue = 'virt'
       }
       return [

--- a/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
+++ b/containers/Compute/views/vminstance/components/AdjustConfigForm.vue
@@ -615,6 +615,8 @@ export default {
           params.cpu_arch = HOST_CPU_ARCHS.x86.key
         } else if (this.selectedItem.os_arch.includes('arm') || this.selectedItem.os_arch.includes('aarch64')) {
           params.cpu_arch = HOST_CPU_ARCHS.arm.key
+        } else if (this.selectedItem.os_arch.toLowerCase().includes('riscv')) {
+          params.cpu_arch = HOST_CPU_ARCHS.riscv64.key
         }
       }
       return params
@@ -839,7 +841,7 @@ export default {
     clearInterval(this.dataDiskInterval)
   },
   methods: {
-    // 是否支持开机直接调整（ARM 架构开机全平台不支持热调，需先关机）
+    // 是否支持开机直接调整（ARM/RISC-V 架构开机全平台不支持热调，需先关机）
     canHotAdjust (item) {
       if (this.isArmArch(item)) return false
       if (HOTPLUG_RUNNING_ADJUST_HYPERVISORS.includes(item.hypervisor)) {
@@ -849,7 +851,7 @@ export default {
     },
     isArmArch (item) {
       const arch = (item.os_arch || '').toLowerCase()
-      return arch === HOST_CPU_ARCHS.arm.key || arch.includes('arm') || arch.includes('aarch64')
+      return arch === HOST_CPU_ARCHS.arm.key || arch.includes('arm') || arch.includes('aarch64') || arch.includes('riscv')
     },
     isDowngradeFor (item, vcpu, vmem) {
       return vcpu < item.vcpu_count || vmem < item.vmem_size

--- a/containers/Compute/views/vminstance/create/form/IDC.vue
+++ b/containers/Compute/views/vminstance/create/form/IDC.vue
@@ -254,7 +254,7 @@
             :form-draft-key="vmDraftFields.schedPolicy" />
         </a-form-item>
         <a-form-item :label="$t('compute.text_1155')" class="mb-0" v-if="isKvm">
-          <bios :decorator="decorators.bios" :uefi="uefi" :isArm="isArm" :showDefault="true" />
+          <bios :decorator="decorators.bios" :uefi="uefi" :isArm="isArmOrRiscv" :showDefault="true" />
         </a-form-item>
         <a-form-item :label="$t('compute.vdi_protocol')" class="mb-0" v-if="isKvm">
           <vdi :decorator="decorators.vdi" :showDefault="true" />
@@ -263,7 +263,7 @@
           <vga :decorator="decorators.vga" :vdi="vdi" :form="form" :showDefault="true" />
         </a-form-item>
         <a-form-item :label="$t('compute.machine')" class="mb-0" v-if="isKvm">
-          <machine :decorator="getMachineDecorator()" :isArm="isArm" :showDefault="true" />
+          <machine :decorator="getMachineDecorator()" :isArm="isArmOrRiscv" :showDefault="true" />
         </a-form-item>
         <a-form-item v-show="!isServertemplate" v-if="isKvm && isLocalDisk" :label="$t('compute.text_1156')" :extra="$t('compute.text_1157')">
           <backup
@@ -330,7 +330,7 @@ import Machine from '@Compute/sections/Machine'
 import { NETWORK_OPTIONS_MAP, hasVgaGpuInPciForm } from '@Compute/constants'
 import Kickstart from '@Compute/sections/Kickstart'
 import OsArch from '@/sections/OsArch'
-import { IMAGES_TYPE_MAP, STORAGE_TYPES, HOST_CPU_ARCHS } from '@/constants/compute'
+import { IMAGES_TYPE_MAP, STORAGE_TYPES, HOST_CPU_ARCHS, resolveHostCpuArch } from '@/constants/compute'
 import { resolveValueChangeField } from '@/utils/common/ant'
 import { HYPERVISORS_MAP } from '@/constants'
 import { diskSupportTypeMedium, getOriginDiskKey } from '@/utils/common/hypervisor'
@@ -367,6 +367,12 @@ export default {
     },
     isArm () {
       return this.form.fd.os_arch === HOST_CPU_ARCHS.arm.key
+    },
+    isRiscv64 () {
+      return this.form.fd.os_arch === HOST_CPU_ARCHS.riscv64.key
+    },
+    isArmOrRiscv () {
+      return this.isArm || this.isRiscv64
     },
     isLoongarch64 () {
       return this.form.fd.os_arch === HOST_CPU_ARCHS.loongarch64.key
@@ -429,6 +435,7 @@ export default {
         params.image_type = 'system'
       }
       if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+      if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
       return params
     },
     showSku () {
@@ -485,6 +492,7 @@ export default {
         }
         if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
         if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+        if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
         return params
       }
       return {}
@@ -502,6 +510,7 @@ export default {
         }
         if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
         if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+        if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
         return params
       }
       return {}
@@ -722,6 +731,7 @@ export default {
       }
       if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
       if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+      if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
       return params
     },
     archOptions () {
@@ -731,6 +741,7 @@ export default {
           if (item === HOST_CPU_ARCHS.arm.capabilityKey) return HOST_CPU_ARCHS.arm
           if (item === HOST_CPU_ARCHS.x86.capabilityKey) return HOST_CPU_ARCHS.x86
           if (item === HOST_CPU_ARCHS.loongarch64.capabilityKey) return HOST_CPU_ARCHS.loongarch64
+          if (item === HOST_CPU_ARCHS.riscv64.capabilityKey) return HOST_CPU_ARCHS.riscv64
           return item
         })
       }
@@ -748,7 +759,7 @@ export default {
     isShowAgent () {
       if (this.isIso || !this.osType) return false
       if (this.isWindows) {
-        return !this.isArm
+        return !this.isArmOrRiscv
       }
       return true
     },
@@ -844,7 +855,7 @@ export default {
     uefi (val) {
       this.setBios(val)
     },
-    isArm (val, oldV) {
+    isArmOrRiscv (val, oldV) {
       this.setBios(val)
     },
     isShowAgent (val) {
@@ -1057,12 +1068,8 @@ export default {
         const { os_arch } = this.$route.query
         // 数据延迟回填
         if (os_arch) {
-          let canUseOsArch = ''
-          if (os_arch.indexOf('x86') !== -1) {
-            canUseOsArch = HOST_CPU_ARCHS.x86.key
-          } else if (os_arch.indexOf('aarch') !== -1) {
-            canUseOsArch = HOST_CPU_ARCHS.arm.key
-          }
+          const archConfig = resolveHostCpuArch(os_arch)
+          const canUseOsArch = archConfig ? archConfig.key : ''
           if (!canUseOsArch) return
           this.form.fc.setFieldsValue({ os_arch: canUseOsArch })
         }
@@ -1070,7 +1077,7 @@ export default {
     },
     getMachineDecorator () {
       let initValue = ''
-      if (this.isArm) {
+      if (this.isArmOrRiscv) {
         initValue = 'virt'
       }
       return [

--- a/containers/Compute/views/vminstance/create/form/Private.vue
+++ b/containers/Compute/views/vminstance/create/form/Private.vue
@@ -235,6 +235,9 @@ export default {
     isLoongarch64 () {
       return this.form.fd.sku && this.form.fd.sku.cpu_arch === HOST_CPU_ARCHS.loongarch64.capabilityKey
     },
+    isRiscv64 () {
+      return this.form.fd.sku && this.form.fd.sku.cpu_arch === HOST_CPU_ARCHS.riscv64.capabilityKey
+    },
     osArch () {
       if (this.form.fd.sku && this.form.fd.sku.cpu_arch) {
         return this.form.fd.sku.cpu_arch
@@ -270,6 +273,7 @@ export default {
         params.os_arch = HOST_CPU_ARCHS.x86.key
         if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
         if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+        if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
       }
       return params
     },

--- a/containers/Compute/views/vminstance/create/form/Public.vue
+++ b/containers/Compute/views/vminstance/create/form/Public.vue
@@ -309,6 +309,9 @@ export default {
     isLoongarch64 () {
       return this.form.fd.sku && this.form.fd.sku.cpu_arch === HOST_CPU_ARCHS.loongarch64.capabilityKey
     },
+    isRiscv64 () {
+      return this.form.fd.sku && this.form.fd.sku.cpu_arch === HOST_CPU_ARCHS.riscv64.capabilityKey
+    },
     osArch () {
       if (this.form.fd.sku && this.form.fd.sku.cpu_arch) {
         return this.form.fd.sku.cpu_arch
@@ -443,6 +446,7 @@ export default {
         params.os_arch = HOST_CPU_ARCHS.x86.key
         if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
         if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+        if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
       }
       return params
     },

--- a/containers/Compute/views/vminstance/dialogs/RebuildRoot.vue
+++ b/containers/Compute/views/vminstance/dialogs/RebuildRoot.vue
@@ -152,6 +152,9 @@ export default {
     },
     osArch () {
       const { instance_type = '', os_arch } = this.params.data[0]
+      if (String(os_arch).toLowerCase().startsWith('riscv')) {
+        return HOST_CPU_ARCHS.riscv64.capabilityKey
+      }
       if (instance_type.startsWith('k') || os_arch === HOST_CPU_ARCHS.arm.capabilityKey) {
         return HOST_CPU_ARCHS.arm.capabilityKey
       }
@@ -166,6 +169,9 @@ export default {
       }
       if (this.osArch === HOST_CPU_ARCHS.arm.capabilityKey) {
         params.os_arch = HOST_CPU_ARCHS.arm.key
+      }
+      if (this.osArch === HOST_CPU_ARCHS.riscv64.capabilityKey) {
+        params.os_arch = HOST_CPU_ARCHS.riscv64.key
       }
       return params
     },
@@ -373,7 +379,7 @@ export default {
       const { os } = this.form.fd
       if (![HYPERVISORS_MAP.kvm.key, HYPERVISORS_MAP.esxi.key].includes(this.hypervisor)) return false
       if (os === 'Windows') {
-        return this.osArch !== HOST_CPU_ARCHS.arm.capabilityKey
+        return ![HOST_CPU_ARCHS.arm.capabilityKey, HOST_CPU_ARCHS.riscv64.capabilityKey].includes(this.osArch)
       }
       return true
     },

--- a/containers/Compute/views/vminstance/dialogs/Update.vue
+++ b/containers/Compute/views/vminstance/dialogs/Update.vue
@@ -26,7 +26,7 @@
             </a-radio-group>
           </a-form-item> -->
           <a-form-item :label="$t('compute.text_1155')">
-            <bios :decorator="decorators.bios" :isArm="isArm" />
+            <bios :decorator="decorators.bios" :isArm="requiresVirtMachine" />
           </a-form-item>
           <a-form-item :label="$t('compute.vdi_protocol')">
             <vdi :decorator="decorators.vdi" @change="handleVdiChange" />
@@ -35,7 +35,7 @@
             <vga :decorator="decorators.vga" :vdi="vdi" :form="form" />
           </a-form-item>
           <a-form-item :label="$t('compute.machine')">
-            <machine :decorator="decorators.machine" :isArm="isArm" />
+            <machine :decorator="decorators.machine" :isArm="requiresVirtMachine" />
           </a-form-item>
           <a-form-item v-if="isKvm" :label="$t('compute.usb_kbd')">
             <a-switch v-decorator="decorators.disable_usb_kbd" />
@@ -176,6 +176,12 @@ export default {
     isArm () {
       return this.params.data.length >= 1 && (this.params.data[0].os_arch === 'arm' || this.params.data[0].os_arch === 'aarch64')
     },
+    isRiscv64 () {
+      return this.params.data.length >= 1 && String(this.params.data[0].os_arch).toLowerCase().startsWith('riscv')
+    },
+    requiresVirtMachine () {
+      return this.isArm || this.isRiscv64
+    },
     canAdminUpdate () {
       return hasPermission({ key: 'server_update', resourceData: this.params.data[0] }) && this.$store.getters.isAdminMode
     },
@@ -229,11 +235,11 @@ export default {
         }
         if (this.isKvm) {
           // updateObj.boot_order = data.boot_order
-          updateObj.bios = data.bios || (this.isArm ? 'UEFI' : 'BIOS')
+          updateObj.bios = data.bios || (this.requiresVirtMachine ? 'UEFI' : 'BIOS')
           updateObj.vdi = data.vdi ? data.vdi : 'vnc'
           updateObj.vga = data.vga ? data.vga : 'std'
           this.vdi = updateObj.vdi
-          updateObj.machine = data.machine ? data.machine : (this.isArm ? 'virt' : 'pc')
+          updateObj.machine = data.machine ? data.machine : (this.requiresVirtMachine ? 'virt' : 'pc')
           // updateObj.is_daemon = data.is_daemon
           this.is_daemon = data.is_daemon
         }

--- a/containers/Dashboard/constants/index.js
+++ b/containers/Dashboard/constants/index.js
@@ -2525,6 +2525,15 @@ export const USAGE_CONFIG = {
   },
 }
 
+// Architecture-specific server metrics share the same units and scope rules.
+// Keep RISC-V in sync with the existing x86_64 metric set without duplicating
+// dozens of otherwise identical entries.
+Object.keys(USAGE_CONFIG).forEach(key => {
+  if (key.includes('.x86_64')) {
+    USAGE_CONFIG[key.replace('.x86_64', '.riscv64')] = { ...USAGE_CONFIG[key] }
+  }
+})
+
 export const K8S_USAGE_CONFIG = {
   'all.cluster.count': {
     unit: i18n.t('dashboard.text_1'),

--- a/src/components/JsonSchemaForm/JComponents/JImageList/JImageList.vue
+++ b/src/components/JsonSchemaForm/JComponents/JImageList/JImageList.vue
@@ -93,6 +93,9 @@ export default {
     isLoongarch64 () {
       return this.fe.sku && this.fe.sku.cpu_arch === HOST_CPU_ARCHS.loongarch64.capabilityKey
     },
+    isRiscv64 () {
+      return this.fe.sku && this.fe.sku.cpu_arch === HOST_CPU_ARCHS.riscv64.capabilityKey
+    },
     isIDC () {
       return HYPERVISORS_MAP[this.hypervisor]?.env === 'idc'
     },
@@ -132,6 +135,7 @@ export default {
         params.os_arch = HOST_CPU_ARCHS.x86.key
         if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
         if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+        if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
       }
       return params
     },
@@ -152,6 +156,7 @@ export default {
         params.os_arch = HOST_CPU_ARCHS.x86.key
         if (this.isArm) params.os_arch = HOST_CPU_ARCHS.arm.key
         if (this.isLoongarch64) params.os_arch = HOST_CPU_ARCHS.loongarch64.key
+        if (this.isRiscv64) params.os_arch = HOST_CPU_ARCHS.riscv64.key
       }
       return params
     },
@@ -455,7 +460,11 @@ export default {
       const min_disk = sizestr(img.min_disk, 'M', 1024)
       const size = sizestr(img.size, 'B', 1024)
       const props = img.properties || (img.info ? img.info.properties : undefined)
-      const arch = props && props.os_arch && props.os_arch === 'aarch64' ? this.$t('compute.cpu_arch.aarch64') : props?.os_arch || 'x86_64'
+      const rawArch = props?.os_arch || HOST_CPU_ARCHS.x86.capabilityKey
+      let arch = rawArch === HOST_CPU_ARCHS.arm.capabilityKey ? this.$t('compute.cpu_arch.aarch64') : rawArch
+      if (String(rawArch).toLowerCase().startsWith('riscv')) {
+        arch = this.$t('compute.cpu_arch.riscv64')
+      }
       let bios = 'BIOS'
       if (props) {
         const { uefi_support, bios_support } = props

--- a/src/constants/compute.js
+++ b/src/constants/compute.js
@@ -2,6 +2,8 @@ import i18n from '@/locales'
 import { HYPERVISORS_MAP } from '@/constants'
 import { arrayToObj } from '@/utils/utils'
 
+export { HOST_CPU_ARCHS, resolveHostCpuArch } from './computeArch'
+
 // 镜像类型
 export const IMAGES_TYPE_MAP = {
   standard: { key: 'standard', label: i18n.t('label.standardImage'), tooltip: i18n.t('common.text00016') },
@@ -901,27 +903,6 @@ export const DISK_MOUNT_POINT_OPTIONS = [
   { key: 'xfs', label: 'xfs' },
   // { key: 'swap', label: 'swap' },
 ]
-
-export const HOST_CPU_ARCHS = {
-  x86: {
-    key: 'x86',
-    label: 'x86_64',
-    capabilityKey: 'x86_64',
-    order: 1,
-  },
-  arm: {
-    key: 'arm',
-    label: 'aarch64',
-    capabilityKey: 'aarch64',
-    order: 2,
-  },
-  loongarch64: {
-    key: 'loongarch64',
-    label: 'loongarch64',
-    capabilityKey: 'loongarch64',
-    order: 3,
-  },
-}
 
 export const DISK_LABEL_MAP = {
   GPSSD: i18n.t('compute.disk.rotate_gpssd'),

--- a/src/constants/computeArch.js
+++ b/src/constants/computeArch.js
@@ -1,0 +1,54 @@
+export const HOST_CPU_ARCHS = {
+  x86: {
+    key: 'x86',
+    label: 'x86_64',
+    capabilityKey: 'x86_64',
+    order: 1,
+  },
+  arm: {
+    key: 'arm',
+    label: 'aarch64',
+    capabilityKey: 'aarch64',
+    order: 2,
+  },
+  loongarch64: {
+    key: 'loongarch64',
+    label: 'loongarch64',
+    capabilityKey: 'loongarch64',
+    order: 3,
+  },
+  riscv64: {
+    key: 'riscv64',
+    label: 'riscv64',
+    capabilityKey: 'riscv64',
+    order: 4,
+  },
+}
+
+export const resolveHostCpuArch = (arch) => {
+  const value = String(arch || '').toLowerCase()
+  if (!value) return undefined
+  if (value === 'amd64' || value === 'i386' || value.startsWith('x86')) {
+    return HOST_CPU_ARCHS.x86
+  }
+  if (value.startsWith('arm') || value.startsWith('aarch')) {
+    return HOST_CPU_ARCHS.arm
+  }
+  if (value.startsWith('riscv')) {
+    return HOST_CPU_ARCHS.riscv64
+  }
+  if (value === 'loong64' || value === HOST_CPU_ARCHS.loongarch64.key) {
+    return HOST_CPU_ARCHS.loongarch64
+  }
+  return undefined
+}
+
+export const addRiscvUsageMessages = (usageMessages, label) => {
+  Object.keys(usageMessages).forEach(key => {
+    const value = usageMessages[key]
+    if (key.includes('.x86_64') && typeof value === 'string') {
+      usageMessages[key.replace('.x86_64', '.riscv64')] = value.replace(/x86/g, label)
+    }
+  })
+  return usageMessages
+}

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -6,6 +6,7 @@ import vxeTableEN from 'vxe-table/lib/locale/lang/en-US'
 import vxeTableJP from 'vxe-table/lib/locale/lang/ja-JP'
 import setting from '@/config/setting'
 import { getLanguage } from '@/utils/common/cookie'
+import { addRiscvUsageMessages } from '@/constants/computeArch'
 import en from './en'
 import zhCN from './zh-CN'
 import jaJP from './ja-JP'
@@ -35,6 +36,17 @@ const register = (ctx) => {
 
 register(moduleCtx)
 register(scopeCtx)
+
+const riscvUsageLabels = {
+  en: 'RISC-V 64-bit',
+  'zh-CN': 'RISC-V 64位',
+  'ja-JP': 'RISC-V 64ビット',
+}
+
+Object.keys(riscvUsageLabels).forEach(lang => {
+  const usageMessages = messages[lang].usage || {}
+  addRiscvUsageMessages(usageMessages, riscvUsageLabels[lang])
+})
 
 const i18n = new VueI18n({
   locale: getLanguage(),

--- a/tests/unit/compute-arch.spec.js
+++ b/tests/unit/compute-arch.spec.js
@@ -1,0 +1,49 @@
+import { addRiscvUsageMessages, HOST_CPU_ARCHS, resolveHostCpuArch } from '@/constants/computeArch'
+
+describe('RISC-V architecture support', () => {
+  it('exposes riscv64 in shared architecture options', () => {
+    expect(HOST_CPU_ARCHS.riscv64).toEqual({
+      key: 'riscv64',
+      label: 'riscv64',
+      capabilityKey: 'riscv64',
+      order: 4,
+    })
+  })
+
+  it.each([
+    ['amd64', HOST_CPU_ARCHS.x86],
+    ['i386', HOST_CPU_ARCHS.x86],
+    ['x86', HOST_CPU_ARCHS.x86],
+    ['riscv', HOST_CPU_ARCHS.riscv64],
+    ['riscv32', HOST_CPU_ARCHS.riscv64],
+    ['riscv64', HOST_CPU_ARCHS.riscv64],
+    ['x86_64', HOST_CPU_ARCHS.x86],
+    ['arm', HOST_CPU_ARCHS.arm],
+    ['arm32', HOST_CPU_ARCHS.arm],
+    ['arm64', HOST_CPU_ARCHS.arm],
+    ['aarch64', HOST_CPU_ARCHS.arm],
+    ['loong64', HOST_CPU_ARCHS.loongarch64],
+    ['loongarch64', HOST_CPU_ARCHS.loongarch64],
+    ['RISCV64', HOST_CPU_ARCHS.riscv64],
+  ])('normalizes %s to its UI architecture option', (value, expected) => {
+    expect(resolveHostCpuArch(value)).toBe(expected)
+  })
+
+  it.each([undefined, null, '', 'mips64'])('leaves unsupported architecture %p unresolved', value => {
+    expect(resolveHostCpuArch(value)).toBeUndefined()
+  })
+
+  it('adds RISC-V usage labels without assuming every value is a string', () => {
+    const messages = {
+      'all.servers.x86_64': 'Number of Servers (x86)',
+      'all.servers.x86_64.meta': { unit: 'count' },
+      'all.servers.aarch64': 'Number of Servers (ARM)',
+    }
+
+    expect(addRiscvUsageMessages(messages, 'RISC-V 64-bit')).toEqual({
+      ...messages,
+      'all.servers.riscv64': 'Number of Servers (RISC-V 64-bit)',
+    })
+    expect(messages['all.servers.riscv64.meta']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
The Dashboard can be built for RISC-V, but its runtime architecture options and Compute workflows do not recognize `riscv64`. RISC-V images and instances are therefore missing from filters and several create or update flows apply x86/ARM assumptions.

- adds `riscv64` to architecture options and usage labels;
- normalizes x86, ARM, RISC-V, and LoongArch aliases in one helper;
- updates image, host, VM, container-VM, create, rebuild, resize, and update flows;
- uses UEFI with the `virt` machine type for RISC-V and avoids unsupported Windows-agent behavior;
- preserves existing x86, ARM, and LoongArch branches and option ordering;
- adds focused unit tests for aliases, case normalization, empty/unknown inputs, and usage labels.

<!--
- [x] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:
UNKNOWN
<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
