### PR TITLE
fix(security): escape user-controlled data in chart tooltip HTML to prevent XSS

### DIFF
--- a/containers/Monitor/components/MonitorCard/DashboardCard/index.vue
+++ b/containers/Monitor/components/MonitorCard/DashboardCard/index.vue
@@ -73,7 +73,7 @@ import { addMissingSeries } from '@Monitor/utils'
 import WindowsMixin from '@/mixins/windows'
 import DialogMixin from '@/mixins/dialog'
 import { getSignature } from '@/utils/crypto'
-import { getRequestT, transformUnit } from '@/utils/utils'
+import { getRequestT, transformUnit, escapeHTML } from '@/utils/utils'
 import { getNameDescriptionTableColumn } from '@/utils/common/tableColumn'
 import OverviewCardLayout from '../layout'
 // import { currencyUnitMap } from '@/constants/currency'
@@ -398,10 +398,10 @@ export default {
                 } catch (err) { }
               }
             }
-            return `<div class="d-flex align-items-center"><span>${line.marker}</span> <span class="text-truncate" style="max-width: 500px;">${name || ' '}</span>:&nbsp;<span>${value}</span></div>`
+            return `<div class="d-flex align-items-center"><span>${line.marker}</span> <span class="text-truncate" style="max-width: 500px;">${escapeHTML(name || ' ')}</span>:&nbsp;<span>${escapeHTML(value)}</span></div>`
           }).join('')
           const wrapper = `<div>
-                        <div>${params[0].name}</div>
+                        <div>${escapeHTML(params[0].name)}</div>
                         <div class="lines-wrapper">${series}</div>
                       </div>`
           dom.style.border = 'none'

--- a/containers/Monitor/components/MonitorCard/OverviewCard/filterForm.vue
+++ b/containers/Monitor/components/MonitorCard/OverviewCard/filterForm.vue
@@ -372,17 +372,11 @@ export default {
       if (['system', 'project_domain', 'tenant'].indexOf(this.dimension.name) >= 0) {
         namecolumn.slots = {
           default: ({ row }, h) => {
+            // 文本节点由 Vue 自动转义，避免 innerHTML 注入
             if (!row[this.dimension.id]) {
-              return [h('span', {
-                domProps: {
-                  innerHTML: row[this.dimension.name] || '-',
-                },
-              })]
+              return [h('span', row[this.dimension.name] || '-')]
             }
             return [h('a', {
-              domProps: {
-                innerHTML: row[this.dimension.name] || '-',
-              },
               props: {
                 value: row[this.dimension.id] || '-',
               },
@@ -391,7 +385,7 @@ export default {
                   self.changeNav(row)
                 },
               },
-            })]
+            }, row[this.dimension.name] || '-')]
           },
         }
       }

--- a/src/components/Uchart/index.vue
+++ b/src/components/Uchart/index.vue
@@ -17,6 +17,7 @@
 import UPlot from 'uplot'
 import 'uplot/dist/uPlot.min.css'
 import DataEmpty from '@/components/DataEmpty'
+import { escapeHTML } from '@/utils/utils'
 
 export default {
   name: 'Uchart',
@@ -186,7 +187,7 @@ export default {
               const label = d.label.startsWith('unknown-0-') ? d.label.replace('unknown-0-', '') : d.label
               const shortLabel = d.label.length > 50 ? label.substring(0, 50) + '...' : label
               const valueUnit = that.options?.tooltip?.valueFormatter ? that.options.tooltip.valueFormatter(d.value, d.unit) : `${(d.value || 0).toFixed(2)}${d.unit || ''}`
-              html += `<div class="uplot-tooltip-item"><span class="uplot-tooltip-dot" style="background-color:${d.color}"></span>${shortLabel}: ${valueUnit}</div>`
+              html += `<div class="uplot-tooltip-item"><span class="uplot-tooltip-dot" style="background-color:${escapeHTML(d.color)}"></span>${escapeHTML(shortLabel)}: ${escapeHTML(valueUnit)}</div>`
               textList.push(`${shortLabel}: ${valueUnit}`)
             })
             html += '</div>'

--- a/src/sections/Charts/Lines.vue
+++ b/src/sections/Charts/Lines.vue
@@ -9,6 +9,7 @@
 </template>
 
 <script>
+import { escapeHTML } from '@/utils/utils'
 import mixin from './mixin'
 import { colors } from './constants'
 
@@ -73,7 +74,7 @@ export default {
           position: (point, params, dom, rect, size) => {
             let wrapper = ''
             if (params[0] && params[0].axisValueLabel) {
-              wrapper = `<div style="color: #5D6F80; margin-top:10px;">${params[0].axisValueLabel}</div>`
+              wrapper = `<div style="color: #5D6F80; margin-top:10px;">${escapeHTML(params[0].axisValueLabel)}</div>`
             }
             dom.innerHTML = wrapper + dom.innerHTML
           },

--- a/src/sections/Monitor/index.vue
+++ b/src/sections/Monitor/index.vue
@@ -25,6 +25,7 @@
 import _ from 'lodash'
 import * as R from 'ramda'
 import { numerify } from '@/filters'
+import { escapeHTML } from '@/utils/utils'
 import MonitorHeader from './Header'
 import MonitorList from './List'
 
@@ -266,12 +267,12 @@ export default {
                 }
                 return `<div style="color: #616161;">
                     ${line.marker}
-                    <span>${line.seriesName}</span>:
-                    <span>${value}${unit}</span>
+                    <span>${escapeHTML(line.seriesName)}</span>:
+                    <span>${escapeHTML(value)}${escapeHTML(unit)}</span>
                   </div>`
               }).join('')
               const wrapper = `<div class="chart-tooltip-wrapper">
-                <div style="color: #5D6F80;">${title}</div>
+                <div style="color: #5D6F80;">${escapeHTML(title)}</div>
                 <div class="lines-wrapper">${series}</div>
               </div>`
               dom.innerHTML = wrapper

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1114,7 +1114,7 @@ export function getKeyIgnoreCase (dict, needle) {
 
 /* eslint-disable */
 export const escapeHTML = str =>
-  str.replace(
+  String(str == null ? '' : str).replace(
     /[&<>'"]/g,
     tag =>
     ({


### PR DESCRIPTION
## 问题

监控图表 tooltip 与表格单元格把用户可控数据（资源名、tag、维度名）直接拼接进 HTML 字符串后通过 `innerHTML` 渲染，构成存储型 XSS：

- `containers/Monitor/components/MonitorCard/DashboardCard/index.vue:409`（在线代码）— 系列名来自监控 API 的 `raw_name`/`tags`，把虚拟机命名为 `<img src=x onerror=...>` 或创建同名 tag，悬停图表即执行任意 JS
- `src/sections/Monitor/index.vue:278`、`src/components/Uchart/index.vue`（v-html）、`src/sections/Charts/Lines.vue:79` — 同款模式（休眠组件）
- `containers/Monitor/components/MonitorCard/OverviewCard/filterForm.vue:378,384`（在线代码，扫描时新发现）— render 函数用 `domProps.innerHTML` 渲染 system/project/tenant 维度名称

全项目无 HTML sanitize 库，无兜底。

## 修复方案

在 HTML 拼接出口对动态值做实体转义（这些 tooltip 只需纯文本渲染，转义即可彻底消除注入，无需新增依赖）：

- 加固 `src/utils/utils.js` 的 `escapeHTML`：空值安全（`String(str == null ? '' : str)`），原实现传 undefined/number 会抛异常
- 4 处 tooltip 动态值（系列名、值、单位、标题、label、color）全部经 `escapeHTML` 后拼接
- filterForm 的 `domProps.innerHTML` 改为 Vue 文本子节点（框架自动转义）
- echarts 自身生成的 `line.marker` 标记 HTML 属可信来源，有意保留不转义

## 验证

- `escapeHTML` 行为实测：`<img onerror>` → `&lt;img onerror&gt;`，`& < > ' "` 全转义，中文不受影响，undefined/0/数字安全
- ESLint 6 个文件零告警，pre-commit lint-staged 通过

## 已知残留（本 PR 未处理，需决策）

`containers/Ai/views/llm-image/import-community/index.vue:111,203` — `marked(text)`（marked 1.x 无 sanitize）直接 `innerHTML`，数据源为社区镜像 API 的描述字段。该 sink 需要保留 markdown 富文本渲染，不能简单转义，正确修法是引入 DOMPurify 消毒 marked 输出——需要新增依赖，留待另行决策。

🤖 Generated with [Claude Code](https://claude.com/claude-code)