### PR TITLE
fix(security): mask sensitive fields in error request details

### DIFF
--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -6,6 +6,7 @@ import i18n from '@/locales'
 import store from '@/store'
 import windowsMixin from '@/mixins/windows'
 import { hasPermission } from '@/utils/auth'
+import { maskSensitiveData, maskSensitiveUrlQuery } from '@/utils/maskSensitive'
 
 const WindowVue = Vue.extend({
   mixins: [windowsMixin],
@@ -195,16 +196,16 @@ export const getHttpErrorMessage = (err, isErrorBody = false) => {
   }
 }
 
-// 获取http请求信息
+// 获取http请求信息（敏感字段已脱敏，避免密码/token 随错误详情回显）
 export const getHttpReqMessage = error => {
   const { headers, method, params, data, url } = error.config
   const req = {
     method,
-    url,
-    headers,
+    url: maskSensitiveUrlQuery(url),
+    headers: maskSensitiveData(headers),
   }
-  if (data) req.data = R.is(String, data) ? JSON.parse(data) : data
-  if (params) req.params = R.is(String, params) ? JSON.parse(params) : params
+  if (data) req.data = maskSensitiveData(R.is(String, data) ? JSON.parse(data) : data)
+  if (params) req.params = maskSensitiveData(R.is(String, params) ? JSON.parse(params) : params)
   return req
 }
 

--- a/src/utils/maskSensitive.js
+++ b/src/utils/maskSensitive.js
@@ -1,0 +1,55 @@
+/**
+ * 错误详情展示前的敏感信息脱敏：
+ * 对请求 data/params/headers/url query 中字段名命中敏感模式的字段值统一打码，
+ * 避免密码、token、密钥等随错误详情回显到页面
+ */
+
+// 敏感字段名模式（不区分大小写）：密码、token、密钥、认证头、cookie
+const SENSITIVE_KEY_REG = /passwd|password|pwd|token|secret|access_key|apikey|api_key|credential|authorization|cookie/i
+
+const MASKED_VALUE = '******'
+
+const maskValueByKey = (key, value) => {
+  if (SENSITIVE_KEY_REG.test(String(key))) return MASKED_VALUE
+  if (Array.isArray(value)) {
+    return value.map(item => maskSensitiveData(item))
+  }
+  if (value && typeof value === 'object') {
+    return maskSensitiveData(value)
+  }
+  return value
+}
+
+/**
+ * 递归打码对象中敏感字段的值
+ * @param {Object} obj 任意对象（字符串/数字等原样返回）
+ * @returns {Object} 脱敏后的新对象
+ */
+export const maskSensitiveData = (obj) => {
+  if (!obj || typeof obj !== 'object') return obj
+  const ret = {}
+  Object.keys(obj).forEach(key => {
+    ret[key] = maskValueByKey(key, obj[key])
+  })
+  return ret
+}
+
+/**
+ * 打码 URL query string 中敏感参数的值
+ * @param {String} url 完整 URL
+ * @returns {String} 脱敏后的 URL
+ */
+export const maskSensitiveUrlQuery = (url) => {
+  if (typeof url !== 'string') return url
+  const idx = url.indexOf('?')
+  if (idx < 0) return url
+  const base = url.slice(0, idx)
+  const parts = url.slice(idx + 1).split('&').map((part) => {
+    const eqIdx = part.indexOf('=')
+    if (eqIdx < 0) return part
+    const key = part.slice(0, eqIdx)
+    if (SENSITIVE_KEY_REG.test(key)) return `${key}=${MASKED_VALUE}`
+    return part
+  })
+  return `${base}?${parts.join('&')}`
+}

--- a/tests/unit/maskSensitive.spec.js
+++ b/tests/unit/maskSensitive.spec.js
@@ -1,0 +1,92 @@
+import { maskSensitiveData, maskSensitiveUrlQuery } from '@/utils/maskSensitive'
+
+describe('maskSensitiveData', () => {
+  it('打码密码类字段', () => {
+    const data = {
+      username: 'admin',
+      password: 'secret123',
+      password_old: 'oldpass',
+      password_new: 'newpass',
+      password_confirm: 'newpass',
+    }
+    expect(maskSensitiveData(data)).toEqual({
+      username: 'admin',
+      password: '******',
+      password_old: '******',
+      password_new: '******',
+      password_confirm: '******',
+    })
+  })
+
+  it('打码 token/密钥/认证字段（不区分大小写）', () => {
+    const data = {
+      name: 'vm1',
+      token: 'jwt-token-value',
+      AccessToken: 'access-value',
+      api_key: 'key-value',
+      SECRET_KEY: 'secret-value',
+      client_secret: 'client-secret-value',
+      authorization: 'Bearer xxx',
+    }
+    const masked = maskSensitiveData(data)
+    expect(masked.name).toBe('vm1')
+    expect(masked.token).toBe('******')
+    expect(masked.AccessToken).toBe('******')
+    expect(masked.api_key).toBe('******')
+    expect(masked.SECRET_KEY).toBe('******')
+    expect(masked.client_secret).toBe('******')
+    expect(masked.authorization).toBe('******')
+  })
+
+  it('递归打码嵌套对象与数组，非敏感字段原样保留', () => {
+    const data = {
+      auth: {
+        user: 'u1',
+        password: 'nested-pass',
+        meta: [{ key: 'a', token: 'nested-token' }],
+      },
+      projects: [{ id: 'p1', name: 'project1' }],
+      count: 3,
+    }
+    const masked = maskSensitiveData(data)
+    expect(masked.auth.password).toBe('******')
+    expect(masked.auth.meta[0].token).toBe('******')
+    expect(masked.auth.meta[0].key).toBe('a')
+    expect(masked.projects).toEqual([{ id: 'p1', name: 'project1' }])
+    expect(masked.count).toBe(3)
+  })
+
+  it('headers 中认证头与 cookie 被打码', () => {
+    const headers = {
+      Accept: 'application/json',
+      Authorization: 'Bearer real-jwt',
+      'X-Auth-Token': 'xauth-value',
+      Cookie: 'session=abc123',
+    }
+    expect(maskSensitiveData(headers)).toEqual({
+      Accept: 'application/json',
+      Authorization: '******',
+      'X-Auth-Token': '******',
+      Cookie: '******',
+    })
+  })
+
+  it('非对象输入原样返回', () => {
+    expect(maskSensitiveData(null)).toBe(null)
+    expect(maskSensitiveData(undefined)).toBe(undefined)
+    expect(maskSensitiveData('string')).toBe('string')
+    expect(maskSensitiveData(42)).toBe(42)
+  })
+})
+
+describe('maskSensitiveUrlQuery', () => {
+  it('打码 query 中敏感参数，保留其余参数', () => {
+    expect(maskSensitiveUrlQuery('/api/v1/login?username=admin&password=pw123&captcha=ab'))
+      .toBe('/api/v1/login?username=admin&password=******&captcha=ab')
+  })
+  it('无 query 或无敏感参数时原样返回', () => {
+    expect(maskSensitiveUrlQuery('/api/v1/servers')).toBe('/api/v1/servers')
+    expect(maskSensitiveUrlQuery('/api/v1/servers?name=vm1')).toBe('/api/v1/servers?name=vm1')
+    expect(maskSensitiveUrlQuery(null)).toBe(null)
+  })
+})


### PR DESCRIPTION
## 问题

错误详情对话框会把完整 HTTP 请求信息回显给用户并可一键复制（`src/utils/error.js` 的 `getHttpReqMessage` → `ErrorDialog` 的 `params.request`）。登录/改密请求失败后点"查看详情"，请求体中的 `password` 字段（Base64 明文等价或 AES 密文）、`Authorization` 等认证头会展示在页面 DOM 中。`hide_web_error_details` 开关默认未启用，无法兜底。

## 修复方案

- 新增 `src/utils/maskSensitive.js`（零依赖、可单测）：
  - `maskSensitiveData(obj)` — 递归打码字段名命中敏感模式的字段值（`passwd|password|pwd|token|secret|access_key|apikey|api_key|credential|authorization|cookie`，不区分大小写），支持嵌套对象与数组
  - `maskSensitiveUrlQuery(url)` — 打码 URL query 中敏感参数的值
- 在 `getHttpReqMessage`（唯一汇聚点，覆盖 `http.js` 两个调用方）统一脱敏 `data`/`params`/`headers`/`url`
- 脱敏后错误详情仍保留完整字段结构便于排查，敏感值统一显示为 `******`；`hide_web_error_details` 开关保持原语义

## 验证

- 新增单测 `tests/unit/maskSensitive.spec.js`：7/7 通过（密码类字段、token/密钥、递归嵌套、headers 认证头、URL query、非对象输入）
- ESLint 零告警，pre-commit lint-staged 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)