### PR TITLE
fix(security): sanitize v-html/markdown sinks with DOMPurify

### DIFF
--- a/containers/Ai/views/llm-image/import-community/index.vue
+++ b/containers/Ai/views/llm-image/import-community/index.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import marked from 'marked'
+import { renderMarkdownSafe } from '@/utils/sanitizeHtml'
 import { parseLlmImageRoute, getAllowedImageLlmTypes } from '@Ai/utils/llmRouteContext'
 import {
   createCommunityImageAndSku,
@@ -201,8 +201,8 @@ export default {
       }
     },
     renderMarkdown (text) {
-      if (!text || text === '-') return text || '-'
-      return marked(text)
+      // marked 1.x 不内置 sanitize，输出必须经 DOMPurify 消毒（描述来自社区镜像 API，不可信）
+      return renderMarkdownSafe(text)
     },
     async handleImport (record) {
       try {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "core-js": "^3.6.5",
     "crypto-js": "^4.0.0",
     "custom-protocol-detection": "^1.0.1",
+    "dompurify": "^3",
     "echarts": "^4.4.0",
     "echarts-liquidfill": "^2.0.6",
     "extend": "^3.0.2",

--- a/src/components/HelpTooltip/index.vue
+++ b/src/components/HelpTooltip/index.vue
@@ -10,6 +10,8 @@
 </template>
 
 <script>
+import { sanitizeHtml } from '@/utils/sanitizeHtml'
+
 export default {
   name: 'HelpTooltip',
   props: {
@@ -22,10 +24,11 @@ export default {
   },
   computed: {
     content () {
+      // text 可能来自服务端错误消息（如 SSH/RDP 登录错误回显），需消毒后渲染
       if (this.text) {
-        return this.text
+        return sanitizeHtml(this.text)
       }
-      return this.$t(`help.${this.name}`)
+      return sanitizeHtml(this.$t(`help.${this.name}`))
     },
   },
 }

--- a/src/sections/Auth/Login/index.vue
+++ b/src/sections/Auth/Login/index.vue
@@ -2,7 +2,7 @@
   <div class="login-index-wrap flex-fill d-flex h-100 align-items-center" v-loading.fullscreen="!regionsLoading">
     <div class="login-index-left d-flex flex-fill align-items-center pl-4 pr-4 pt-4" :style="{backgroundImage: loginBg}">
       <div>
-        <h2 :style="{ color: getI18nColorVal(companyInfo, 'login_page_slogan'), lineHeight: getI18nVal(companyInfo, 'login_page_slogan').includes('<br') ? '1.5em' : '1em' }" v-html="getI18nVal(companyInfo, 'login_page_slogan') || $t('login.desc1')" />
+        <h2 :style="{ color: getI18nColorVal(companyInfo, 'login_page_slogan'), lineHeight: loginSlogan.includes('<br') ? '1.5em' : '1em' }" v-html="loginSlogan" />
         <h4 :style="{ color: getI18nColorVal(companyInfo, 'login_page_sub_slogan') }">{{ getI18nVal(companyInfo, 'login_page_sub_slogan') || $t('login.desc2') }}</h4>
       </div>
     </div>
@@ -40,6 +40,7 @@ import * as R from 'ramda'
 import { mapGetters, mapState } from 'vuex'
 import { getLoginDomain } from '@/utils/common/cookie'
 import { getI18nVal, getI18nColorVal } from '@/utils/i18n'
+import { sanitizeHtml } from '@/utils/sanitizeHtml'
 import { getLoginModeInStorage } from '@/utils/auth'
 
 export default {
@@ -106,6 +107,10 @@ export default {
       const bg_img = this.companyInfo.login_page_backgroup_image
       if (!bg_img) return `url(${require('./assets/bg.png')})`
       return `url(data:image/png;base64,${bg_img})`
+    },
+    loginSlogan () {
+      // slogan 来自 OEM 品牌配置，经 DOMPurify 消毒后再 v-html 渲染
+      return sanitizeHtml(getI18nVal(this.companyInfo, 'login_page_slogan') || this.$t('login.desc1'))
     },
   },
   watch: {

--- a/src/utils/sanitizeHtml.js
+++ b/src/utils/sanitizeHtml.js
@@ -1,0 +1,22 @@
+import DOMPurify from 'dompurify'
+import marked from 'marked'
+
+/**
+ * 消毒 HTML（DOMPurify），供 v-html/innerHTML 出口使用
+ * @param {String} html 待消毒的 HTML 字符串
+ * @returns {String} 消毒后的 HTML；空值原样返回
+ */
+export const sanitizeHtml = (html) => {
+  if (html == null || html === '') return html || ''
+  return DOMPurify.sanitize(String(html))
+}
+
+/**
+ * markdown 渲染 + 消毒：marked 1.x 不内置 sanitize，输出必须经 DOMPurify 消毒
+ * @param {String} text markdown 文本
+ * @returns {String} 消毒后的 HTML
+ */
+export const renderMarkdownSafe = (text) => {
+  if (!text || text === '-') return text || '-'
+  return sanitizeHtml(marked(text))
+}

--- a/tests/unit/sanitizeHtml.spec.js
+++ b/tests/unit/sanitizeHtml.spec.js
@@ -1,0 +1,51 @@
+import { sanitizeHtml, renderMarkdownSafe } from '@/utils/sanitizeHtml'
+
+describe('sanitizeHtml', () => {
+  it('移除事件属性与脚本', () => {
+    const html = '<img src=x onerror=alert(1)>'
+    const result = sanitizeHtml(html)
+    expect(result).not.toContain('onerror')
+    expect(result).not.toContain('alert')
+  })
+
+  it('移除 javascript: 链接', () => {
+    const result = sanitizeHtml('<a href="javascript:alert(1)">click</a>')
+    expect(result).not.toContain('javascript:')
+    expect(result).toContain('click')
+  })
+
+  it('保留常规格式', () => {
+    expect(sanitizeHtml('<p><strong>bold</strong><a href="https://example.com">link</a></p>'))
+      .toBe('<p><strong>bold</strong><a href="https://example.com">link</a></p>')
+  })
+
+  it('空值返回空字符串', () => {
+    expect(sanitizeHtml('')).toBe('')
+    expect(sanitizeHtml(null)).toBe('')
+    expect(sanitizeHtml(undefined)).toBe('')
+  })
+})
+
+describe('renderMarkdownSafe', () => {
+  it('渲染正常 markdown', () => {
+    expect(renderMarkdownSafe('**bold**')).toContain('<strong>bold</strong>')
+    expect(renderMarkdownSafe('[link](https://example.com)')).toContain('href="https://example.com"')
+  })
+
+  it('过滤 markdown 中混入的 HTML 注入', () => {
+    const result = renderMarkdownSafe('<img src=x onerror=alert(1)>')
+    expect(result).not.toContain('onerror')
+    expect(result).not.toContain('alert(1)')
+  })
+
+  it('过滤 markdown 链接中的 javascript: 协议', () => {
+    const result = renderMarkdownSafe('[click](javascript:alert(1))')
+    expect(result).not.toContain('javascript:')
+  })
+
+  it('空值与 "-" 返回 "-" 占位（与组件原行为一致）', () => {
+    expect(renderMarkdownSafe('')).toBe('-')
+    expect(renderMarkdownSafe(null)).toBe('-')
+    expect(renderMarkdownSafe('-')).toBe('-')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,6 +1634,11 @@
   resolved "https://registry.npmmirror.com/@types/tapable/-/tapable-1.0.12.tgz#bc2cab12e87978eee89fb21576b670350d6d86ab"
   integrity sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/uglify-js@*":
   version "3.17.5"
   resolved "https://registry.npmmirror.com/@types/uglify-js/-/uglify-js-3.17.5.tgz#905ce03a3cbbf2e31cbefcbc68d15497ee2e17df"
@@ -4991,6 +4996,13 @@ dompurify@^2.5.4:
   version "2.5.8"
   resolved "https://registry.npmmirror.com/dompurify/-/dompurify-2.5.8.tgz#2809d89d7e528dc7a071dea440d7376df676f824"
   integrity sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==
+
+dompurify@^3:
+  version "3.4.14"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.14.tgz#a789edb2c7bcdb69a93713a34edb7e0a5245d8c9"
+  integrity sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domready@1.0.8:
   version "1.0.8"
@@ -12135,7 +12147,7 @@ string-length@^3.1.0:
     astral-regex "^1.0.0"
     strip-ansi "^5.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12169,6 +12181,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -12234,7 +12255,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12261,6 +12282,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -13700,8 +13728,7 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13731,6 +13758,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## 问题

多个把不可信数据经 `v-html`/`innerHTML` 渲染的 sink，全项目此前无任何 HTML 消毒库：

1. **社区镜像描述（存储型 XSS，在线代码）**：`containers/Ai/views/llm-image/import-community/index.vue` 把社区镜像 API 返回的 `description` 经 `marked()`（1.x 无内置 sanitize）渲染后直接 `innerHTML`，恶意描述可在所有打开该页面的用户会话中执行任意 JS
2. **HelpTooltip（反射型面）**：`src/components/HelpTooltip/index.vue` 的 `v-html`，`text` prop 来自 SSH/RDP 登录错误消息（服务端可能回显用户输入）
3. **登录页 slogan（预认证页存储型面）**：`src/sections/Auth/Login/index.vue:5` 的 `v-html` 渲染 OEM 品牌配置 `login_page_slogan`

## 修复方案

- 新增依赖 `dompurify@^3`（yarn 解析 **3.4.14**，已逐一核对 npm audit 全部 18 条 dompurify advisory，最新漏洞范围 `<=3.4.12`，本版本不受影响；audit 报告的 critical 来自 package-lock.json 中 jspdf 锁定的 dompurify 2.5.8，为既有问题）
- 新增可复用工具 `src/utils/sanitizeHtml.js`：
  - `sanitizeHtml(html)` — DOMPurify 消毒，供所有 v-html/innerHTML 出口复用
  - `renderMarkdownSafe(text)` — `marked()` + 消毒，保留 markdown 富文本渲染；空值返回 `'-'` 占位，与原组件行为一致
- 三处 sink 接入：
  - import-community：`renderMarkdown` 改用 `renderMarkdownSafe`
  - HelpTooltip：`content` 计算属性对 `text` prop 与 i18n 文案统一消毒（保留 h4/p/br 等正常标签）
  - Login slogan：新增 `loginSlogan` 计算属性消毒后渲染，行高 `<br>` 判断同步改用消毒后的值（DOMPurify 默认保留 `<br>`）
- 使用 DOMPurify 默认配置（不涉及 IN_PLACE/USE_PROFILES 等历史上被绕过的模式）

## 验证

- 新增单测 `tests/unit/sanitizeHtml.spec.js`：8/8 通过（事件属性剥离、javascript: 链接剥离、markdown 注入过滤、正常渲染不受影响、空值行为）
- ESLint 零告警，pre-commit lint-staged 通过

## 说明

- 本 PR 更新 package.json + yarn.lock（CI 用 yarn）；package-lock.json 保持现状（该文件本已与 yarn.lock 不同步）
- 本地 node 24 安装需 `yarn add --ignore-engines --ignore-scripts`（@achrinza/node-ipc engines 限制与 deasync 原生编译，均为本地环境问题）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
