### PR TITLE
feat(ai): 为失败的即时模型增加继续导入操作

### DIFF
--- a/containers/Ai/locales/en.json
+++ b/containers/Ai/locales/en.json
@@ -374,6 +374,8 @@
   "aice.detail": "Details",
   "aice.event": "Operation Log",
   "aice.perform_sync_status": "Sync Status",
+  "aice.perform_resume_import": "Resume Import",
+  "aice.perform_resume_import.tooltip": "Only failed (killed) models can resume import",
   "aice.add": "Add {0}",
   "aice.screenshot": "Screenshot",
   "aice.desktop_status": "App Status",

--- a/containers/Ai/locales/ja-JP.json
+++ b/containers/Ai/locales/ja-JP.json
@@ -373,6 +373,8 @@
   "aice.detail": "詳細",
   "aice.event": "操作ログ",
   "aice.perform_sync_status": "同期状態",
+  "aice.perform_resume_import": "インポートを再開",
+  "aice.perform_resume_import.tooltip": "失敗（killed）したモデルのみ再開できます",
   "aice.add": "{0}を追加",
   "aice.screenshot": "スクリーンショット",
   "aice.desktop_status": "アプリケーション状態",

--- a/containers/Ai/locales/zh-CN.json
+++ b/containers/Ai/locales/zh-CN.json
@@ -381,6 +381,8 @@
   "aice.detail": "详情",
   "aice.event": "操作日志",
   "aice.perform_sync_status": "同步状态",
+  "aice.perform_resume_import": "继续导入",
+  "aice.perform_resume_import.tooltip": "仅导入失败（killed）的模型可继续导入",
   "aice.add": "增加{0}",
   "aice.screenshot": "截屏",
   "aice.desktop_status": "应用状态",

--- a/containers/Ai/views/llm-instantmodel/mixins/singleActions.js
+++ b/containers/Ai/views/llm-instantmodel/mixins/singleActions.js
@@ -86,6 +86,28 @@ export default {
                 })
               },
             },
+            // 继续导入（失败后断点续传）
+            {
+              label: this.$t('aice.perform_resume_import'),
+              permission: 'llm_instant_models_perform_resume_import',
+              action: (obj) => {
+                this.onManager('performAction', {
+                  steadyStatus: ['queued', 'packaging', 'saving', 'active'],
+                  id: obj.id,
+                  managerArgs: {
+                    action: 'resume-import',
+                  },
+                })
+              },
+              meta: (obj) => {
+                const ret = { validate: true, tooltip: null }
+                if (obj.status !== 'killed') {
+                  ret.validate = false
+                  ret.tooltip = this.$t('aice.perform_resume_import.tooltip')
+                }
+                return ret
+              },
+            },
             // 更改项目
             {
               label: this.$t('compute.perform_change_owner', [this.$t('dictionary.project')]),

--- a/src/constants/permission.js
+++ b/src/constants/permission.js
@@ -1566,6 +1566,7 @@ export const PERMISSION = {
   llm_instant_models_update: ['llm', 'llm_instant_models', 'update'],
   llm_instant_models_delete: ['llm', 'llm_instant_models', 'delete'],
   llm_instant_models_perform_syncstatus: ['llm', 'llm_instant_models', 'perform', 'syncstatus'],
+  llm_instant_models_perform_resume_import: ['llm', 'llm_instant_models', 'perform', 'resume-import'],
   llm_instant_models_perform_change_owner: ['llm', 'llm_instant_models', 'perform', 'change-owner'],
   llm_instant_models_perform_public: ['llm', 'llm_instant_models', 'perform', 'public'],
 


### PR DESCRIPTION
仅对 status 为 killed 的模型开放 resume-import，并补充权限与多语言文案。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0.4