### PR TITLE
fix(ai): refine aiproxy client model ids and anthropic max_tokens

### DIFF
--- a/containers/Ai/sections/AiproxyClientAccessDetail.vue
+++ b/containers/Ai/sections/AiproxyClientAccessDetail.vue
@@ -246,6 +246,7 @@ export default {
           endpoint: this.anthropicMessagesUrl,
           model: this.displayModel,
           virtualKey: this.virtualKey,
+          clientModelOptions: this.clientModelOptions,
         })
       }
       return buildAiproxyCurlExample({

--- a/containers/Ai/sections/Chat/index.vue
+++ b/containers/Ai/sections/Chat/index.vue
@@ -42,35 +42,38 @@
             </a-select-option>
           </a-select>
         </div>
-        <div class="chat-test-field chat-test-field-grow">
-          <div class="chat-test-field-label">{{ $t('aice.aiproxy.virtual_key') }}</div>
-          <base-select
-            v-model="selectedVirtualKeyId"
-            resource="ai_virtual_keys"
-            :params="virtualKeySelectParams"
-            :extra-opts="virtualKeyExtraOpts"
-            filterable
-            version="v2"
-            class="chat-test-vk-select"
-            :select-props="virtualKeySelectProps"
-            @change="onVirtualKeySelectChange"
-            @update:item="onVirtualKeyItemSelected" />
-        </div>
-        <div v-if="showChatModelSelect" class="chat-test-field">
-          <div class="chat-test-field-label">{{ $t('aice.aiproxy.client_model_select') }}</div>
-          <a-select
-            v-model="selectedChatModelId"
-            class="chat-test-model-select"
-            :loading="chatModelsLoading"
-            :placeholder="$t('aice.aiproxy.client_model_select')"
-            @change="onChatModelChange">
-            <a-select-option
-              v-for="opt in chatModelOptions"
-              :key="opt.id"
-              :value="opt.id">
-              {{ opt.id }}
-            </a-select-option>
-          </a-select>
+        <div class="chat-test-vk-model">
+          <div class="chat-test-field chat-test-field-vk">
+            <div class="chat-test-field-label">{{ $t('aice.aiproxy.virtual_key') }}</div>
+            <base-select
+              v-model="selectedVirtualKeyId"
+              resource="ai_virtual_keys"
+              :params="virtualKeySelectParams"
+              :extra-opts="virtualKeyExtraOpts"
+              filterable
+              version="v2"
+              class="chat-test-vk-select"
+              :select-props="virtualKeySelectProps"
+              @change="onVirtualKeySelectChange"
+              @update:item="onVirtualKeyItemSelected" />
+          </div>
+          <div v-if="showChatModelSelect" class="chat-test-field chat-test-field-model">
+            <div class="chat-test-field-label">{{ $t('aice.aiproxy.client_model_select') }}</div>
+            <a-select
+              v-model="selectedChatModelId"
+              class="chat-test-model-select"
+              :loading="chatModelsLoading"
+              :placeholder="$t('aice.aiproxy.client_model_select')"
+              :dropdownMatchSelectWidth="false"
+              @change="onChatModelChange">
+              <a-select-option
+                v-for="opt in chatModelOptions"
+                :key="opt.id"
+                :value="opt.id">
+                {{ opt.id }}
+              </a-select-option>
+            </a-select>
+          </div>
         </div>
       </div>
     </div>
@@ -168,7 +171,7 @@ import {
   appendAnthropicStreamLine,
   extractAnthropicResponseText,
 } from '@Ai/utils/anthropicStream'
-import { splitThinkingContent, normalizeMarkdownTables } from '@Ai/utils/chatContent'
+import { extractUpstreamErrorMessage, splitThinkingContent, normalizeMarkdownTables } from '@Ai/utils/chatContent'
 import {
   buildDeploymentClientModelOptions,
   defaultClientModelOption,
@@ -434,12 +437,14 @@ export default {
         const greetingText = this.$t('ai.mcp.greeting')
         history = this.messages
           .slice(0, userMessageIndex)
+          .filter(m => !m.isError)
           .filter(m => !(m.role === 'assistant' && m.content === greetingText))
           .slice(-6)
       } else {
         const greetingText = this.$t('ai.mcp.greeting')
         history = this.messages
           .slice(0, userMessageIndex)
+          .filter(item => !item.isError)
           .map(item => ({
             role: item.role,
             content: item.role === 'assistant' ? (item.content || '') : item.content,
@@ -458,8 +463,11 @@ export default {
       } catch (error) {
         console.error('Chat error:', error)
         if (error.name !== 'AbortError') {
-          this.$set(this.messages[assistantMessageIndex], 'content', this.$t('ai.mcp.error_occurred'))
-          this.$message.error(this.$t('ai.mcp.send_failed'))
+          const detail = String(error.message || '').trim() || this.$t('ai.mcp.error_occurred')
+          this.$set(this.messages[assistantMessageIndex], 'isError', true)
+          this.$set(this.messages[assistantMessageIndex], 'content', detail)
+          const toast = detail.length > 300 ? `${detail.slice(0, 300)}…` : detail
+          this.$message.error(toast)
         }
       } finally {
         this.loading = false
@@ -487,6 +495,15 @@ export default {
         this.abortController = null
       }
     },
+    async throwFailedChatResponse (response) {
+      let body = ''
+      try {
+        body = await response.text()
+      } catch (e) {
+        body = ''
+      }
+      throw new Error(extractUpstreamErrorMessage(body, response.status))
+    },
     async streamMcpChatResponse (message, assistantMessageIndex, history = []) {
       const baseURL = this.$http.defaults.baseURL || process.env.VUE_APP_BASE_API || ''
       const apiVersion = 'v1'
@@ -513,7 +530,7 @@ export default {
       })
 
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`)
+        await this.throwFailedChatResponse(response)
       }
 
       // 与 chatTest 共用按行解析，支持后端 token 级增量 SSE（data: xxx\n\n）
@@ -547,7 +564,7 @@ export default {
       })
 
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`)
+        await this.throwFailedChatResponse(response)
       }
 
       const streamFormat = protocol === 'anthropic' ? 'anthropic' : 'openai'
@@ -865,10 +882,12 @@ export default {
       const builder = this.chatProtocol === 'anthropic'
         ? buildAnthropicChatTestRequestConfig
         : buildChatTestRequestConfig
+      const selectedOpt = (this.chatModelOptions || []).find(opt => opt && opt.id === model)
       const config = builder({
         endpoint: this.endpointUrl,
         model,
         virtualKey: this.selectedVirtualKey,
+        contextWindow: selectedOpt?.contextWindow,
       })
       this.chatTestConfig = config || null
     },
@@ -957,7 +976,7 @@ export default {
     max-width: 760px;
     margin-left: 16px;
     display: flex;
-    gap: 8px;
+    gap: 16px;
     align-items: flex-end;
     flex-wrap: wrap;
 
@@ -965,16 +984,6 @@ export default {
       display: flex;
       flex-direction: column;
       gap: 4px;
-    }
-
-    .chat-test-field-grow {
-      flex: 1;
-      min-width: 180px;
-
-      .chat-test-vk-select {
-        width: 100%;
-        min-width: 0;
-      }
     }
 
     .chat-test-field-label {
@@ -989,13 +998,36 @@ export default {
       flex-shrink: 0;
     }
 
-    .chat-test-vk-select {
-      width: 180px;
+    .chat-test-vk-model {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      gap: 16px;
+      align-items: flex-end;
     }
 
-    .chat-test-model-select {
-      width: 220px;
-      flex-shrink: 0;
+    .chat-test-field-vk {
+      flex: 4 1 0;
+      min-width: 0;
+
+      .chat-test-vk-select {
+        width: 100%;
+        min-width: 0;
+      }
+    }
+
+    .chat-test-vk-model:not(:has(.chat-test-field-model)) .chat-test-field-vk {
+      flex: 0 0 40%;
+    }
+
+    .chat-test-field-model {
+      flex: 6 1 0;
+      min-width: 0;
+
+      .chat-test-model-select {
+        width: 100%;
+        min-width: 0;
+      }
     }
   }
 }

--- a/containers/Ai/utils/__tests__/aiproxyClientModelId.spec.js
+++ b/containers/Ai/utils/__tests__/aiproxyClientModelId.spec.js
@@ -1,0 +1,53 @@
+import { buildRoutingClientModelOptions } from '../aiproxyClientModelId'
+
+jest.mock('@/utils/manager', () => ({ Manager: class {} }), { virtual: true })
+jest.mock('@Ai/constants/aiproxyResources', () => ({ getAiproxyResourceScope: () => '' }), { virtual: true })
+jest.mock('@Ai/utils/aiProviderKind', () => ({ fetchRoutingModelsForRouting: async () => [] }), { virtual: true })
+
+describe('buildRoutingClientModelOptions', () => {
+  const routing = { model_key: 'qwen38-Qwen3.8-27B-NVFP4' }
+  const catalogModelsById = {
+    'model-a': { model_key: 'Qwen3.8-27B-NVFP4' },
+    'model-b': { model_key: 'Qwen3.8-27B-NVFP4' },
+    'model-c': { model_key: 'Qwen3.8-27B-Instruct' },
+  }
+
+  it('emits only the flat id for a single routing model with model_key', () => {
+    const options = buildRoutingClientModelOptions({
+      routing,
+      routingModels: [{ ai_model_id: 'model-a', enabled: true, priority: 10 }],
+      catalogModelsById,
+    })
+    expect(options.map(o => o.id)).toEqual(['qwen38-Qwen3.8-27B-NVFP4'])
+    expect(options[0].kind).toBe('flat')
+  })
+
+  it('emits only the flat id for replica rows that share the same catalog', () => {
+    const options = buildRoutingClientModelOptions({
+      routing,
+      routingModels: [
+        { ai_model_id: 'model-a', enabled: true, priority: 10 },
+        { ai_model_id: 'model-b', enabled: true, priority: 20 },
+      ],
+      catalogModelsById,
+    })
+    expect(options.map(o => o.id)).toEqual(['qwen38-Qwen3.8-27B-NVFP4'])
+    expect(options[0].kind).toBe('flat')
+  })
+
+  it('emits flat plus hierarchical ids when routing binds distinct catalogs', () => {
+    const options = buildRoutingClientModelOptions({
+      routing,
+      routingModels: [
+        { ai_model_id: 'model-a', enabled: true, priority: 10 },
+        { ai_model_id: 'model-c', enabled: true, priority: 20 },
+      ],
+      catalogModelsById,
+    })
+    expect(options.map(o => ({ id: o.id, kind: o.kind }))).toEqual([
+      { id: 'qwen38-Qwen3.8-27B-NVFP4', kind: 'flat' },
+      { id: 'qwen38-Qwen3.8-27B-NVFP4/Qwen3.8-27B-NVFP4', kind: 'hierarchical' },
+      { id: 'qwen38-Qwen3.8-27B-NVFP4/Qwen3.8-27B-Instruct', kind: 'hierarchical' },
+    ])
+  })
+})

--- a/containers/Ai/utils/__tests__/aiproxyEndpoint.spec.js
+++ b/containers/Ai/utils/__tests__/aiproxyEndpoint.spec.js
@@ -1,0 +1,45 @@
+import {
+  DEFAULT_ANTHROPIC_MAX_TOKENS,
+  buildAnthropicChatTestRequestConfig,
+  resolveAnthropicMaxTokens,
+} from '../aiproxyEndpoint'
+
+jest.mock('@/utils/manager', () => ({ Manager: class {} }), { virtual: true })
+jest.mock('@Ai/constants/aiproxyResources', () => ({ getAiproxyResourceScope: () => '' }), { virtual: true })
+
+describe('resolveAnthropicMaxTokens', () => {
+  it('defaults to 1024 when context is unknown', () => {
+    expect(resolveAnthropicMaxTokens()).toBe(DEFAULT_ANTHROPIC_MAX_TOKENS)
+    expect(DEFAULT_ANTHROPIC_MAX_TOKENS).toBe(1024)
+  })
+
+  it('does not consume a 4096-token vLLM context window', () => {
+    expect(resolveAnthropicMaxTokens({
+      contextWindow: 4096,
+      requested: 4096,
+    })).toBeLessThan(4096)
+    expect(resolveAnthropicMaxTokens({
+      contextWindow: 4096,
+    })).toBe(1024)
+  })
+
+  it('clamps requested tokens when context is small', () => {
+    expect(resolveAnthropicMaxTokens({
+      contextWindow: 1024,
+      requested: 1024,
+    })).toBe(768)
+  })
+})
+
+describe('buildAnthropicChatTestRequestConfig', () => {
+  it('sets a prompt-safe max_tokens', () => {
+    const cfg = buildAnthropicChatTestRequestConfig({
+      endpoint: 'https://example/ai/anthropic/v1/messages',
+      model: 'qwen38-Qwen3.8-27B-NVFP4',
+      virtualKey: 'sk-test',
+      contextWindow: 4096,
+    })
+    expect(cfg.body.max_tokens).toBe(1024)
+    expect(cfg.protocol).toBe('anthropic')
+  })
+})

--- a/containers/Ai/utils/__tests__/chatContent.spec.js
+++ b/containers/Ai/utils/__tests__/chatContent.spec.js
@@ -1,4 +1,4 @@
-import { normalizeMarkdownTables, splitThinkingContent } from '../chatContent'
+import { extractUpstreamErrorMessage, normalizeMarkdownTables, splitThinkingContent } from '../chatContent'
 
 describe('normalizeMarkdownTables', () => {
   it('splits compacted pipe rows', () => {
@@ -33,5 +33,29 @@ describe('splitThinkingContent', () => {
       reasoning: 'r',
       content: 'hello',
     })
+  })
+})
+
+describe('extractUpstreamErrorMessage', () => {
+  it('reads OpenAI error.message', () => {
+    expect(extractUpstreamErrorMessage(JSON.stringify({
+      error: { message: 'context length exceeded', type: 'BadRequestError' },
+    }), 400)).toBe('context length exceeded')
+  })
+
+  it('reads Anthropic error.message', () => {
+    expect(extractUpstreamErrorMessage(JSON.stringify({
+      type: 'error',
+      error: { type: 'invalid_request_error', message: 'max_tokens too large' },
+    }), 400)).toBe('max_tokens too large')
+  })
+
+  it('falls back to HTTP status when body is empty', () => {
+    expect(extractUpstreamErrorMessage('', 400)).toBe('HTTP 400')
+    expect(extractUpstreamErrorMessage('   ', 502)).toBe('HTTP 502')
+  })
+
+  it('returns truncated raw text when body is not JSON', () => {
+    expect(extractUpstreamErrorMessage('upstream exploded', 500)).toBe('upstream exploded')
   })
 })

--- a/containers/Ai/utils/aiproxyClientModelId.js
+++ b/containers/Ai/utils/aiproxyClientModelId.js
@@ -59,8 +59,20 @@ function catalogContextWindow (catalog) {
   return Number.isFinite(n) && n > 0 ? n : 0
 }
 
+function uniqueClientFacingParts (routing, entries, catalogModelsById) {
+  const parts = new Set()
+  for (const entry of entries) {
+    const catalog = catalogModelsById[entry.ai_model_id] || {}
+    const part = clientFacingModelId(routing, entry, catalog)
+    if (part) parts.add(part)
+  }
+  return parts
+}
+
 /**
  * Build selectable client model options for access panel.
+ * Hierarchical ids are only emitted when the routing binds more than one unique catalog.
+ * Replica rows that share the same catalog part still count as a single model.
  * @returns {{ id: string, kind: 'flat'|'hierarchical', catalogKey: string, contextWindow: number, priority: number }[]}
  */
 export function buildRoutingClientModelOptions ({
@@ -87,7 +99,9 @@ export function buildRoutingClientModelOptions ({
     options.push(opt)
   }
 
-  if (routeKey && entries.length > 1) {
+  const multiCatalog = uniqueClientFacingParts(routing, entries, catalogModelsById).size > 1
+
+  if (routeKey && multiCatalog) {
     push({ id: routeKey, kind: 'flat', catalogKey: '', contextWindow: 0, priority: -1 })
   }
 
@@ -95,7 +109,7 @@ export function buildRoutingClientModelOptions ({
     const catalog = catalogModelsById[entry.ai_model_id] || {}
     const catalogKey = trim(catalog.model_key)
     const contextWindow = catalogContextWindow(catalog)
-    if (routeKey) {
+    if (routeKey && multiCatalog) {
       const hierarchical = hierarchicalClientModelId(routing, entry, catalog)
       if (hierarchical) {
         push({
@@ -106,6 +120,16 @@ export function buildRoutingClientModelOptions ({
           priority: entry.priority || 0,
         })
       }
+      continue
+    }
+    if (routeKey) {
+      push({
+        id: routeKey,
+        kind: 'flat',
+        catalogKey,
+        contextWindow,
+        priority: entry.priority || 0,
+      })
       continue
     }
     const flat = clientFacingModelId(routing, entry, catalog)

--- a/containers/Ai/utils/aiproxyEndpoint.js
+++ b/containers/Ai/utils/aiproxyEndpoint.js
@@ -156,20 +156,48 @@ export function parseShellScriptLines (script) {
   }))
 }
 
-export const DEFAULT_ANTHROPIC_MAX_TOKENS = 4096
+// Anthropic Messages requires max_tokens (output budget). Do not default to
+// 4096: many vLLM deployments use --max-model-len=4096, and max_tokens=4096
+// leaves 0 room for the prompt.
+export const DEFAULT_ANTHROPIC_MAX_TOKENS = 1024
+const ANTHROPIC_CONTEXT_RESERVE = 512
+
+/**
+ * Pick a max_tokens that fits in context_window (output + reserve < context).
+ * Unknown context falls back to DEFAULT_ANTHROPIC_MAX_TOKENS.
+ */
+export function resolveAnthropicMaxTokens ({ contextWindow, requested } = {}) {
+  const req = Number(requested)
+  let want = Number.isFinite(req) && req > 0 ? Math.floor(req) : DEFAULT_ANTHROPIC_MAX_TOKENS
+  const ctx = Number(contextWindow)
+  if (Number.isFinite(ctx) && ctx > 1) {
+    const reserve = Math.min(ANTHROPIC_CONTEXT_RESERVE, Math.max(1, Math.floor(ctx / 4)))
+    const room = ctx - reserve
+    if (room > 0 && want > room) {
+      want = room
+    }
+  }
+  return Math.max(1, want)
+}
 
 export function buildAnthropicCurlExample ({
   endpoint,
   model,
   virtualKey = '<API Key>',
-  maxTokens = DEFAULT_ANTHROPIC_MAX_TOKENS,
+  maxTokens,
+  contextWindow,
+  clientModelOptions = [],
 } = {}) {
   const url = endpoint || '<endpoint>/ai/anthropic/v1/messages'
   const m = model || 'your-model'
   const key = virtualKey || '<API Key>'
+  const tokens = resolveAnthropicMaxTokens({
+    contextWindow: contextWindow || contextWindowForClientModel(m, clientModelOptions),
+    requested: maxTokens,
+  })
   const body = JSON.stringify({
     model: m,
-    max_tokens: maxTokens,
+    max_tokens: tokens,
     stream: true,
     messages: [{ role: 'user', content: 'hello' }],
   })
@@ -185,7 +213,8 @@ export function buildAnthropicChatTestRequestConfig ({
   endpoint,
   model,
   virtualKey,
-  maxTokens = DEFAULT_ANTHROPIC_MAX_TOKENS,
+  maxTokens,
+  contextWindow,
 } = {}) {
   const url = String(endpoint || '').trim()
   const m = String(model || '').trim()
@@ -200,7 +229,7 @@ export function buildAnthropicChatTestRequestConfig ({
     },
     body: {
       model: m,
-      max_tokens: maxTokens,
+      max_tokens: resolveAnthropicMaxTokens({ contextWindow, requested: maxTokens }),
       messages: [{ role: 'user', content: 'hello' }],
     },
     model: m,

--- a/containers/Ai/utils/chatContent.js
+++ b/containers/Ai/utils/chatContent.js
@@ -1,3 +1,27 @@
+const RAW_ERROR_BODY_LIMIT = 2000
+
+/**
+ * Pull a human-readable message from an OpenAI / Anthropic error JSON body.
+ * Falls back to truncated raw text, then `HTTP {status}`.
+ */
+export function extractUpstreamErrorMessage (text, status) {
+  const raw = String(text || '').trim()
+  const code = Number(status)
+  const httpFallback = Number.isFinite(code) && code > 0 ? `HTTP ${code}` : ''
+
+  if (raw) {
+    try {
+      const data = JSON.parse(raw)
+      const msg = String(data?.error?.message || data?.message || '').trim()
+      if (msg) return msg
+    } catch (e) {
+      // not JSON
+    }
+    return raw.length > RAW_ERROR_BODY_LIMIT ? raw.slice(0, RAW_ERROR_BODY_LIMIT) : raw
+  }
+  return httpFallback || 'HTTP error'
+}
+
 export function splitThinkingContent (raw) {
   const text = String(raw || '')
   const closedMatch = text.match(/<(?:redacted_)?think(?:ing)?>([\s\S]*?)<\/(?:redacted_)?think(?:ing)?>\s*([\s\S]*)$/i)


### PR DESCRIPTION
Only emit hierarchical model ids for multi-catalog routes, and clamp Anthropic max_tokens to the model context window to avoid empty prompt room.

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
- 4.0