### PR TITLE
fix(ai): 精简 LLM 部署相关 expectStatus 的 info 态

### DIFF
--- a/src/constants/expectStatus.js
+++ b/src/constants/expectStatus.js
@@ -659,12 +659,12 @@ export default {
     info: ['unknown', 'importing_model'],
   },
   llmDeployment: {
-    info: ['unknown', 'partial', 'start_delete', 'deleted', 'deploying', 'syncing', 'restarting', 'creating', 'importing_model', 'creating_sku', 'deleting'],
+    info: ['unknown', 'partial', 'deleted'],
     success: ['ready'],
     danger: ['create_fail', 'create_failed', 'import_model_failed', 'create_sku_failed', 'delete_fail', 'delete_failed', 'start_fail'],
   },
   llmDeploymentAiproxy: {
-    info: ['unknown', 'pending', 'syncing', 'partial'],
+    info: ['unknown'],
     success: ['synced', 'disabled'],
     danger: ['failed'],
   },


### PR DESCRIPTION
去掉 llmDeployment / llmDeploymentAiproxy 中过渡与过程态，仅保留稳定 info 状态。

**What this PR does / why we need it**:

<!--
- [ ] Smoke testing completed
- [ ] Unit test written
-->

**Does this PR need to be backport to the previous release branch?**:

<!--
If no, just write "NONE".

If don't know, write "UNKNOWN", and let the reviewer decide.

If yes, write the release branches name in the below format and submit the related cherry-pick PR:
- release/3.7
- release/3.6

Take a look at "https://docs.yunion.io/en/docs/contribute/contrib/" to learn how to submit a cherry-pick PR. 
-->
